### PR TITLE
Doc revisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Welcome to Snap - Searchspring's SDK for integrating into front end web apps.
 
 # Contributing
 
-We invite your participation through issues and pull requests! Please reference Searchspring's [Community Contribution Guidelines](https://github.com/searchspring/community/blob/main/CONTRIBUTING.md).
+We invite your participation through issues, discussions and pull requests! Please reference Searchspring's [Community Contribution Guidelines](https://github.com/searchspring/community/blob/main/CONTRIBUTING.md).
 
 # Packages
 Snap packages that are published to NPM's registry are found under the `/packages` directory. 
@@ -14,16 +14,18 @@ Snap packages that are published to NPM's registry are found under the `/package
 Documentation for each package can be found in its respective README file.
 
 <details>
-    <summary>Package dependencies hierarchy</summary>
-    <br/>
-    <img src="images/snap-dependencies.jpg"/>
+	<summary>Package dependencies hierarchy</summary>
+	<br/>
+	<img src="images/snap-dependencies.jpg"/>
 </details>
+
+<br>
 
 ## Client
 
 [@searchspring/snap-client-javascript](packages/snap-client-javascript) <a href="https://www.npmjs.com/package/@searchspring/snap-client-javascript"><img alt="NPM Status" src="https://img.shields.io/npm/v/@searchspring/snap-client-javascript.svg?style=flat"></a>
 
-Simple Javascript client for communicating with Searchspring's API.
+Simple Javascript client for communicating with Searchspring's API
 
 ## Component Libraries
 
@@ -37,13 +39,13 @@ A collection of interface elements for front end libraries
 
 [@searchspring/snap-controller](packages/snap-controller) <a href="https://www.npmjs.com/package/@searchspring/snap-controller"><img alt="NPM Status" src="https://img.shields.io/npm/v/@searchspring/snap-controller.svg?style=flat"></a>
 
-The heart of controlling Search, Autocomplete, & Finder functionality.
+The heart of controlling Search, Autocomplete, & Finder functionality
 
 ## Demo Stores
 
 A demo store utilizing all Snap packages and components.
 ### React / Preact
-Check it out at [try.searchspring.com](http://try.searchspring.com/) or use it as a reference.
+Check it out at [try.searchspring.com](http://try.searchspring.com/) or use it as a reference
 <!-- TODO: Update try.searchspring.com to Snap deployed demostore -->
 
 [@searchspring/snap-preact-demo](packages/snap-preact-demo)
@@ -52,7 +54,7 @@ Check it out at [try.searchspring.com](http://try.searchspring.com/) or use it a
 
 [@searchspring/snap-event-manager](packages/snap-event-manager) <a href="https://www.npmjs.com/package/@searchspring/snap-event-manager"><img alt="NPM Status" src="https://img.shields.io/npm/v/@searchspring/snap-event-manager.svg?style=flat"></a>
 
-Hook into custom events for modifying data.
+Hook into custom events for modifying data
 
 ## Logger
 
@@ -113,14 +115,19 @@ While at the <b>repo root</b>, the following commands are available:
 npm install
 ```
 
+## Build
+Executes `npm run build` across all packages sequentially. 
+```shell
+npm run build
+```
 ## Dev
 Executes `npm run dev` across all packages sequentially. All packages will be linked with hot reloading.
 ```shell
 npm run dev
 ```
-http://localhost:3333 Demo store
+Demo store: http://localhost:4444
 
-http://localhost:8888 Webpack bundle analyzer
+Webpack bundle analyzer: http://localhost:8888
 
 ## Commit
 Instead of using `git commit`, use `npm run commit` to utilize Commitizen
@@ -128,13 +135,13 @@ Instead of using `git commit`, use `npm run commit` to utilize Commitizen
 npm run commit
 ```
 
-## Storybook
-http://localhost:6006
+## Storybook Components
+Preact Components: http://localhost:6006
 ```shell
-npm run storybook
+npm run storybook:preact
 ```
 
-## Unit Tests
+## Tests (unit + headless E2E)
 ```shell
 npm run test
 ```
@@ -143,12 +150,6 @@ npm run test
 Only applies to `packages/snap-preact-demo`
 ```shell
 npm run cypress
-```
-
-## Build
-Executes `npm run build` across all packages sequentially. 
-```shell
-npm run build
 ```
 
 ## Clean
@@ -170,20 +171,20 @@ npm run <command> [--workspace=<package> | -w <package>] [--workspace=<package> 
 
 <h1 id="TypicalUsage">Typical Usage</h1>
 
-This section will provide an overview of how to get up and running with Snap
+This section will provide an overview of how to get up and running with Snap.
 
 ## Installation & Imports
-First, we'll start by installing all Snap dependencies
+First, we'll start by installing all Snap dependencies:
 
 ```shell
 npm install --save @searchspring/snap-client-javascript @searchspring/snap-url-manager @searchspring/snap-event-manager @searchspring/snap-profiler @searchspring/snap-logger @searchspring/snap-toolbox @searchspring/snap-controller @searchspring/snap-store-mobx
 ```
 
-Then we'll import them in our main entry point `index.js`
+Then we'll import them in our main entry point `index.js`:
 
 ```typescript
 import SnapClient from '@searchspring/snap-client-javascript';
-import { UrlManager, HybridTranslator, reactLinker } from '@searchspring/snap-url-manager';
+import { UrlManager, UrlTranslator, reactLinker } from '@searchspring/snap-url-manager';
 import { EventManager } from '@searchspring/snap-event-manager';
 import { Profiler } from '@searchspring/snap-profiler';
 import { Logger } from '@searchspring/snap-logger';
@@ -193,27 +194,18 @@ import { SearchStore, AutocompleteStore, FinderStore } from '@searchspring/snap-
 ```
 
 ## Snap Client
-Next, let's define Snap Client as it is required and can be shared across multiple services
+Next, let's define Snap Client as it is required and can be shared across multiple services:
 
 ```typescript
-const client = new SnapClient(globals, clientConfig);
+const client = new SnapClient(globals);
 ```
 
-The Snap Client requires two object config parameters:
-
-### Client Config
-In most cases, this will be an empty object. 
-
-`apiHost` defines the Searchspring API endpoint to use
-
-```typescript
-const clientConfig = {
-	// apiHost: 'http://localhost:8080/api/v1',
-};
-```
+The Snap Client requires `ClientGlobals` for instantiation.
 
 ### Global Config
-If the project has been created using `@searchspring/snapfu`, the `siteId` can be referenced from the `package.json`
+The `globals` object can be used to set client search parameters that will apply to all requests made with the client. Typically only the `siteId` will be set here, but could be used for setting globally utilized background filters and/or sorts as well.
+
+If the project has been created using `@searchspring/snapfu`, the `siteId` can be referenced from the `package.json`.
 
 ```typescript
 import { searchspring } from '../package.json';
@@ -235,20 +227,17 @@ const globals = {
 
 <h2 id="SearchTypicalUsage">Search</h2>
 
-To set up Search using Snap, we'll need to utilize a `SearchController` which requires two objects:  `SearchControllerConfig` and `ControllerServices`
+To set up Search using Snap, we'll need to utilize a `SearchController` which requires `SearchControllerConfig` and `ControllerServices` objects to instantiate.
 ```typescript
-const search = new SearchController(searchConfig, searchControllerServices);
+const searchController = new SearchController(searchConfig, searchControllerServices);
 ```
 ### Config (SearchControllerConfig)
 Lets define a `SearchControllerConfig` object:
 ```typescript
-const searchConfig : SearchControllerConfig = {
+const searchConfig = {
 	id: 'search',
 	globals: {
 		filters: [],
-		merchanding: {
-			disabled: false
-		}
 	},
 	settings: {
 		redirects: {
@@ -264,50 +253,46 @@ const searchConfig : SearchControllerConfig = {
 
 
 ### Category Pages / Background Filters
-Optionally, apply filters from the page's content to the SearchControllerConfig `globals.filters` property.
-This can be used to configure category pages.
+Optionally, apply filters from the page's content to the SearchControllerConfig `globals.filters` property. The controller globals are similar to the client globals in that all search requests will include the parameters specified. This can be used to configure category/brand pages, or other special filtering to apply to the current page's search requests.
 
-For example, if migrating an exisiting Searchspring AJAX V3 implementation:
+For example, if a global variable `snapConfig` exists on the page (must be defined prior to our Snap script):
 
-```typescript
-const getV3ScriptAttrs = () => {
-	const scriptElement = document.querySelector('script[src*="searchspring.catalog.js"]');
-
-	if (scriptElement) {
-		const attributes = {};
-
-		scriptElement.attributes.forEach((attribute) => {
-			attributes[attribute.name] = attribute.value;
-		});
-
-		return attributes;
+```html
+<script>
+	const snapConfig = {
+		shopper: {
+			id: 'shopper@emailprovider.com'
+		},
+		category: {
+			name: 'Shirts',
+			value: 'Clothing/Shirts'
+		}
 	}
-};
+</script>
 ```
 
 ```typescript
-const v3Context = getV3ScriptAttrs();
-if (v3Context?.category) {
+if (snapConfig?.category) {
 	searchConfig.globals.filters.push({
 		type: 'value',
-		field: 'categories_hierarchy',
-		value: v3Context.category,
 		background: true,
+		field: 'categories_hierarchy',
+		value: snapConfig.category.value,
 	});
 }
 ```
 
 
 ### ControllerServices
-The `ControllerServices` object contains all of the controller's dependencies
+The `ControllerServices` object contains all of the controller's dependencies.
 
-Note that the `UrlManager` is utilizing a `HybridTranslator` which will use `'q'` as the URL query parameter. This can be overwritten by providing a `queryParameter` config such as in this example:
+Note that the `UrlManager` is utilizing the `UrlTranslator` which will use `'q'` as the default URL query parameter. This can be overwritten by providing a `queryParameter` config such as in this example:
 
 ```typescript
 const searchControllerServices = {
 	client,
 	store: new SearchStore(),
-	urlManager: new UrlManager(new HybridTranslator({ queryParameter: 'search_query' }), reactLinker),
+	urlManager: new UrlManager(new UrlTranslator({ queryParameter: 'search_query' }), reactLinker),
 	eventManager: new EventManager(),
 	profiler: new Profiler(),
 	logger: new Logger()
@@ -315,36 +300,28 @@ const searchControllerServices = {
 ```
 
 <h3 id="SearchMiddleware">Middleware</h3>
-Now that our SearchController is defined, we can optionally attach middleware to hook into various events. There are two ways of doing this, using the Controller's `use` or `on` methods
 
-#### via `use` method:
+Now that our `SearchController` is defined (using `search` variable), we can optionally attach middleware to hook into various [events](/packages/snap-controller/#searchcontroller-event-lifecycle). There are two ways of doing this, using the Controller's `on` or `use` methods.
+#### via `on` method:
 ```typescript
-async function scrollToTop({ controller }, next) {
-	// keep the same position when a user clicks on a facet
-	if (controller.store.pagination.page != 1) {
-		window.scroll({ top: 0, left: 0, behavior: 'smooth' });
-	}
-
+searchController.on('afterStore', async ({ controller }, next) => {
+	controller.log.debug('store', controller.store.toJSON());
 	await next();
-}
+})
+```
 
+#### via `use` method (to attach groups of middleware):
+```typescript
 const middleware = (controller) => {
-	
-    controller.on('init', async({ controller }, next) => {
-		const versionText = 'bbwheelsonline.com';
-
+	controller.on('init', async({ controller }, next) => {
 		controller.log.imageText({
 			url: 'https://searchspring.com/wp-content/themes/SearchSpring-Theme/dist/images/favicons/favicon.svg',
-			text: `${versionText}`,
+			text: 'snap integration initialized',
 			style: `color: ${controller.log.colors.indigo}; font-weight: bold;`,
 		});
 
 		await next();
 	});
-
-	// scroll to top
-	controller.on('afterStore', scrollToTop);
-
 	// log the store
 	controller.on('afterStore', async({ controller }, next) => {
 		controller.log.debug('store', controller.store.toJSON());
@@ -353,40 +330,17 @@ const middleware = (controller) => {
 };
 
 
-search.use(middleware);
-```
-
-#### via `on` method:
-```typescript
-search.on('afterStore', async ({ controller }, next) => {
-    controller.log.debug('store', controller.store.toJSON());
-	await next();
-})
+searchController.use(middleware);
 ```
 
 <h3 id="SearchDomTargeter">DomTargeter</h3>
 
-`DomTargeter` is a utility for rending components in specified DOM targets. 
+`DomTargeter` is a utility for rending components in specified DOM targets. The following example shows how to use the DomTargeter inside of the 'init' middleware of the `SearchController`.
 
 For further usage and documentation, see [@searchspring/snap-toolbox DomTargeter](../snap-toolbox/README.md#DomTargeter)
 
 ```typescript
-search.on('init', async ({ controller }, next) => {
-    const searchPageTarget = new DomTargeter(
-		[
-			{
-				selector: '.searchspring-container',
-				component: <SearchPage />,
-			},
-		],
-		(target, elem) => {
-			render(target.component, elem);
-
-			const breadcrumbTarget = document.querySelector('.page--searchresults ul.breadcrumbs');
-			breadcrumbTarget && render(<BreadCrumbs />, breadcrumbTarget);
-		}
-	);
-
+searchController.on('init', async ({ controller }, next) => {
 	const contentTarget = new DomTargeter(
 		[
 			{
@@ -418,8 +372,8 @@ search.on('init', async ({ controller }, next) => {
 		}
 	);
 
-    window.addEventListener('DOMContentLoaded', () => {
-		searchPageTarget.retarget();
+	// add a listener to re-target on DOMContentLoaded
+	window.addEventListener('DOMContentLoaded', () => {
 		contentTarget.retarget();
 		sidebarTarget.retarget();
 	});
@@ -429,41 +383,35 @@ search.on('init', async ({ controller }, next) => {
 ```
 
 ### Initialize
-Initializing the controller by invoking its `init` method will subscribe to any URL state changes.
+Initializing the controller by invoking its `init` method will subscribe to any URL state changes and fire the `init` event and any attached middleware.
 
 ```typescript
-search.init();
+searchController.init();
 ```
 
 
 ## Autocomplete
-To set up autocomplete using Snap, we'll need to utilize an `AutocompleteController` which requires two objects:  `AutocompleteControllerConfig` and `ControllerServices`
+To set up autocomplete using Snap, we'll need to utilize an `AutocompleteController` which just like the `SearchController`, requires `AutocompleteControllerConfig` and `ControllerServices` objects to instantiate.
 ```typescript
-const autocomplete = new AutocompleteController(autocompleteConfig, autocompleteControllerServices);
+const autocompleteController = new AutocompleteController(autocompleteConfig, autocompleteControllerServices);
 ```
 
-### Config (AutocompleteControllerConfig)
-Lets define a `AutocompleteControllerConfig` object:
+### Autocomplete Config
+Lets define an `AutocompleteControllerConfig` object:
 
 ```typescript
-const autocompleteConfig : AutocompleteControllerConfig = {
+const autocompleteConfig = {
 	id: 'autocomplete',
 	selector: '#search_query',
-    action: '',
 	globals: {
 		suggestions: {
 			count: 4,
-		},
-		search: {
-			query: {
-				spellCorrection: true,
-			},
 		},
 		pagination: {
 			pageSize: 6,
 		},
 	},
-    settings: {
+	settings: {
 		initializeFromUrl: true,
 		syncInputs: false,
 		facets: {
@@ -473,33 +421,35 @@ const autocompleteConfig : AutocompleteControllerConfig = {
 }
 ```
 
-### ControllerServices
+### Autocomplete Controller Services
 The `ControllerServices` object contains all of the controller's dependencies. Note the difference between SearchController's ControllerServices is the different store. Here we are using `AutocompleteStore`
 
-Note that the `UrlManager` is utilizing a `HybridTranslator` which will use `'q'` as the URL query parameter. This can be overwritten by providing a `queryParameter` config such as in this example:
+Note that the `UrlManager` is utilizing the `UrlTranslator` which will use `'q'` as the URL query parameter. This can be overwritten by providing a `queryParameter` config such as in this example:
 
 ```typescript
 const autocompleteControllerServices = {
 	client,
 	store: new AutocompleteStore(),
-	urlManager: new UrlManager(new HybridTranslator({ queryParameter: 'search_query' }), reactLinker),
+	urlManager: new UrlManager(new UrlTranslator({ queryParameter: 'search_query' }), reactLinker),
 	eventManager: new EventManager(),
 	profiler: new Profiler(),
 	logger: new Logger()
 }
 ```
 
+The translator type should be the same between Autocomplete and Search Controllers in order for compatible URLs to be generated.
+
 ### Middleware
-Autocomplete supports middleware to hook into various events. See [Search Middleware](#SearchMiddleware) above for same usage via `use` and `on` methods
+Autocomplete supports middleware to hook into various events. See [Search Middleware](#SearchMiddleware) above for same usage via `use` and `on` methods.
 
 
 ## DomTargeter
-Similar to [Search DomTargeter](#SearchDomTargeter), we'll use middle wear to hook into AutocompleteController's init event to render autocomplete.
+Similar to [Search DomTargeter](#SearchDomTargeter), we'll use middleware to hook into AutocompleteController's init event to render autocomplete.
 
 For further usage and documentation, see [@searchspring/snap-toolbox DomTargeter](../snap-toolbox/README.md#DomTargeter)
 
 ```typescript
-autocomplete.on('init', async ({ controller }) => {
+autocompleteController.on('init', async ({ controller }) => {
 	new DomTargeter(
 		[
 			{
@@ -530,171 +480,109 @@ autocomplete.on('init', async ({ controller }) => {
 ```
 
 ### Initialize
-Initializing the controller by invoking its `init` method will subscribe to any URL state changes.
+Initializing the controller by invoking its `init` method will subscribe to any URL state changes and fire the `init` event and any attached middleware.
 
 ```typescript
-autocomplete.init();
+autocompleteController.init();
 ```
 
 
 ## Finder
-To set up finder using Snap, we'll need to utilize a `FinderController` which requires two objects:  `FinderControllerConfig` and `ControllerServices`
+To set up a product finder using Snap, we'll need to utilize a `FinderController` which like other controllers seen controllers, requires a `FinderControllerConfig` and a `ControllerServices` object.
 ```typescript
-const finder = new FinderController(finderConfig, finderControllerServices);
+const finderController = new FinderController(finderConfig, finderControllerServices);
 ```
 
 ### Config (FinderControllerConfig)
-There are two types of Finder configurations, a Hierarchy and Non-Hierarchy. The difference is they type of field being used and how it is configured in the Searchspring Management Console.
+There are two types of Finder configurations, a Hierarchy and Non-Hierarchy. The difference is the type of field being used and how it is configured in the Searchspring Management Console.
 
 #### Hierarchy Config
-To use a Hierarchy configuration, ensure that the config's `fields` array contain a single entry, and `fields.field` is of type `hierarchy` in the Searchspring Management Console. Here is an example of a Hierarchy `FinderControllerConfig` object:
+To use a Hierarchy configuration, ensure that the config's `fields` array contain a single entry, and that the field is of type `hierarchy` in the Searchspring Management Console (SMC). Here is an example of a Hierarchy `FinderControllerConfig` object:
 
 ```typescript
-const finderConfig : FinderControllerConfig = {
+const finderConfig = {
 	id: 'finder',
-    url: '/search',
-	globals: {},
-    fields: [{
-        field: 'ss_tire',
-        label: 'Wheel Finder',
-        levels: ['Year', 'Make', 'Model', 'Wheel Size'],
-    }],
+	url: '/search'
+	fields: [{
+		field: 'ss_tire',
+		label: 'Wheel Finder',
+		levels: ['Year', 'Make', 'Model', 'Wheel Size']
+	}]
 }
 ```
 
 #### Non-Hierarchy Config
-To use a Non-Hierarchy configuration, each dropdown will contain its own field and can be of any type. Here is an example of a Non-Hierarchy `FinderControllerConfig` object:
-
-Note if using fields that are not of hierarchy type, `levels` is not required
+To use a Non-Hierarchy configuration, multiple fields are specified; these fields should be `value` type facet fields (as configured in the SMC). Here is an example of a Non-Hierarchy `FinderControllerConfig` object:
 
 ```typescript
-const finderConfig: FinderControllerConfig = {
-    id: 'finder',
-    url: '/search',
-	globals: {},
+const finderConfig = {
+	id: 'finder',
+	url: '/search',
 	fields: [
-        { 
-            field: 'custom_wheel_size',
-            label: 'Size',
-        }, 
-        { 
-            field: 'custom_wheel_width',
-            label: 'Width',
-        }, 
-        { 
-            field: 'custom_wheel_bolt_pattern',
-            label: 'Bolt Pattern',
-        }, 
-        { 
-            field: 'custom_color',
-            label: 'Color',
-        }
-    ]
+		{ 
+			field: 'custom_wheel_size',
+			label: 'Size'
+		}, 
+		{ 
+			field: 'custom_wheel_width',
+			label: 'Width'
+		}, 
+		{ 
+			field: 'custom_wheel_bolt_pattern',
+			label: 'Bolt Pattern'
+		}, 
+		{ 
+			field: 'custom_color',
+			label: 'Color'
+		}
+	]
 };
 ```
 
+Note: When using fields that are not of hierarchy type, `levels` are not required.
 
 ### ControllerServices
-The `ControllerServices` object contains all of the controller's dependencies. Note the difference between SearchController's ControllerServices is the different store. Here we are using `FinderStore`
+The `ControllerServices` object contains all of the controller's dependencies. Note the difference between SearchController's ControllerServices is the different store. Here we are using `FinderStore`:
 
 ```typescript
 const finderControllerServices = {
 	client,
 	store: new FinderStore(),
-	urlManager: new UrlManager(new HybridTranslator(), reactLinker),
+	urlManager: new UrlManager(new UrlTranslator(), reactLinker),
 	eventManager: new EventManager(),
 	profiler: new Profiler(),
 	logger: new Logger()
 }
 ```
 
-### Multiple Finder Instances
-It is common to have multiple Finder instances on a page, each with its own configuration. Here is an example of how that may look:
-
-```typescript
-const finderConfigs = [
-    {
-        id: 'finder_wheel_finder',
-        url: '/search',
-        globals: {},
-        fields: [{
-            field: 'ss_tire',
-            label: 'Wheel Finder',
-            levels: ['Year', 'Make', 'Model', 'Wheel Size'],
-        }],
-    },
-    {
-        id: 'finder_size_finder',
-        url: '/search',
-        globals: {},
-        fields: [
-            { 
-                field: 'custom_wheel_size' 
-                label: 'Size',
-            }, 
-            { 
-                field: 'custom_wheel_width' 
-                label: 'Width',
-            }, 
-            { 
-                field: 'custom_wheel_bolt_pattern' 
-                label: 'Bolt Pattern',
-            }, 
-            { 
-                field: 'custom_color'
-                label: 'Color',
-            }
-        ]
-    }
-]
-```
-
-```typescript
-finderConfigs.forEach((finderConfig) => {
-	const finderInstance = new FinderController(finderConfig, {
-		client,
-		store: new FinderStore(),
-		urlManager: new UrlManager(new HybridTranslator(), reactLinker),
-		eventManager: new EventManager(),
-		profiler: new Profiler(),
-		logger: new Logger()
-	});
-
-	finderInstance.use(finderware);
-    finderInstance.init();
-});
-```
-
 ### Middleware
-Finder supports middleware to hook into various events. See [Search Middleware](#SearchMiddleware) above for same usage via `use` and `on` methods
+`FinderController` (like all controllers) supports middleware to hook into various events. See [Search Middleware](#SearchMiddleware) above for same usage via `use` and `on` methods.
 
 
 ## DomTargeter
-Similar to [Search DomTargeter](#SearchDomTargeter), we'll use middle wear to hook into FinderController's init event to render autocomplete.
+Similar to [Search DomTargeter](#SearchDomTargeter), we'll use middleware to hook into FinderController's init event to render the `Finder` UI component (not shown).
 
 For further usage and documentation, see [@searchspring/snap-toolbox DomTargeter](../snap-toolbox/README.md#DomTargeter)
 
 ```typescript
-finder.on('init', async ({ controller }) => {
+finderController.on('init', async ({ controller }) => {
 	const finderTarget = new DomTargeter(
 		[
 			{
-				selector: '.finder_target',
+				selector: '#finder-target-selector',
 				component: Finder,
 			},
 		],
 		async (target, elem) => {
-			// search after target element is found
+			// run search after target element is found
 			await controller.search();
-
-			// remove loading sibling element
-			elem.parentElement.querySelector('.search-loading')?.remove();
 
 			const finderComponent = <target.component store={controller.store} />;
 			render(finderComponent, elem);
 		}
 	);
 
+	// in case the element did not exist at time of execution
 	window.addEventListener('DOMContentLoaded', () => {
 		finderTarget.retarget();
 	});
@@ -704,27 +592,25 @@ finder.on('init', async ({ controller }) => {
 ```
 
 ### Initialize
-Initializing the controller by invoking its `init` method will subscribe to any URL state changes.
+Initializing the controller by invoking its `init` method will subscribe to any URL state changes and fire the `init` event and any attached middleware.
 
 ```typescript
-finder.init();
+finderController.init();
 ```
-
 
 ### Search
 After the controller has been initialized, the search method must be invoked for the finder to fetch its initial data. In the example above, this is being invoked in the DomTargeter 
 
 ```typescript
-finder.search();
+finderController.search();
 ```
 
 ### Find
 After selection(s) have been made, the user will click on a 'Find' button. This click event should invoke the `find` method of the Finder controller which will redirect to the specified `url` in the config, along with its selection data.
 
 ```typescript
-finder.find();
+finderController.find();
 ```
-
 
 
 # Troubleshooting
@@ -738,8 +624,14 @@ window.addEventListener('DOMContentLoaded', () => {
 });
 
 window.addEventListener('DOMContentLoaded', () => {
-    searchPageTarget.retarget();
-    contentTarget.retarget();
-    sidebarTarget.retarget();
+		searchPageTarget.retarget();
+		contentTarget.retarget();
+		sidebarTarget.retarget();
 });
 ```
+
+## Some middleware isn't executing at all
+Most likely middleware that was attached prior to the one failing to execute failed to call the `await next()` function. This is required to allow other middleware to process the event data.
+
+## Some middleware isn't executing when it should be
+Most likely middleware that was attached is not using `async` functions, or failing to `await` the `next()` function.

--- a/packages/snap-controller/README.md
+++ b/packages/snap-controller/README.md
@@ -2,13 +2,13 @@
 
 <a href="https://www.npmjs.com/package/@searchspring/snap-controller"><img alt="NPM Status" src="https://img.shields.io/npm/v/@searchspring/snap-controller.svg?style=flat"></a>
 
-The heart of controlling Search, Autocomplete, & Finder functionality
+The heart of controlling Search, Autocomplete, & Finder functionality. The Controller is responsible for tying various Snap services together.
 
 ---
 
 # Dependencies
 
-Snap Controller is a top-level package that requires the following dependencies:
+Snap Controller is a top-level package that requires the following dependencies as services:
 
 <a href="https://www.npmjs.com/package/@searchspring/snap-client-javascript"><img alt="NPM Status" src="https://img.shields.io/npm/v/@searchspring/snap-client-javascript.svg?style=flat"></a> [@searchspring/snap-client-javascript](../snap-client-javascript)
 
@@ -23,432 +23,467 @@ Snap Controller is a top-level package that requires the following dependencies:
 <a href="https://www.npmjs.com/package/@searchspring/snap-logger"><img alt="NPM Status" src="https://img.shields.io/npm/v/@searchspring/snap-logger.svg?style=flat"></a> [@searchspring/snap-logger](../snap-logger)
 
 <details>
-    <summary>Package dependencies hierarchy</summary>
-    <br/>
-    <img src="../../images/snap-dependencies.jpg"/>
+	<summary>Package dependencies hierarchy</summary>
+	<br/>
+	<img src="../../images/snap-dependencies.jpg"/>
 </details>
 
-
+<br>
 
 # Installation
+
+To install the `snap-controller` package and it's services:
 
 ```bash
 npm install --save @searchspring/snap-controller @searchspring/snap-client-javascript @searchspring/snap-store-mobx @searchspring/snap-url-manager @searchspring/snap-event-manager @searchspring/snap-profiler @searchspring/snap-logger
 ```
 
 # Usage
-## Global Config
-Object required for all controllers
 
-`siteId` (required)
+## Instantiation
+Each `Controller` must be passed a configuration object as the first parameter to the constructor, and a services object (dependencies) as the second. The contents of these objects will depend on which type of `Controller` is being instantiated. For example, a `SearchController` would usually be paired with a `SearchStore` service, and would take a `SearchControllerConfig` configuration object.
 
-Any other keys defined here will be passed to the API request
-
-```typescript
-const globals = {
-	siteId: 'scmq7n'
-};
-```
-
-## Client Config
-Object required for all controllers
-
-`apiHost` (optional) - Specify local [Snapi](https://link.to.snapi) endpoint for development
-<!-- TODO: snapi link -->
-
-```typescript
-const clientConfig = {
-	apiHost: 'http://localhost:8080/api/v1'
-};
-```
-## Import
-```typescript
-import { SearchController, AutocompleteController, FinderController } from '@searchspring/snap-controller';
-```
-
-<h2 id="SearchController">SearchController</h2>
-
-### Default Config
-`id` - a unique identifier for this controller. Will appear in console log & warn
-
-`globals` - keys defined here will be passed to the API request (overwrites global config)
-
-`settings.redirects.merchandising` - merchandising redirects
-
-`settings.redirects.singleResult` - redirect to product detail page if search yields 1 result count
-
-`settings.facets.trim` - facets that do not change results will be removed
-
-```typescript
-const searchConfig: SearchControllerConfig = {
-	id: 'search',
-	globals: {},
-	settings: {
-		redirects: {
-			merchandising: true,
-			singleResult: true,
-		},
-		facets: {
-			trim: true,
-		},
-	},
-};
-```
-### Instantiate
-Search controller requires a `SearchControllerConfig` and `ControllerServices` object
+The complete example below shows how a `SearchController` could be instatiated, initialized and searched:
 
 ```typescript
 import { SearchController } from '@searchspring/snap-controller';
 import SnapClient from '@searchspring/snap-client-javascript';
 import { SearchStore } from '@searchspring/snap-store-mobx';
-import { UrlManager, QueryStringTranslator, reactLinker } from '@searchspring/snap-url-manager';
+import { UrlManager, UrlTranslator, reactLinker } from '@searchspring/snap-url-manager';
+import { EventManager } from '@searchspring/snap-event-manager';
+import { Profiler } from '@searchspring/snap-profiler';
+import { Logger } from '@searchspring/snap-logger';
+
+const configuration = {
+	id: 'search'
+};
+
+const services = {
+	client: new SnapClient({ siteId: 'abc123' }),
+	store: new SearchStore(),
+	urlManager: new UrlManager(new UrlTranslator(), reactLinker),
+	eventManager: new EventManager(),
+	profiler: new Profiler(),
+	logger: new Logger()
+}
+
+const controller = new SearchController(configuration, services);
+controller.init();
+controller.search();
+```
+
+## Configuration
+The configuration object provided during instantiation provides a way of configuring the controller for different behavior. Each controller type (`SearchController`, `AutocompleteController`, `FinderController`, etc...) has default configurations that can be modified with the instantiation configuration object. At minimum an `id` attribute is required for identifying controllers. The `id` should be unique to each *instance* of a controller.
+## Services
+Along with a configuration, each controller is passed a collection of services during instantiation. These services are then used by the controller and made available via controller methods. Sometimes controllers might share a reference to a service (the `client` service for example), but in most cases a controller will have it's own instance of a service.
+
+```typescript
+{ client, store, urlManager, eventManager, profiler, logger }
+```
+### client
+The `client` service makes the requests to the API when the controller `search` method is called. The response is passed onto the `store` service. This service is exposed as `controller.client`.
+
+### store
+This service mutates the API responses and adds convenience functions for common functionality. The `store` data is then used by the UI components for display. This service is exposed as `controller.store`.
+### urlManager
+`urlManager` is responsible for updating the page URL when interacting with UI components. The type of translator passed into the `UrlManager` constructor will determine the types of URLs generated. This service is exposed as `controller.urlManager`.
+### eventManager
+Middleware provide an opportunity to hook into these events they occur. Middleware are attached to events, and these events are managed by the `eventManager`. This service is exposed as `controller.eventManager`.
+
+### profiler
+Controllers may need to know how long a certain event took, the `profiler` service provides the means to track this information. This service is exposed as `controller.profiler`.
+
+### logger
+The `logger` service provides logging functionality to a controller. Each controller logs when errors in middleware and when controller events occur. The logger is responsible for sending this information to the developer console. In addition the logger may provide additional emoji or colors to use. This service is exposed as `controller.log`.
+
+## Initialization
+Invoking the `init` method is required to subscribe to changes that occur in the UrlManager. It also fires the `init` event which executes attached middleware. This should happen prior to any calls to the controller `search` method.
+
+```typescript
+controller.init();
+```
+
+## Searching
+The `search` method of a controller will run the search that is expected by leveraging the `client` service to make the request; the subsequent response will be passed to the `store` service.
+
+Most controllers will provide a means of manipulating the request and response using `beforeSearch` and `afterSearch` events respectively. Read on for details about events.
+
+```typescript
+controller.search();
+```
+
+## Stores
+Different controller types will utilize different Snap Stores (typically of the same name). Each `store` will provide different properties and methods for its unique purposes. See the documentation for more details.
+
+## Events
+Each controller will fire various events. Some of the event names are shared between controllers for consistency (ex: `beforeSearch`, `afterSearch`, `afterStore`); however the attaching of middleware and execution of it must remain separate. This is why a new `EventManager` instance is created for each controller. Middleware are attached to events via the `on` method and the functions should almost always end with `await next()` unless purposefully preventing the next attached middleware from executing.
+
+```typescript
+controller.on('init', async (eventData, next) => {
+	const { controller } = eventData;
+
+	controller.log.debug('init event has occurred');
+
+	await next();
+});
+```
+
+Note: Groups of middleware (plugins) can be attached using the `use` method.
+
+The data available within a middleware (first parameter) is determined by what gets passed into the `fire` method. For existing events on the controller, the `fire` method is already being called when appropriate to the event, and the `eventData` will typically be an object containing a reference to the controller and any other details that may be of importance to the particular event. Custom events can be created as needed; but keep in mind that any middleware tied to the event should be bound (using `on` or `use`) prior to executing the `fire` method.
+
+```typescript
+controller.eventManager.fire('customEventName', { thing1: 'one', thing2: 2 });
+```
+
+See the EventManager documentation for more details.
+
+## Environment
+A controller's environment is initialized at build time, and is used to control certain runtime behavior. For example, a `production` build will supress most logs while a `development` build will show them all.
+## Logging
+The logger provides a clear way of outputting details like profile data or errors to the developer console. A `production` build will supress most logs while a `development` build will show them all. The environment is automatically determined, but can be toggled during runtime by setting it to either `development` or `production`.
+
+```typescript
+controller.environment = 'development';
+```
+
+The use of `console.log()` is discouraged. Logging should be done via controller instance to help debug and navigate the sea of console logs. Each controller will output the `id` for easily deciphering which controller made the log.
+
+```typescript
+controller.log.warn('THIS IS A WARNING!');
+```
+
+Many logs are supressed depending on a development `environment` of the controller instance. The Logger documentation provides more details about the various methods, colors and emoji available.
+
+# Controller Types
+Each `Controller` has a unique configuration and set of default events; it may also provide additional methods for specific functionality.
+
+<h2 id="SearchController">SearchController</h2>
+
+The `SearchController` is used when making queries to the API `search` endpoint.
+
+### SearchControllerConfig
+
+| option | description | default value | required | 
+|---|---|---|---|
+| id | unique identifier for this controller | :heavy_minus_sign: | :heavy_check_mark: |
+| globals | keys defined here will be passed to the API request (can overwrite global config)| :heavy_minus_sign: |   |
+| settings.redirects.merchandising | enable merchandising redirects | true |   |
+| settings.redirects.singleResult | enable redirect to product detail page if search yields 1 result count | true |   |
+| settings.facets.trim | facets that do not change results will be removed | true |   |
+
+<br>
+
+```typescript
+const searchConfig = {
+	id: 'search',
+	globals: {
+		pagination: {
+			pageSize: 12
+		}
+	}
+};
+```
+### Instantiate
+`SearchController` requires a `SearchControllerConfig` and `ControllerServices` object and is usually paired with a `SearchStore`.
+
+```typescript
+import { SearchController } from '@searchspring/snap-controller';
+import SnapClient from '@searchspring/snap-client-javascript';
+import { SearchStore } from '@searchspring/snap-store-mobx';
+import { UrlManager, UrlTranslator, reactLinker } from '@searchspring/snap-url-manager';
 import { EventManager } from '@searchspring/snap-event-manager';
 import { Profiler } from '@searchspring/snap-profiler';
 import { Logger } from '@searchspring/snap-logger';
 
 const searchController = new SearchController(searchConfig, {
-        client: new SnapClient(globals, clientConfig),
-        store: new SearchStore(),
-        urlManager: new UrlManager(new QueryStringTranslator(), reactLinker),
-        eventManager: new EventManager(),
-        profiler: new Profiler(),
-        logger: new Logger()
-    }: ControllerServices
-));
+	client: new SnapClient({ siteId: 'abc123' }),
+	store: new SearchStore(),
+	urlManager: new UrlManager(new UrlTranslator(), reactLinker),
+	eventManager: new EventManager(),
+	profiler: new Profiler(),
+	logger: new Logger()
+});
 ```
+
 ### Initialize
-Invoking the `init` method is required to subscribe to changes that occur in the UrlManager
+Invoking the `init` method is required to subscribe to changes that occur in the UrlManager.
 
 ```typescript
 searchController.init();
 ```
 
 ### Search
-This will invoke an initial search request to Searchspring's search API and render results after the SearchStore has been populated
+This will invoke a search request to Searchspring's search API and populate the store with the response.
+
 ```typescript
 searchController.search();
 ```
 
-### Render
-```typescript
-import { h, render } from 'preact';
-
-render(<Sidebar store={searchController.store} />, document.getElementById('searchspring-sidebar'));
-render(<Content store={searchController.store} />, document.getElementById('searchspring-content'));
-```
-
-### SearchController Event lifecycle
-Events are invoked in the following order:
+### Events
 
 #### init
-- Must be called manually
-- subscribes to changes in the UrlManager
+- Called with `eventData` = { controller }
+- Always invoked by a call to the `init` controller method
 
 #### beforeSearch
+- Called with `eventData` = { controller, request }
 - Always invoked before an API request is made 
 - Sets `controller.store.loading = true`
 
 #### afterSearch
+- Called with `eventData` = { controller, request, response }
 - Always invoked after an API request is made 
-- Invokes `window.location.replace()` if API response contains merchandising redirects AND if `searchConfig.settings.redirects.merchandising = true` (default)
-- Invokes `window.location.replace()` to redirect to product detail page if API response returned a single product AND `searchConfig.settings.redirects.singleResult = true` (default)
+- Invokes `window.location.replace()` if API response contains merchandising redirects AND if `config.settings.redirects.merchandising = true` (default)
+- Invokes `window.location.replace()` to redirect to product detail page if API response returned a single product AND `config.settings.redirects.singleResult = true` (default)
 - Sets `controller.store.loading = false`
 
 #### afterStore
+- Called with `eventData` = { controller, request, response }
 - Always invoked after data has been stored in mobx store
-- no operation
 
 <h2 id="AutocompleteController">AutocompleteController</h2>
 
-### Default Config
-`id` - a unique identifier for this controller. Will appear in console log & warn
+The `AutocompleteController` is used when making queries to the API `autocomplete` endpoint. It can also bind events to DOM elements to handle user input of queries.
 
-`selector` - css selector that targets all search input(s)
+### AutocompleteControllerConfig
 
-`action` - If the input does not contain a parent form element, or you would like to override the form action
+| option | description | default value | required | 
+|---|---|:---:|:---:|
+| id | unique identifier for this controller | :heavy_minus_sign: | :heavy_check_mark: |
+| selector | css selector for input elements that DOM events should be bound to | :heavy_minus_sign: | :heavy_check_mark: |
+| action | optional way to override the form action or provide one when it does not exist | :heavy_minus_sign: |   |
+| globals | keys defined here will be passed to the API request (can overwrite global config)| :heavy_minus_sign: |   |
+| settings.initializeFromUrl | initialize the controller with query parameter from URL (pre-fill input with current search) | true |   |
+| settings.syncInputs | if the selector targets multiple inputs, the value of those inputs will be synced | false |   |
+| settings.facets.trim | facets that do not change results will be removed | true |   |
 
-`globals` - keys defined here will be passed to the API request (overwrites global config)
-
-`settings.initializeFromUrl` - initialize the controller with query parameters from URL
-
-`settings.syncInputs` - if the selector targets multiple inputs, the value of those inputs will be synced
-
-`settings.facets.trim` - facets that do not change results will be removed
+<br>
 
 ```typescript
-const autocompleteConfig: AutocompleteControllerConfig = {
+const autocompleteConfig = {
 	id: 'autocomplete',
-	selector: '',
-	action: '',
-	globals: {},
+	selector: '#searchInput',
 	settings: {
-		initializeFromUrl: true,
-		syncInputs: false,
-		facets: {
-			trim: true,
-		},
+		syncInputs: true
 	},
 };
 ```
 
 ### Instantiate
-Autocomplete controller requires an `AutocompleteControllerConfig` and `ControllerServices` object
+`AutocompleteController` requires an `AutocompleteControllerConfig` and `ControllerServices` object and is usually paired with an `AutocompleteStore`.
 
 ```typescript
 import { AutocompleteController } from '@searchspring/snap-controller';
 import SnapClient from '@searchspring/snap-client-javascript';
 import { AutocompleteStore } from '@searchspring/snap-store-mobx';
-import { UrlManager, QueryStringTranslator, reactLinker } from '@searchspring/snap-url-manager';
+import { UrlManager, UrlTranslator, reactLinker } from '@searchspring/snap-url-manager';
 import { EventManager } from '@searchspring/snap-event-manager';
 import { Profiler } from '@searchspring/snap-profiler';
 import { Logger } from '@searchspring/snap-logger';
 
 const autocompleteController = new AutocompleteController(autocompleteConfig, {
-        client: new SnapClient(globals, clientConfig),
-        store: new AutocompleteStore(),
-        urlManager: new UrlManager(new QueryStringTranslator({ queryParameter: 'search_query' }), reactLinker),
-        eventManager: new EventManager(),
-        profiler: new Profiler(),
-        logger: new Logger()
-    }: ControllerServices
+		client: new SnapClient(globals, clientConfig),
+		store: new AutocompleteStore(),
+		urlManager: new UrlManager(new UrlTranslator(), reactLinker),
+		eventManager: new EventManager(),
+		profiler: new Profiler(),
+		logger: new Logger()
+	}
 ));
 ```
 
 ### Initialize
-Invoking the `init` method is required to subscribe to changes that occur in the UrlManager
+Invoking the `init` method is required to subscribe to changes that occur in the UrlManager.
 
 ```typescript
-window.addEventListener('DOMContentLoaded', () => {
-	autocompleteController.init();
-});
+autocompleteController.init();
 ```
 
 ### Bind
 <!-- TODO: set/test link to DomTargeter -->
-Invoking the `bind` method is required to attach event listeners to each input.
+Invoking the `bind` method is required to attach event listeners to each input specified as `selector` in the `AutocompleteControllerConfig`.
 
 ```typescript
 autocompleteController.bind();
 ```
 
+### Search
+This will invoke a search request to Searchspring's search API and populate the store with the response. This should be automatically called by the DOM event binding that occurs when the `bind` method (see above) is invoked.
+
+```typescript
+autocompleteController.search();
+```
+
+### Events
+#### init
+- Called with `eventData` = { controller }
+- Always invoked by a call to the `init` controller method
+
+#### beforeSearch
+- Called with `eventData` = { controller, request }
+- Always invoked before an API request is made 
+- Sets `controller.store.loading = true`
+
+#### afterSearch
+- Called with `eventData` = { controller, request, response }
+- Always invoked after an API request is made 
+- Sets `controller.store.loading = false`
+- Cancels search if input doesn't match current urlManager input state
+
+#### afterStore
+- Called with `eventData` = { controller, request, response }
+- Always invoked after data has been stored in mobx store
+
+#### focusChange
+- Called with `eventData` = { controller }
+- Invoked when an input has been focused
+
 
 <h2 id="FinderController">FinderController</h2>
 
-### Default Config
-<!-- TODO: add selector, wrapSelector, type, className ? -->
+The `FinderController` should be used for building product finders. It makes queries to the API `search` endpoint.
 
-`id` - a unique identifier for this controller. Will appear in console log & warn
 
-`url` - URL to be redirected to upon clicking finder's 'find' button
+### FinderControllerConfig
 
-`globals` - keys defined here will be passed to the API request (overwrites global config)
+| option | description | default value | required | 
+|---|---|:---:|:---:|
+| id | unique identifier for this controller | :heavy_minus_sign: | :heavy_check_mark: |
+| url | URL to be redirected to upon clicking finder's 'find' button | :heavy_minus_sign: | :heavy_check_mark: |
+| globals | keys defined here will be passed to the API request (can overwrite global config)| :heavy_minus_sign: |   |
+| fields | an array of finder field configurations | :heavy_minus_sign: | :heavy_check_mark: |
+| fields.field | required field name | :heavy_minus_sign: | :heavy_check_mark: |
+| fields.label | optional finder label | :heavy_minus_sign: |   |
+| fields.levels | optional finder selection levels (hierarchy only) | :heavy_minus_sign: |   |
 
-`fields` - an array of finder field configurations
-
-`fields.field` - required field name
-
-`fields.label` - optional finder label
-
-`fields.levels` - optional finder selection levels
-
-```typescript
-const finderConfig: FinderControllerConfig = {
-    id: 'finder',
-    url: '',
-	globals: {},
-	fields: FinderFieldConfig[],
-};
-
-type FinderFieldConfig = {
-	field: string;
-	label?: string;
-	levels?: string[];
-};
-```
+<br>
 
 <h4 id="HierarchyConfig">Hierarchy Config</h4>
 Specifying `levels` will display a dropdown for each hierarchy level. Finders that use hierarchy fields will enforce selecting dropdowns in order by disabling the following dropdowns
 
 ```typescript
-const finderConfig: FinderControllerConfig = {
-    id: 'finder',
-    url: '/search',
-	globals: {},
+const finderConfig = {
+	id: 'finder',
+	url: '/search',
 	fields: [
-        {
-            field: 'ss_tire',
-            label: 'Wheel Finder',
-            levels: ['Year', 'Make', 'Model', 'Wheel Size'],
-        },
-    ]
+		{
+			field: 'ss_tire',
+			label: 'Wheel Finder',
+			levels: ['Year', 'Make', 'Model', 'Wheel Size']
+		},
+	]
 };
 ```
 
 Optionally if `levels` are not defined, a single dropdown will be displayed on the initial load. Each selection will dynamically append additional dropdowns until there are no more available selections
 
 ```typescript
-const finderConfig: FinderControllerConfig = {
-    id: 'finder',
-    url: '/search',
-	globals: {},
+const finderConfig = {
+	id: 'finder',
+	url: '/search',
 	fields: [
-        {
-            field: 'ss_tire',
-        },
-    ]
+		{
+			field: 'ss_tire'
+		}
+	]
 };
 ```
-
 
 <h4 id="NonHierarchyConfig">Non-Hierarchy Config</h4>
 If using fields that are not of hierarchy type, `levels` are not required
 
 ```typescript
-const finderConfig: FinderControllerConfig = {
-    id: 'finder',
-    url: '/search',
-	globals: {},
+const finderConfig = {
+	id: 'finder',
+	url: '/search',
 	fields: [
-        { 
-            field: 'custom_wheel_size' 
-            label: 'Size',
-        }, 
-        { 
-            field: 'custom_wheel_width' 
-            label: 'Width',
-        }, 
-        { 
-            field: 'custom_wheel_bolt_pattern' 
-            label: 'Bolt Pattern',
-        }, 
-        { 
-            field: 'custom_color'
-            label: 'Color',
-        }
-    ]
+		{ 
+			field: 'custom_wheel_size' 
+			label: 'Size'
+		}, 
+		{ 
+			field: 'custom_wheel_width' 
+			label: 'Width'
+		}, 
+		{ 
+			field: 'custom_wheel_bolt_pattern' 
+			label: 'Bolt Pattern'
+		}, 
+		{ 
+			field: 'custom_color'
+			label: 'Color'
+		}
+	]
 };
 ```
 
-### Installation
-
 ### Instantiate
-FinderController requires a `FinderControllerConfig` and `ControllerServices` object
+`FinderController` requires a `FinderControllerConfig` and `ControllerServices` object and is usually paired with a `FinderStore`.
 
 ```typescript
 import { FinderController } from '@searchspring/snap-controller';
 import SnapClient from '@searchspring/snap-client-javascript';
 import { FinderStore } from '@searchspring/snap-store-mobx';
-import { UrlManager, QueryStringTranslator, reactLinker } from '@searchspring/snap-url-manager';
+import { UrlManager, UrlTranslator, reactLinker } from '@searchspring/snap-url-manager';
 import { EventManager } from '@searchspring/snap-event-manager';
 import { Profiler } from '@searchspring/snap-profiler';
 import { Logger } from '@searchspring/snap-logger';
 
-const finderController = new FinderController(searchConfig, {
-        client: new SnapClient(globals, clientConfig),
-        store: new FinderStore(),
-        urlManager: new UrlManager(new QueryStringTranslator(), reactLinker),
-        eventManager: new EventManager(),
-        profiler: new Profiler(),
-        logger: new Logger()
-    }: ControllerServices
+const finderController = new FinderController(finderConfig, {
+		client: new SnapClient(globals, clientConfig),
+		store: new FinderStore(),
+		urlManager: new UrlManager(new UrlTranslator(), reactLinker),
+		eventManager: new EventManager(),
+		profiler: new Profiler(),
+		logger: new Logger()
+	}
 ));
 ```
 ### Initialize
-Invoking the `init` method is required to subscribe to changes that occur in the UrlManager
+Invoking the `init` method is required to subscribe to changes that occur in the UrlManager.
 
 ```typescript
 finderController.init();
 ```
 
 ### Search
-This will invoke an initial search request to Searchspring's search API and render results after the FinderStore has been populated
+This will invoke a search request to Searchspring's search API and populate the store with the response. This should be called initially and after finder selections have been made.
+
 ```typescript
 finderController.search();
 ```
 
 ### Find
-After selection(s) have been made, the user will click on a 'Find' button. This click event should invoke the `find` method of the Finder controller which will redirect to the specified `url` in the config, along with its selection data.
+After selection(s) have been made, the user will click on a 'Find' button. This click event should invoke the `find` method of the `FinderController` which will redirect to the specified `url` in the config, along with its selection data.
 
 ```typescript
 finderController.find();
 ```
 
-### FinderController Event lifecycle
-Events are invoked in the following order:
+### Reset
+This mthod should be invoked to 'reset' or remove all finder selections. This will also clear out any persisted selection storage data.
 
-#### init
-- Must be called manually
-- subscribes to changes in the urlManager
-
-#### beforeSearch
-- Always invoked before an API request is made 
-- Sets `controller.store.loading = true`
-
-#### afterSearch
-- Always invoked after an API request is made 
-- Sets `controller.store.loading = false`
-
-#### afterStore
-- Always invoked after data has been stored in mobx store
-- no operation
-
-
-## Middleware (Search, Autocomplete, & Finder Controllers)
-Each controller has several events that you can hook into before data is rendered. 
-Since Snap Event Manager is a dependency of all the controllers, it is recommended to use the event manager via the controller. For direct usage, see [Snap Event Manager](../snap-event-manager/)
-
-|                                                                      | `[custom event]`   | init               | beforeSearch       | afterSearch        | afterStore         | focusChange        | 
-| --:                                                                  | :-:                | :-:                | :-:                | :-:                | :-:                | :-:                |
-| [SearchController](#SearchController)             | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |
-| [AutocompleteController](#AutocompleteController) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| [FinderController](#FinderController)             | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |
-
-### `use` method
-Apply multiple event middleware using the `use` method
-
-If `next()` is not called or `false` is returned, the middleware chain will not continue
 ```typescript
-const middleware = (controller) => {
-    controller.on('afterStore', ({ controller }, next) => {
-        // keep the same position when a user clicks on a facet
-        if (controller.store.pagination.page != 1) { 
-            window.scroll({ top: 0, left: 0, behavior: 'smooth' });
-        }
-		next();
-	});
-}
-searchController.use(middleware);
-```
-
-### `on` method
-Alternatively, you can also use the `on` method. Invoking `next()` is not required here
-```typescript
-searchController.on('init', async ({ controller }) => {});
+finderController.reset();
 ```
 
 ### Events
-Must first be defined using `on` method before called using `fire` method
-
 #### init
-The `init` event must be called after instantiating an instance of any Controller for changes in the urlManager to take effect by subscribing to changes.
+- Called with `eventData` = { controller }
+- Always invoked by a call to the `init` controller method
 
 #### beforeSearch
+- Called with `eventData` = { controller, request }
 - Always invoked before an API request is made 
 - Sets `controller.store.loading = true`
 
 #### afterSearch
+- Called with `eventData` = { controller, request, response }
 - Always invoked after an API request is made 
 - Sets `controller.store.loading = false`
-- When using SearchController:
-    - Invokes `window.location.replace()` if API response contains merchandising redirects AND if `searchConfig.settings.redirects.merchandising = true` (default)
-    - Invokes `window.location.replace()` to redirect to product detail page if API response returned a single product AND `searchConfig.settings.redirects.singleResult = true` (default)
-- When using AutocompleteController:
-    - Cancels search if no input or query doesn't match current urlManager state
 
 #### afterStore
+- Called with `eventData` = { controller, request, response }
 - Always invoked after data has been stored in mobx store
-- no operation
-
-#### focusChange
-- Invoked when an input has been focused
 - no operation


### PR DESCRIPTION
I was only able to get to root doc and controller. I hope to have time to at minimum verify the accuracy of the remainder of the service readme files at some point.

I re-arranged quite a bit in controller. At some point we may want to consider splitting the root doc, and controller doc into smaller separate docs where it makes sense. For example, the root doc has a section about the mono repo usage, then a "Typical Usage" section on creating various snap controllers, then another for "Troubleshooting". For now, content is key.