### PR TITLE
feat: hide control column of ArgsTable on docs tab using css

### DIFF
--- a/packages/snap-preact-components/.storybook/preview.js
+++ b/packages/snap-preact-components/.storybook/preview.js
@@ -1,6 +1,7 @@
 import { h } from 'preact';
 import { ThemeProvider } from '../src/providers/theme';
 import { defaultTheme } from '../src/providers/theme';
+import './styles.css'
 
 export const decorators = [
 	(Story) => (

--- a/packages/snap-preact-components/.storybook/styles.css
+++ b/packages/snap-preact-components/.storybook/styles.css
@@ -1,0 +1,18 @@
+/* hides 'control' column in ArgsTable on docs tab  */
+.docblock-argstable-head tr th:nth-child(1),
+.docblock-argstable-body tr td:nth-child(1) {
+    width: 20%!important;
+}
+.docblock-argstable-head tr th:nth-child(2),
+.docblock-argstable-body tr td:nth-child(2) {
+    width: 60%!important;
+}
+.docblock-argstable-head tr th:nth-child(3),
+.docblock-argstable-body tr td:nth-child(3) {
+    width: 20%!important;
+}
+.docblock-argstable-head tr th:nth-child(4),
+.docblock-argstable-body tr td:nth-child(4) {
+    display: none!important;
+    width: 0!important;
+}


### PR DESCRIPTION
I took a look at the ArgsTableProps and saw an 'exclude' prop but this seems apply to the list of props in the ArgsTable and not the columns. It doesn't look like this can be done but I joined storybook's discord and asked a question there as it seems they're pretty active. For now, in this PR I was able to hide just on the docs tab using css