### PR TITLE
fix: icon gallery hiding controls

### DIFF
--- a/packages/snap-preact-components/.storybook/preview.js
+++ b/packages/snap-preact-components/.storybook/preview.js
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import { ThemeProvider } from '../src/providers/theme';
 import { defaultTheme } from '../src/providers/theme';
-import './styles.css'
+import './styles.css';
 
 export const decorators = [
 	(Story) => (
@@ -12,6 +12,15 @@ export const decorators = [
 ];
 
 export const parameters = {
-	actions: { argTypesRegex: '^on[A-Z].*' },
-	controls: { expanded: true },
+	actions: {
+		argTypesRegex: '^on[A-Z].*',
+		disabled: false,
+	},
+	controls: {
+		expanded: true,
+		disabled: false,
+	},
+	options: {
+		showPanel: true,
+	},
 };

--- a/packages/snap-preact-components/src/components/Atoms/Icon/Icon.stories.tsx
+++ b/packages/snap-preact-components/src/components/Atoms/Icon/Icon.stories.tsx
@@ -24,12 +24,6 @@ export default {
 		actions: {
 			disabled: true,
 		},
-		controls: {
-			disabled: false,
-		},
-		options: {
-			showPanel: true,
-		},
 	},
 	argTypes: {
 		icon: {
@@ -155,6 +149,7 @@ Gallery.args = {
 };
 Gallery.parameters = {
 	controls: {
+		expanded: false,
 		disabled: true,
 	},
 	options: {


### PR DESCRIPTION
Hierarchy of parameters now:
- global show controls and actions for all stories
  - hide actions for all icon stories
    - hide control & options panel for icon gallery story