### PR TITLE
fix: fix refinedValues filter for when values are not strings causing…

### DIFF
--- a/packages/snap-store-mobx/src/Search/Stores/FacetStore.ts
+++ b/packages/snap-store-mobx/src/Search/Stores/FacetStore.ts
@@ -225,7 +225,7 @@ class ValueFacet extends Facet {
 
 		if (this.search.input) {
 			const search = new RegExp(escapeRegExp(this.search.input), 'i');
-			values = this.values.filter((value) => value.label.match(search));
+			values = this.values.filter((value) => String(value.label).match(search));
 		}
 
 		if (this.overflow.enabled && this.overflow.limited) {


### PR DESCRIPTION
… .match() to fail