### PR TITLE
Middleware Refactor

### DIFF
--- a/packages/snap-client/src/Client/Client.ts
+++ b/packages/snap-client/src/Client/Client.ts
@@ -179,10 +179,10 @@ export class Client {
 		return results;
 	}
 
-	async trending(params: TrendingRequestModel): Promise<TrendingResponseModel> {
+	async trending(params: Partial<TrendingRequestModel>): Promise<TrendingResponseModel> {
 		params = deepmerge({ siteId: this.globals.siteId }, params || {});
 
-		return this.requesters.suggest.getTrending(params);
+		return this.requesters.suggest.getTrending(params as TrendingRequestModel);
 	}
 
 	async recommend(params: RecommendCombinedRequestModel): Promise<RecommendCombinedResponseModel> {

--- a/packages/snap-controller/README.md
+++ b/packages/snap-controller/README.md
@@ -99,7 +99,7 @@ Controllers may need to know how long a certain event took, the `profiler` servi
 The `logger` service provides logging functionality to a controller. Each controller logs when errors in middleware and when controller events occur. The logger is responsible for sending this information to the developer console. In addition the logger may provide additional emoji or colors to use. This service is exposed as `controller.log`.
 
 ## Initialization
-Invoking the `init` method is required to subscribe to changes that occur in the UrlManager. It also fires the `init` event which executes attached middleware. This should happen prior to any calls to the controller `search` method.
+Invoking the `init` method is required to subscribe to changes that occur in the UrlManager. It also fires the `init` event which executes attached middleware. This can be fired manually as needed; if it was not manually fired it will happen automatically on the first call to the controller `search` method.
 
 ```typescript
 controller.init();
@@ -130,9 +130,9 @@ controller.on('init', async (eventData, next) => {
 });
 ```
 
-Note: Groups of middleware (plugins) can be attached using the `use` method.
+Note: Groups of middleware (plugins) can be attached using the `plugin` method.
 
-The data available within a middleware (first parameter) is determined by what gets passed into the `fire` method. For existing events on the controller, the `fire` method is already being called when appropriate to the event, and the `eventData` will typically be an object containing a reference to the controller and any other details that may be of importance to the particular event. Custom events can be created as needed; but keep in mind that any middleware tied to the event should be bound (using `on` or `use`) prior to executing the `fire` method.
+The data available within a middleware (first parameter) is determined by what gets passed into the `fire` method. For existing events on the controller, the `fire` method is already being called when appropriate to the event, and the `eventData` will typically be an object containing a reference to the controller and any other details that may be of importance to the particular event. Custom events can be created as needed; but keep in mind that any middleware tied to the event should be bound (using `on` or `plugin`) prior to the execution of the `fire` method.
 
 ```typescript
 controller.eventManager.fire('customEventName', { thing1: 'one', thing2: 2 });

--- a/packages/snap-controller/src/Abstract/AbstractController.ts
+++ b/packages/snap-controller/src/Abstract/AbstractController.ts
@@ -1,28 +1,24 @@
-import { Tracker } from '@searchspring/snap-tracker';
-import type { EventManager, Middleware } from '@searchspring/snap-event-manager';
 import { LogMode } from '@searchspring/snap-logger';
 import { DomTargeter } from '@searchspring/snap-toolbox';
+
+import type { ControllerServices, ControllerConfig, Attachments } from '../types';
+import type { Client } from '@searchspring/snap-client';
+import type { AbstractStore } from '@searchspring/snap-store-mobx';
+import type { UrlManager } from '@searchspring/snap-url-manager';
+import type { EventManager, Middleware } from '@searchspring/snap-event-manager';
+import type { Profiler } from '@searchspring/snap-profiler';
+import type { Logger } from '@searchspring/snap-logger';
+import type { Tracker } from '@searchspring/snap-tracker';
 import type { Target, OnTarget } from '@searchspring/snap-toolbox';
-import { ControllerServices } from '../types';
-
-type PluginFunction = (func: (cntrlr: AbstractController) => Promise<void>) => Promise<void>;
-
-type ControllerConfig = {
-	id: string;
-	on?: {
-		[eventName: string]: Middleware<any> | Middleware<any>[];
-	};
-	use?: PluginFunction | PluginFunction[];
-};
 
 export abstract class AbstractController {
 	public config: ControllerConfig;
 	public client;
-	public store;
-	public urlManager;
+	public store: AbstractStore;
+	public urlManager: UrlManager;
 	public eventManager: EventManager;
-	public profiler;
-	public log;
+	public profiler: Profiler;
+	public log: Logger;
 	public tracker: Tracker;
 	public targets: {
 		[key: string]: DomTargeter;
@@ -104,36 +100,6 @@ export abstract class AbstractController {
 		}
 		// set environment
 		this.environment = process.env.NODE_ENV as LogMode;
-
-		// TODO: ensure config middleware is proper type
-		// attach config middleware
-		if (this.config.on) {
-			Object.keys(this.config.on).forEach((eventName) => {
-				const events = this.config.on[eventName];
-				let middlewareArray;
-				if (Array.isArray(events)) {
-					middlewareArray = events;
-				} else {
-					middlewareArray = [events];
-				}
-				middlewareArray.forEach((middleware) => {
-					this.on(eventName, middleware);
-				});
-			});
-		}
-
-		if (this.config.use) {
-			let pluginArray;
-			if (Array.isArray(this.config.use)) {
-				pluginArray = this.config.use;
-			} else {
-				pluginArray = [this.config.use];
-			}
-
-			pluginArray.forEach((plugin) => {
-				this.use(plugin);
-			});
-		}
 	}
 
 	public createTargeter(target: Target, onTarget: OnTarget, document?: Document): DomTargeter {
@@ -156,7 +122,7 @@ export abstract class AbstractController {
 
 	public async init(): Promise<void> {
 		if (this._initialized) {
-			return;
+			this.log.warn(`'init' middleware recalled`);
 		}
 		const initProfile = this.profiler.create({ type: 'event', name: 'init', context: this.config }).start();
 
@@ -179,23 +145,26 @@ export abstract class AbstractController {
 			}
 		}
 
-		// subscribe to urlManager changes
-		this.urlManager.subscribe((prev, next) => {
-			try {
-				const prevString = JSON.stringify(prev);
-				const nextString = JSON.stringify(next);
+		if (!this._initialized) {
+			// subscribe to urlManager changes
+			this.urlManager.subscribe((prev, next) => {
+				try {
+					const prevString = JSON.stringify(prev);
+					const nextString = JSON.stringify(next);
 
-				if (prevString !== nextString) {
-					this.search();
+					if (prevString !== nextString) {
+						this.search();
+					}
+				} catch (err) {
+					this.log.error('URL state is invalid', err);
 				}
-			} catch (err) {
-				this.log.error('URL state is invalid', err);
-			}
-		});
+			});
+
+			this._initialized = true;
+		}
 
 		initProfile.stop();
 		this.log.profile(initProfile);
-		this._initialized = true;
 	}
 
 	public retarget(): void {
@@ -206,11 +175,43 @@ export abstract class AbstractController {
 
 	public abstract search(): Promise<void>;
 
-	public async use(func: (cntrlr: AbstractController) => Promise<void>): Promise<void> {
+	public async plugin(func: (cntrlr: AbstractController) => Promise<void>): Promise<void> {
 		await func(this);
 	}
 
 	public on<T>(event: string, ...func: Middleware<T>[]): void {
 		this.eventManager.on(event, ...func);
+	}
+
+	public use(attachments: Attachments): void {
+		// TODO: ensure config middleware is proper type
+		// attach middleware
+		if (attachments?.plugin) {
+			let pluginArray;
+			if (Array.isArray(attachments.plugin)) {
+				pluginArray = attachments.plugin;
+			} else {
+				pluginArray = [attachments.plugin];
+			}
+
+			pluginArray.forEach((plugin) => {
+				this.plugin(plugin);
+			});
+		}
+
+		if (attachments?.on) {
+			Object.keys(attachments.on).forEach((eventName) => {
+				const eventMiddleware = attachments.on[eventName];
+				let middlewareArray;
+				if (Array.isArray(eventMiddleware)) {
+					middlewareArray = eventMiddleware;
+				} else {
+					middlewareArray = [eventMiddleware];
+				}
+				middlewareArray.forEach((middleware) => {
+					this.on(eventName, middleware);
+				});
+			});
+		}
 	}
 }

--- a/packages/snap-controller/src/Autocomplete/AutocompleteController.ts
+++ b/packages/snap-controller/src/Autocomplete/AutocompleteController.ts
@@ -1,12 +1,18 @@
 import deepmerge from 'deepmerge';
+
+import { StorageStore, StorageType } from '@searchspring/snap-store-mobx';
 import { AbstractController } from '../Abstract/AbstractController';
-import type { AutocompleteControllerConfig, BeforeSearchObj, AfterSearchObj, ControllerServices, NextEvent } from '../types';
 import { getSearchParams } from '../utils/getParams';
 import { URL as utilsURL } from '../utils/URL';
-import { StorageStore, StorageType } from '@searchspring/snap-store-mobx';
+
+import type { AutocompleteStore } from '@searchspring/snap-store-mobx';
+import type { AutocompleteControllerConfig, BeforeSearchObj, AfterSearchObj, ControllerServices, NextEvent } from '../types';
+import type { AutocompleteRequestModel } from '@searchspring/snapi-types';
 
 const TRENDING_TERMS_CACHE = 'ss-ac-trending-cache';
+
 const utils = { url: utilsURL };
+
 const defaultConfig: AutocompleteControllerConfig = {
 	id: 'autocomplete',
 	selector: '',
@@ -20,12 +26,15 @@ const defaultConfig: AutocompleteControllerConfig = {
 		},
 	},
 };
+
 type AutocompleteTrackMethods = {
 	product: {
 		click: (e, result) => void;
 	};
 };
+
 export class AutocompleteController extends AbstractController {
+	public store: AutocompleteStore;
 	config: AutocompleteControllerConfig;
 	storage: StorageStore;
 
@@ -64,6 +73,9 @@ export class AutocompleteController extends AbstractController {
 				return false;
 			}
 		});
+
+		// attach config plugins and event middleware
+		this.use(this.config);
 	}
 
 	track: AutocompleteTrackMethods = {
@@ -84,9 +96,9 @@ export class AutocompleteController extends AbstractController {
 		},
 	};
 
-	get params(): Record<string, any> {
+	get params(): AutocompleteRequestModel {
 		const urlState = this.urlManager.state;
-		const params: Record<string, any> = deepmerge({ ...getSearchParams(urlState) }, this.config.globals);
+		const params: AutocompleteRequestModel = deepmerge({ ...getSearchParams(urlState) }, this.config.globals);
 
 		return params;
 	}
@@ -178,15 +190,15 @@ export class AutocompleteController extends AbstractController {
 
 				let query = input.value;
 				if (!this.store.loading && this.store.search.originalQuery) {
-					query = this.store.search.query;
+					query = this.store.search.query.string;
 					actionUrl.params.query.push({
 						key: 'oq',
-						value: this.store.search.originalQuery,
+						value: this.store.search.originalQuery.string,
 					});
 				}
 
 				actionUrl.params.query.push({
-					key: input.name || this.urlManager.translator.config.queryParameter,
+					key: input.name || (this.urlManager.getTranslatorConfig().queryParameter as string),
 					value: query,
 				});
 
@@ -211,7 +223,7 @@ export class AutocompleteController extends AbstractController {
 			let query = input.value;
 			if (!this.store.loading && this.store.search.originalQuery) {
 				query = this.store.search.query;
-				addHiddenFormInput(form, 'oq', this.store.search.originalQuery);
+				addHiddenFormInput(form, 'oq', this.store.search.originalQuery.string);
 			}
 
 			// TODO expected spell correct behavior queryAssumption
@@ -287,12 +299,17 @@ export class AutocompleteController extends AbstractController {
 			terms = JSON.parse(storedTerms);
 		} else {
 			// query for trending terms, save to storage, update store
-			const trendingProfile = this.profiler.create({ type: 'event', name: 'trending' }).start();
-			terms = await this.client.trending({
+			const trendingParams = {
 				limit: this.config.settings?.trending?.limit || 5,
-			});
+			};
+
+			const trendingProfile = this.profiler.create({ type: 'event', name: 'trending', context: trendingParams }).start();
+
+			terms = await this.client.trending(trendingParams);
+
 			trendingProfile.stop();
 			this.log.profile(trendingProfile);
+
 			this.storage.set('terms', JSON.stringify(terms));
 		}
 		this.store.updateTrendingTerms(terms);

--- a/packages/snap-controller/src/Finder/FinderController.ts
+++ b/packages/snap-controller/src/Finder/FinderController.ts
@@ -1,9 +1,10 @@
 import deepmerge from 'deepmerge';
 
 import { AbstractController } from '../Abstract/AbstractController';
-
-import type { FinderControllerConfig, BeforeSearchObj, AfterSearchObj, ControllerServices, NextEvent } from '../types';
 import { getSearchParams } from '../utils/getParams';
+
+import type { FinderStore } from '@searchspring/snap-store-mobx';
+import type { FinderControllerConfig, BeforeSearchObj, AfterSearchObj, ControllerServices, NextEvent } from '../types';
 
 const defaultConfig: FinderControllerConfig = {
 	id: 'finder',
@@ -12,6 +13,7 @@ const defaultConfig: FinderControllerConfig = {
 };
 
 export class FinderController extends AbstractController {
+	public store: any;
 	config: FinderControllerConfig;
 
 	constructor(config: FinderControllerConfig, { client, store, urlManager, eventManager, profiler, logger, tracker }: ControllerServices) {
@@ -45,6 +47,9 @@ export class FinderController extends AbstractController {
 
 			search.controller.store.loading = false;
 		});
+
+		// attach config plugins and event middleware
+		this.use(this.config);
 	}
 
 	get params(): Record<string, any> {

--- a/packages/snap-controller/src/Recommendation/RecommendationController.ts
+++ b/packages/snap-controller/src/Recommendation/RecommendationController.ts
@@ -2,10 +2,11 @@ import deepmerge from 'deepmerge';
 
 import type { BeaconEvent } from '@searchspring/snap-tracker';
 import { BeaconType, BeaconCategory } from '@searchspring/snap-tracker';
-
-import { AbstractController } from '../Abstract/AbstractController';
-import type { RecommendationControllerConfig, BeforeSearchObj, AfterSearchObj, ControllerServices, NextEvent } from '../types';
 import { LogMode } from '@searchspring/snap-logger';
+import { AbstractController } from '../Abstract/AbstractController';
+
+import type { RecommendationStore } from '@searchspring/snap-store-mobx';
+import type { RecommendationControllerConfig, BeforeSearchObj, AfterSearchObj, ControllerServices, NextEvent } from '../types';
 
 type RecommendationTrackMethods = {
 	product: {
@@ -25,6 +26,7 @@ const defaultConfig: RecommendationControllerConfig = {
 };
 
 export class RecommendationController extends AbstractController {
+	public store: RecommendationStore;
 	config: RecommendationControllerConfig;
 	events = {
 		click: null,
@@ -56,6 +58,9 @@ export class RecommendationController extends AbstractController {
 
 			recommend.controller.store.loading = false;
 		});
+
+		// attach config plugins and event middleware
+		this.use(this.config);
 	}
 
 	track: RecommendationTrackMethods = {

--- a/packages/snap-controller/src/types.ts
+++ b/packages/snap-controller/src/types.ts
@@ -1,5 +1,5 @@
 import type { AbstractController } from './Abstract/AbstractController';
-import type { EventManager, Next } from '@searchspring/snap-event-manager';
+import type { EventManager, Middleware, Next } from '@searchspring/snap-event-manager';
 
 import type { Client } from '@searchspring/snap-client';
 import type { AbstractStore } from '@searchspring/snap-store-mobx';
@@ -8,22 +8,18 @@ import type { Profiler } from '@searchspring/snap-profiler';
 import type { UrlManager } from '@searchspring/snap-url-manager';
 import type { Logger } from '@searchspring/snap-logger';
 
+// Global
+declare global {
+	interface Window {
+		searchspring?: any;
+	}
+}
+
+// Middleware
+
 export type NextEvent = Next;
 
-/** Search */
-export type SearchControllerConfig = {
-	id: string;
-	globals?: any;
-	settings?: {
-		redirects?: {
-			merchandising?: boolean;
-			singleResult?: boolean;
-		};
-		facets?: {
-			trim?: boolean;
-		};
-	};
-};
+export type PluginFunction = (func: (cntrlr: AbstractController) => Promise<void>) => Promise<void>;
 
 export type BeforeSearchObj = {
 	controller: AbstractController;
@@ -39,47 +35,11 @@ export type AfterStoreObj = {
 	controller: AbstractController;
 };
 
-/** Finder */
-export type FinderControllerConfig = {
+// Abstract
+export interface ControllerConfig {
 	id: string;
-	url?: string;
-	globals?: any;
-	fields: FinderFieldConfig[];
-};
+}
 
-export type FinderFieldConfig = {
-	field: string;
-	label?: string;
-	levels?: string[];
-};
-
-/** Autocomplete */
-export type AutocompleteControllerConfig = {
-	id: string;
-	selector: string;
-	action?: string;
-	globals?: any;
-	settings: {
-		initializeFromUrl: boolean;
-		syncInputs: boolean;
-		facets?: {
-			trim?: boolean;
-		};
-		trending?: {
-			limit: number;
-		};
-	};
-};
-
-/** Recommend */
-export type RecommendationControllerConfig = {
-	id: string;
-	tag: string;
-	branch?: string;
-	globals?: any;
-};
-
-/** Abstract */
 export type ControllerServices = {
 	client: Client;
 	store: AbstractStore;
@@ -90,8 +50,65 @@ export type ControllerServices = {
 	tracker: Tracker;
 };
 
-declare global {
-	interface Window {
-		searchspring?: any;
-	}
-}
+export type Attachments = {
+	on?: {
+		[eventName: string]: Middleware<unknown> | Middleware<unknown>[];
+	};
+	plugin?: PluginFunction | PluginFunction[];
+	[any: string]: unknown;
+};
+
+// Search Config
+export type SearchControllerConfig = ControllerConfig &
+	Attachments & {
+		globals?: any;
+		settings?: {
+			redirects?: {
+				merchandising?: boolean;
+				singleResult?: boolean;
+			};
+			facets?: {
+				trim?: boolean;
+			};
+		};
+	};
+
+// Finder Config
+export type FinderControllerConfig = ControllerConfig &
+	Attachments & {
+		globals?: any;
+		url?: string;
+		fields: FinderFieldConfig[];
+	};
+
+export type FinderFieldConfig = {
+	field: string;
+	label?: string;
+	levels?: string[];
+};
+
+// Autocomplete config
+export type AutocompleteControllerConfig = ControllerConfig &
+	Attachments & {
+		globals?: any;
+		selector: string;
+		action?: string;
+		settings: {
+			initializeFromUrl: boolean;
+			syncInputs: boolean;
+			facets?: {
+				trim?: boolean;
+			};
+			trending?: {
+				limit: number;
+			};
+		};
+	};
+
+// Recommendation config
+export type RecommendationControllerConfig = ControllerConfig &
+	Attachments & {
+		globals?: any;
+		tag: string;
+		branch?: string;
+	};

--- a/packages/snap-preact-components/src/types.ts
+++ b/packages/snap-preact-components/src/types.ts
@@ -36,7 +36,7 @@ export type InlineBannerContent = {
 	};
 };
 
-export type BannerContent = Record<BannerType, any[]>;
+export type BannerContent = Partial<Record<BannerType, any[]>>;
 export interface Mappings {
 	core: {
 		uid: string;

--- a/packages/snap-preact-demo/src/index.js
+++ b/packages/snap-preact-demo/src/index.js
@@ -11,7 +11,6 @@ import { Sidebar } from './components/Sidebar/Sidebar';
 import { Recs } from './components/Recommendations/';
 
 import { afterStore } from './middleware/plugins/afterStore';
-import { scrollToTop, timeout, ensure, until } from './middleware/functions';
 
 import './styles/custom.scss';
 
@@ -27,8 +26,10 @@ const config = {
 	},
 	instantiators: {
 		recommendation: {
-			branch: BRANCHNAME,
 			components: { Recs, Recs2: Recs },
+			config: {
+				branch: BRANCHNAME,
+			},
 		},
 	},
 	controllers: {
@@ -82,30 +83,5 @@ const config = {
 const snap = new Snap(config);
 const { search, autocomplete } = snap.controllers;
 
-// custom store manipulation
-search.on('afterStore', async ({ controller }, next) => {
-	controller.store.custom.onSaleFacet = controller?.store?.facets.filter((facet) => facet.field == 'on_sale').pop();
-
-	// filtering out certain facets...
-	controller.store.facets = controller?.store?.facets?.filter((facet) => facet.field != 'on_sale');
-
-	const colorFacet = controller?.store?.facets.filter((facet) => facet.field == 'color_family').pop();
-	colorFacet?.values.forEach((value) => {
-		value.custom = {
-			colorImage: `www.storfront.com/images/swatches/${value.value}.png`,
-		};
-	});
-
-	// adding domain to URLs
-	controller.store.results.forEach((result) => {
-		result.mappings.core.url = 'http://try.searchspring.com' + result.mappings.core.url;
-	});
-
-	await next();
-});
-
 // using plugins (groups of middleware)
-search.use(afterStore);
-
-// using a function
-search.on('afterStore', scrollToTop);
+search.plugin(afterStore);

--- a/packages/snap-preact-demo/src/middleware/functions.js
+++ b/packages/snap-preact-demo/src/middleware/functions.js
@@ -1,8 +1,3 @@
-export async function scrollToTop(search, next) {
-	window.scroll({ top: 0, left: 0, behavior: 'smooth' });
-	await next();
-}
-
 export async function timeout(microSeconds) {
 	console.log(`...waiting ${microSeconds} μsecs...`);
 

--- a/packages/snap-preact-demo/src/middleware/plugins/afterStore.js
+++ b/packages/snap-preact-demo/src/middleware/plugins/afterStore.js
@@ -1,4 +1,8 @@
 export function afterStore(controller) {
+	controller.on('init', async ({ controller }, next) => {
+		controller.log.debug('initialization...');
+		await next();
+	});
 	controller.on('afterStore', async ({ controller: { store } }, next) => {
 		mutateFacets(store.facets);
 		mutateResults(store.results);
@@ -11,6 +15,8 @@ export function afterStore(controller) {
 		controller.log.debug('store', controller.store.toJSON());
 		await next();
 	});
+
+	controller.on('afterStore', scrollToTop);
 }
 
 function mutateFacets(facets) {
@@ -28,4 +34,9 @@ function mutateResults(results) {
 	for (let result of results) {
 		result.mappings.core.name += '++';
 	}
+}
+
+export async function scrollToTop(search, next) {
+	window.scroll({ top: 0, left: 0, behavior: 'smooth' });
+	await next();
 }

--- a/packages/snap-store-mobx/src/Recommendation/Stores/ProfileStore.ts
+++ b/packages/snap-store-mobx/src/Recommendation/Stores/ProfileStore.ts
@@ -3,7 +3,7 @@ import { observable, makeObservable } from 'mobx';
 export class ProfileStore {
 	tag: string;
 	placement: string;
-	display = {};
+	display: Record<string, any> = {};
 
 	constructor(services, profile) {
 		if (!profile?.tag) {

--- a/packages/snap-store-mobx/src/Search/Stores/MerchandisingStore.ts
+++ b/packages/snap-store-mobx/src/Search/Stores/MerchandisingStore.ts
@@ -9,9 +9,7 @@ enum ContentType {
 }
 export class MerchandisingStore {
 	redirect = '';
-	content: {
-		[ContentType.HEADER]?: Content;
-	} = {};
+	content: Partial<Record<ContentType, Content[]>> = {};
 
 	constructor(services, merchData) {
 		if (merchData) {


### PR DESCRIPTION
Changed 'use' to 'plugin' and made 'use' a new method on `AbstractController`.

There are now three ways to attach middleware:
1. using the controller config (attached via new `use` method)
2. controller calling `on` method
3. controller calling `plugin` method

Altered the 'init' method on `AbstractController` to allow recalling of it (with a warning).

Altered the `RecommendationInstantiator` to support new middleware attachment methods.

Additionally this PR includes include some typing improvements (had to back pedal a few due to serious typing issues).