### PR TITLE
Fix AC Multiple Inputs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40112,7 +40112,8 @@
 			}
 		},
 		"packages/snap-client": {
-			"version": "0.3.19",
+			"name": "@searchspring/snap-client",
+			"version": "0.3.20",
 			"license": "MIT",
 			"dependencies": {
 				"he": "^1.2.0",
@@ -40123,54 +40124,59 @@
 			}
 		},
 		"packages/snap-controller": {
-			"version": "0.3.19",
+			"name": "@searchspring/snap-controller",
+			"version": "0.3.20",
 			"license": "MIT",
 			"dependencies": {
 				"deepmerge": "^4.2.2"
 			},
 			"devDependencies": {
-				"@searchspring/snap-client": "^0.3.19",
-				"@searchspring/snap-event-manager": "^0.3.19",
-				"@searchspring/snap-logger": "^0.3.19",
-				"@searchspring/snap-profiler": "^0.3.19",
-				"@searchspring/snap-store-mobx": "^0.3.19",
-				"@searchspring/snap-tracker": "^0.3.19",
-				"@searchspring/snap-url-manager": "^0.3.19"
+				"@searchspring/snap-client": "^0.3.20",
+				"@searchspring/snap-event-manager": "^0.3.20",
+				"@searchspring/snap-logger": "^0.3.20",
+				"@searchspring/snap-profiler": "^0.3.20",
+				"@searchspring/snap-store-mobx": "^0.3.20",
+				"@searchspring/snap-tracker": "^0.3.20",
+				"@searchspring/snap-url-manager": "^0.3.20"
 			}
 		},
 		"packages/snap-event-manager": {
-			"version": "0.3.19",
+			"name": "@searchspring/snap-event-manager",
+			"version": "0.3.20",
 			"license": "MIT"
 		},
 		"packages/snap-logger": {
-			"version": "0.3.19",
+			"name": "@searchspring/snap-logger",
+			"version": "0.3.20",
 			"license": "MIT"
 		},
 		"packages/snap-preact": {
-			"version": "0.3.19",
+			"name": "@searchspring/snap-preact",
+			"version": "0.3.20",
 			"license": "MIT",
 			"dependencies": {
-				"@searchspring/snap-client": "^0.3.19",
-				"@searchspring/snap-controller": "^0.3.19",
-				"@searchspring/snap-event-manager": "^0.3.19",
-				"@searchspring/snap-logger": "^0.3.19",
-				"@searchspring/snap-profiler": "^0.3.19",
-				"@searchspring/snap-store-mobx": "^0.3.19",
-				"@searchspring/snap-toolbox": "^0.3.19",
-				"@searchspring/snap-tracker": "^0.3.19",
-				"@searchspring/snap-url-manager": "^0.3.19"
+				"@searchspring/snap-client": "^0.3.20",
+				"@searchspring/snap-controller": "^0.3.20",
+				"@searchspring/snap-event-manager": "^0.3.20",
+				"@searchspring/snap-logger": "^0.3.20",
+				"@searchspring/snap-profiler": "^0.3.20",
+				"@searchspring/snap-store-mobx": "^0.3.20",
+				"@searchspring/snap-toolbox": "^0.3.20",
+				"@searchspring/snap-tracker": "^0.3.20",
+				"@searchspring/snap-url-manager": "^0.3.20"
 			},
 			"devDependencies": {
 				"@types/react": "^17.0.14"
 			}
 		},
 		"packages/snap-preact-components": {
-			"version": "0.3.19",
+			"name": "@searchspring/snap-preact-components",
+			"version": "0.3.20",
 			"license": "MIT",
 			"dependencies": {
 				"@emotion/react": "^11.4.0",
-				"@searchspring/snap-preact": "^0.3.19",
-				"@searchspring/snap-toolbox": "^0.3.19",
+				"@searchspring/snap-preact": "^0.3.20",
+				"@searchspring/snap-toolbox": "^0.3.20",
 				"classnames": "^2.3.1",
 				"mobx-react-lite": "^3.2.0",
 				"react-ranger": "^2.1.0",
@@ -40178,14 +40184,14 @@
 			},
 			"devDependencies": {
 				"@mdx-js/loader": "^1.6.22",
-				"@searchspring/snap-client": "^0.3.19",
-				"@searchspring/snap-controller": "^0.3.19",
-				"@searchspring/snap-event-manager": "^0.3.19",
-				"@searchspring/snap-logger": "^0.3.19",
-				"@searchspring/snap-profiler": "^0.3.19",
-				"@searchspring/snap-store-mobx": "^0.3.19",
+				"@searchspring/snap-client": "^0.3.20",
+				"@searchspring/snap-controller": "^0.3.20",
+				"@searchspring/snap-event-manager": "^0.3.20",
+				"@searchspring/snap-logger": "^0.3.20",
+				"@searchspring/snap-profiler": "^0.3.20",
+				"@searchspring/snap-store-mobx": "^0.3.20",
 				"@searchspring/snap-toolbox": "^0.3.11",
-				"@searchspring/snap-url-manager": "^0.3.19",
+				"@searchspring/snap-url-manager": "^0.3.20",
 				"@storybook/addon-actions": "^6.3.5",
 				"@storybook/addon-controls": "^6.3.5",
 				"@storybook/addon-docs": "^6.3.5",
@@ -40622,11 +40628,12 @@
 			}
 		},
 		"packages/snap-preact-demo": {
-			"version": "0.3.19",
+			"name": "@searchspring/snap-preact-demo",
+			"version": "0.3.20",
 			"license": "MIT",
 			"dependencies": {
-				"@searchspring/snap-preact": "^0.3.19",
-				"@searchspring/snap-preact-components": "^0.3.19",
+				"@searchspring/snap-preact": "^0.3.20",
+				"@searchspring/snap-preact-components": "^0.3.20",
 				"mobx": "^6.3.2",
 				"mobx-react": "^7.2.0",
 				"preact": "^10.5.14"
@@ -40658,30 +40665,34 @@
 			}
 		},
 		"packages/snap-profiler": {
-			"version": "0.3.19",
+			"name": "@searchspring/snap-profiler",
+			"version": "0.3.20",
 			"license": "MIT"
 		},
 		"packages/snap-store-mobx": {
-			"version": "0.3.19",
+			"name": "@searchspring/snap-store-mobx",
+			"version": "0.3.20",
 			"license": "MIT",
 			"dependencies": {
-				"@searchspring/snap-toolbox": "^0.3.19",
+				"@searchspring/snap-toolbox": "^0.3.20",
 				"mobx": "^6.3.2"
 			},
 			"devDependencies": {
-				"@searchspring/snap-url-manager": "^0.3.19"
+				"@searchspring/snap-url-manager": "^0.3.20"
 			}
 		},
 		"packages/snap-toolbox": {
-			"version": "0.3.19",
+			"name": "@searchspring/snap-toolbox",
+			"version": "0.3.20",
 			"license": "MIT"
 		},
 		"packages/snap-tracker": {
-			"version": "0.3.19",
+			"name": "@searchspring/snap-tracker",
+			"version": "0.3.20",
 			"license": "MIT",
 			"dependencies": {
-				"@searchspring/snap-store-mobx": "^0.3.19",
-				"@searchspring/snap-toolbox": "^0.3.19",
+				"@searchspring/snap-store-mobx": "^0.3.20",
+				"@searchspring/snap-toolbox": "^0.3.20",
 				"deepmerge": "^4.2.2",
 				"uuid": "^8.3.2"
 			}
@@ -40695,7 +40706,8 @@
 			}
 		},
 		"packages/snap-url-manager": {
-			"version": "0.3.19",
+			"name": "@searchspring/snap-url-manager",
+			"version": "0.3.20",
 			"license": "MIT",
 			"dependencies": {
 				"seamless-immutable": "^7.1.4"
@@ -45124,13 +45136,13 @@
 		"@searchspring/snap-controller": {
 			"version": "file:packages/snap-controller",
 			"requires": {
-				"@searchspring/snap-client": "^0.3.19",
-				"@searchspring/snap-event-manager": "^0.3.19",
-				"@searchspring/snap-logger": "^0.3.19",
-				"@searchspring/snap-profiler": "^0.3.19",
-				"@searchspring/snap-store-mobx": "^0.3.19",
-				"@searchspring/snap-tracker": "^0.3.19",
-				"@searchspring/snap-url-manager": "^0.3.19",
+				"@searchspring/snap-client": "^0.3.20",
+				"@searchspring/snap-event-manager": "^0.3.20",
+				"@searchspring/snap-logger": "^0.3.20",
+				"@searchspring/snap-profiler": "^0.3.20",
+				"@searchspring/snap-store-mobx": "^0.3.20",
+				"@searchspring/snap-tracker": "^0.3.20",
+				"@searchspring/snap-url-manager": "^0.3.20",
 				"deepmerge": "^4.2.2"
 			}
 		},
@@ -45143,15 +45155,15 @@
 		"@searchspring/snap-preact": {
 			"version": "file:packages/snap-preact",
 			"requires": {
-				"@searchspring/snap-client": "^0.3.19",
-				"@searchspring/snap-controller": "^0.3.19",
-				"@searchspring/snap-event-manager": "^0.3.19",
-				"@searchspring/snap-logger": "^0.3.19",
-				"@searchspring/snap-profiler": "^0.3.19",
-				"@searchspring/snap-store-mobx": "^0.3.19",
-				"@searchspring/snap-toolbox": "^0.3.19",
-				"@searchspring/snap-tracker": "^0.3.19",
-				"@searchspring/snap-url-manager": "^0.3.19",
+				"@searchspring/snap-client": "^0.3.20",
+				"@searchspring/snap-controller": "^0.3.20",
+				"@searchspring/snap-event-manager": "^0.3.20",
+				"@searchspring/snap-logger": "^0.3.20",
+				"@searchspring/snap-profiler": "^0.3.20",
+				"@searchspring/snap-store-mobx": "^0.3.20",
+				"@searchspring/snap-toolbox": "^0.3.20",
+				"@searchspring/snap-tracker": "^0.3.20",
+				"@searchspring/snap-url-manager": "^0.3.20",
 				"@types/react": "^17.0.14"
 			}
 		},
@@ -45160,15 +45172,15 @@
 			"requires": {
 				"@emotion/react": "^11.4.0",
 				"@mdx-js/loader": "^1.6.22",
-				"@searchspring/snap-client": "^0.3.19",
-				"@searchspring/snap-controller": "^0.3.19",
-				"@searchspring/snap-event-manager": "^0.3.19",
-				"@searchspring/snap-logger": "^0.3.19",
-				"@searchspring/snap-preact": "^0.3.19",
-				"@searchspring/snap-profiler": "^0.3.19",
-				"@searchspring/snap-store-mobx": "^0.3.19",
-				"@searchspring/snap-toolbox": "^0.3.19",
-				"@searchspring/snap-url-manager": "^0.3.19",
+				"@searchspring/snap-client": "^0.3.20",
+				"@searchspring/snap-controller": "^0.3.20",
+				"@searchspring/snap-event-manager": "^0.3.20",
+				"@searchspring/snap-logger": "^0.3.20",
+				"@searchspring/snap-preact": "^0.3.20",
+				"@searchspring/snap-profiler": "^0.3.20",
+				"@searchspring/snap-store-mobx": "^0.3.20",
+				"@searchspring/snap-toolbox": "^0.3.20",
+				"@searchspring/snap-url-manager": "^0.3.20",
 				"@storybook/addon-actions": "^6.3.5",
 				"@storybook/addon-controls": "^6.3.5",
 				"@storybook/addon-docs": "^6.3.5",
@@ -45488,8 +45500,8 @@
 				"@babel/preset-react": "^7.14.5",
 				"@babel/runtime": "^7.14.8",
 				"@prefresh/webpack": "^3.3.2",
-				"@searchspring/snap-preact": "^0.3.19",
-				"@searchspring/snap-preact-components": "^0.3.19",
+				"@searchspring/snap-preact": "^0.3.20",
+				"@searchspring/snap-preact-components": "^0.3.20",
 				"babel-loader": "^8.2.2",
 				"core-js": "^3.15.2",
 				"css-loader": "^6.2.0",
@@ -45515,8 +45527,8 @@
 		"@searchspring/snap-store-mobx": {
 			"version": "file:packages/snap-store-mobx",
 			"requires": {
-				"@searchspring/snap-toolbox": "^0.3.19",
-				"@searchspring/snap-url-manager": "^0.3.19",
+				"@searchspring/snap-toolbox": "^0.3.20",
+				"@searchspring/snap-url-manager": "^0.3.20",
 				"mobx": "^6.3.2"
 			}
 		},
@@ -45526,8 +45538,8 @@
 		"@searchspring/snap-tracker": {
 			"version": "file:packages/snap-tracker",
 			"requires": {
-				"@searchspring/snap-store-mobx": "^0.3.19",
-				"@searchspring/snap-toolbox": "^0.3.19",
+				"@searchspring/snap-store-mobx": "^0.3.20",
+				"@searchspring/snap-toolbox": "^0.3.20",
 				"deepmerge": "^4.2.2",
 				"uuid": "^8.3.2"
 			},

--- a/packages/snap-controller/src/Autocomplete/AutocompleteController.ts
+++ b/packages/snap-controller/src/Autocomplete/AutocompleteController.ts
@@ -20,7 +20,7 @@ const defaultConfig: AutocompleteControllerConfig = {
 	globals: {},
 	settings: {
 		initializeFromUrl: true,
-		syncInputs: false,
+		syncInputs: true,
 		facets: {
 			trim: true,
 		},

--- a/packages/snap-preact/src/Snap.tsx
+++ b/packages/snap-preact/src/Snap.tsx
@@ -188,7 +188,7 @@ export class Snap {
 										cntrlr.bind();
 
 										const Component = target.component as React.ElementType<{ controller: any; input: any }>;
-										render(<Component controller={cntrlr} input={controller?.config?.selector} {...target.props} />, elem);
+										render(<Component controller={cntrlr} input={originalElem} {...target.props} />, elem);
 									}
 								);
 							});


### PR DESCRIPTION
Change default Autocomplete setting to sync inputs. Alter snap-preact to use the `originalElement` as the `input` prop for the component. This is needed when targeting multiple input elements. If this needs to be changed the `onTarget` overload could be used to modify the variable.