### PR TITLE
Bug fix: range filters

### DIFF
--- a/packages/snap-client/src/Client/transforms/searchResponse.test.ts
+++ b/packages/snap-client/src/Client/transforms/searchResponse.test.ts
@@ -488,8 +488,8 @@ describe('search response filterSummary transformer', () => {
 
 			if (typeof mockFilter.value == 'object') {
 				expect(filter.type).toBe('range');
-				expect(filter.value.low).toBe(mockFilter.value.rangeLow);
-				expect(filter.value.high).toBe(mockFilter.value.rangeHigh);
+				expect(filter.value.low).toBe(Number(mockFilter.value.rangeLow));
+				expect(filter.value.high).toBe(Number(mockFilter.value.rangeHigh));
 			} else {
 				expect(filter.value).toBe(mockFilter.value);
 				expect(filter.type).toBe('value');

--- a/packages/snap-client/src/Client/transforms/searchResponse.ts
+++ b/packages/snap-client/src/Client/transforms/searchResponse.ts
@@ -91,8 +91,8 @@ transformSearchResponse.filters = (response) => {
 			if (typeof filter.value == 'object') {
 				(type = 'range'),
 					(value = {
-						low: filter.value.rangeLow,
-						high: filter.value.rangeHigh,
+						low: +filter.value.rangeLow,
+						high: +filter.value.rangeHigh,
 					});
 			}
 


### PR DESCRIPTION
API transformation was slightly off for range filters - corrected so that the low/high values are numbers as is expected by the UrlManager.