### PR TITLE
Id support For getScriptContext 

### DIFF
--- a/packages/snap-toolbox/src/getScriptContext/getScriptContext.test.ts
+++ b/packages/snap-toolbox/src/getScriptContext/getScriptContext.test.ts
@@ -33,12 +33,33 @@ describe('getScriptContext', () => {
 		}).not.toThrow();
 	});
 
-	it('expects the script to have "searchspring" prefix in the type attribute', () => {
+	it('expects the script to have "searchspring" prefix in the id or type attribute', () => {
 		expect(() => {
 			const scriptTag = document.createElement('script');
 
 			getScriptContext(scriptTag);
 		}).toThrow();
+
+		expect(() => {
+			const scriptTag = document.createElement('script');
+			scriptTag.id = 'search';
+
+			getScriptContext(scriptTag);
+		}).toThrow();
+
+		expect(() => {
+			const scriptTag = document.createElement('script');
+			scriptTag.id = 'searchspring';
+
+			getScriptContext(scriptTag);
+		}).not.toThrow();
+
+		expect(() => {
+			const scriptTag = document.createElement('script');
+			scriptTag.id = 'searchspring-context';
+
+			getScriptContext(scriptTag);
+		}).not.toThrow();
 
 		expect(() => {
 			const scriptTag = document.createElement('script');
@@ -64,12 +85,12 @@ describe('getScriptContext', () => {
 
 	it('returns an object of variables containing all attributes', () => {
 		const scriptTag = document.createElement('script');
-		scriptTag.setAttribute('type', 'searchspring/recommend');
+		scriptTag.id = 'searchspring-context';
 		scriptTag.setAttribute('profile', 'trending');
 
 		const vars = getScriptContext(scriptTag);
 
-		expect(vars).toHaveProperty('type', 'searchspring/recommend');
+		expect(vars).toHaveProperty('id', 'searchspring-context');
 		expect(vars).toHaveProperty('profile', 'trending');
 	});
 

--- a/packages/snap-toolbox/src/getScriptContext/getScriptContext.ts
+++ b/packages/snap-toolbox/src/getScriptContext/getScriptContext.ts
@@ -8,12 +8,12 @@ export function getScriptContext(script: Element, evaluate?: string[]): ContextV
 	}
 
 	// check script type
-	if (!script.getAttribute('type').match(/^searchspring/)) {
-		throw new Error('script type attribute must start with "searchspring"');
+	if (!script.getAttribute('type')?.match(/^searchspring/) && !script.id?.match(/^searchspring/)) {
+		throw new Error('script type or id attribute must start with "searchspring"');
 	}
 
 	if ((evaluate && !Array.isArray(evaluate)) || (evaluate && !evaluate.reduce((accu, name) => accu && typeof name === 'string', true))) {
-		throw new Error('scriptContext second parameter must be an array of strings');
+		throw new Error('getScriptContext second parameter must be an array of strings');
 	}
 
 	const variables = {};


### PR DESCRIPTION
Adding ability to grab context out of a script tag with searchspring id - to potentially be used for integration.