### PR TITLE
UrlTranslator Alterations

### DIFF
--- a/docs/PREACT_CONFIG.md
+++ b/docs/PREACT_CONFIG.md
@@ -4,9 +4,11 @@ Lets define our config. The config that is provided to Snap will create and retu
 
 ```typescript
 const config = {
-	parameters: {
-		core: {
-			query: { name: 'query' }
+	url: {
+		parameters: {
+			core: {
+				query: { name: 'query' }
+			}
 		}
 	},
 	client: {
@@ -60,7 +62,7 @@ const config = {
 
 Lets go over a few things.
 
-`config.parameters` is optional and contains a `UrlTranslator` parameter config object that is passed to the core [@searchspring/snap-url-manager](https://github.com/searchspring/snap/tree/main/packages/snap-url-manager) package used by all controllers. This parameter configuration will be applied to all controllers created via Snap, but can be specified per controller as needed.
+`config.url` is optional and contains a [`UrlTranslator` config](https://github.com/searchspring/snap/tree/main/packages/snap-url-manager/src/Translators/Url) object that is passed to the core [@searchspring/snap-url-manager](https://github.com/searchspring/snap/tree/main/packages/snap-url-manager) package used by all controllers. This parameter configuration will be applied to all controllers created via Snap, but can be specified per controller for specific customization.
 
 `config.client` is required and contains a config object that is passed to the core [@searchspring/snap-client](https://github.com/searchspring/snap/tree/main/packages/snap-client) package. This service handles the network requests to our APIs to retrieve data to be displayed.
 

--- a/index.html
+++ b/index.html
@@ -44,6 +44,7 @@
 				{ a: "(https://github.com/searchspring/snap/tree/main/packages/snap-client)", b: "(#/package-client)"},
 				{ a: "(https://github.com/searchspring/snap/tree/main/packages/snap-store-mobx)", b: "(#/package-storeMobx)"},
 				{ a: "(https://github.com/searchspring/snap/tree/main/packages/snap-url-manager)", b: "(#/package-urlManager)"},
+				{ a: "(https://github.com/searchspring/snap/tree/main/packages/snap-url-manager/src/Translators/Url)", b: "(#/package-urlManager-translators-url)"},
 				{ a: "(https://github.com/searchspring/snap/tree/main/packages/snap-event-manager)", b: "(#/package-eventManager)"},
 				{ a: "(https://github.com/searchspring/snap/tree/main/packages/snap-profiler)", b: "(#/package-profiler)"},
 				{ a: "(https://github.com/searchspring/snap/tree/main/packages/snap-logger)", b: "(#/package-logger)"},

--- a/packages/snap-preact-demo/src/index.js
+++ b/packages/snap-preact-demo/src/index.js
@@ -21,9 +21,16 @@ import './styles/custom.scss';
  */
 
 const config = {
-	parameters: {
-		core: {
-			query: { name: 'q' },
+	url: {
+		settings: {
+			coreType: 'query',
+			customType: 'query',
+		},
+		parameters: {
+			core: {
+				query: { name: 'q' },
+				page: { name: 'p' },
+			},
 		},
 	},
 	client: {

--- a/packages/snap-preact/README.md
+++ b/packages/snap-preact/README.md
@@ -28,6 +28,13 @@ Full example:
 
 ```typescript
 const config = {
+	url: {
+		parameters: {
+			core: {
+				query: { name: 'search' },
+			},
+		},
+	},
 	client: {
 		globals: {
 			siteId: 'xxxxxx',
@@ -142,16 +149,19 @@ module.exports = {
 
 
 
-### config.parameters
-The `parameters` object contains the config provided to each UrlTranslator
+### config.url
+The `url` object contains the config provided to each [`UrlTranslator`](https://github.com/searchspring/snap/tree/main/packages/snap-url-manager/src/Translators/Url) created by Snap Preact.
 
 ```typescript
 const config = {
-    parameters: {
-        search: {
-            name: 'q'
-        }
-    }
+	url: {
+		parameters: {
+			core: {
+				query: { name: 'search' },
+				page: { name: 'p' }
+			},
+		},
+	},
 }
 ```
 
@@ -195,7 +205,9 @@ const target = {
 }
 ```
 
-`services` - optional object of `ControllerServices` to be used for this controller
+`services` - optional object of `ControllerServices` to be used for this controller in place of the default services
+
+`url` - optional `UrlTranslator` config object to be used with the `UrlManager` for this controller
 
 
 An example creating a SearchController:

--- a/packages/snap-preact/src/Snap.tsx
+++ b/packages/snap-preact/src/Snap.tsx
@@ -25,7 +25,7 @@ import type {
 } from '@searchspring/snap-controller';
 import type { ClientConfig, ClientGlobals } from '@searchspring/snap-client';
 import type { Target, OnTarget } from '@searchspring/snap-toolbox';
-import type { UrlTranslatorParametersConfig } from '@searchspring/snap-url-manager';
+import type { UrlTranslatorConfig } from '@searchspring/snap-url-manager';
 
 import { RecommendationInstantiator, RecommendationInstantiatorConfig } from './Instantiators/RecommendationInstantiator';
 import type { SnapControllerServices } from './types';
@@ -39,7 +39,7 @@ type ExtendedTarget = Target & {
 };
 
 export type SnapConfig = {
-	parameters?: UrlTranslatorParametersConfig;
+	url?: UrlTranslatorConfig;
 	client: {
 		globals: ClientGlobals;
 		config?: ClientConfig;
@@ -52,25 +52,25 @@ export type SnapConfig = {
 			config: SearchControllerConfig;
 			targets?: ExtendedTarget[];
 			services?: SnapControllerServices;
-			parameters?: UrlTranslatorParametersConfig;
+			url?: UrlTranslatorConfig;
 		}[];
 		autocomplete?: {
 			config: AutocompleteControllerConfig;
 			targets: ExtendedTarget[];
 			services?: SnapControllerServices;
-			parameters?: UrlTranslatorParametersConfig;
+			url?: UrlTranslatorConfig;
 		}[];
 		finder?: {
 			config: FinderControllerConfig;
 			targets?: ExtendedTarget[];
 			services?: SnapControllerServices;
-			parameters?: UrlTranslatorParametersConfig;
+			url?: UrlTranslatorConfig;
 		}[];
 		recommendation?: {
 			config: RecommendationControllerConfig;
 			targets?: ExtendedTarget[];
 			services?: SnapControllerServices;
-			parameters?: UrlTranslatorParametersConfig;
+			url?: UrlTranslatorConfig;
 		}[];
 	};
 };
@@ -112,7 +112,7 @@ export class Snap {
 				case 'search': {
 					this.config.controllers[type].forEach((controller, index) => {
 						try {
-							const cntrlr = this.createController(type, controller.config, controller.services, controller.parameters) as SearchController;
+							const cntrlr = this.createController(type, controller.config, controller.services, controller.url) as SearchController;
 
 							let searched = false;
 							const runSearch = () => {
@@ -159,7 +159,7 @@ export class Snap {
 				case 'autocomplete': {
 					this.config.controllers[type].forEach((controller, index) => {
 						try {
-							const cntrlr = this.createController(type, controller.config, controller.services, controller.parameters) as AutocompleteController;
+							const cntrlr = this.createController(type, controller.config, controller.services, controller.url) as AutocompleteController;
 
 							controller?.targets?.forEach((target, target_index) => {
 								if (!target.component) {
@@ -206,7 +206,7 @@ export class Snap {
 				case 'finder': {
 					this.config.controllers[type].forEach((controller, index) => {
 						try {
-							const cntrlr = this.createController(type, controller.config, controller.services, controller.parameters) as FinderController;
+							const cntrlr = this.createController(type, controller.config, controller.services, controller.url) as FinderController;
 
 							let searched = false;
 							const runSearch = () => {
@@ -252,7 +252,7 @@ export class Snap {
 				case 'recommendation': {
 					this.config.controllers[type].forEach((controller, index) => {
 						try {
-							const cntrlr = this.createController(type, controller.config, controller.services, controller.parameters) as RecommendationController;
+							const cntrlr = this.createController(type, controller.config, controller.services, controller.url) as RecommendationController;
 
 							let searched = false;
 							const runSearch = () => {
@@ -310,16 +310,8 @@ export class Snap {
 		}
 	}
 
-	public createController(
-		type: string,
-		config: ControllerConfigs,
-		services?: SnapControllerServices,
-		parametersConfig: UrlTranslatorParametersConfig = {}
-	): AbstractController {
-		const translatorParametersConfig = deepmerge(this.config.parameters || {}, parametersConfig);
-		const translatorConfig = {
-			parameters: translatorParametersConfig,
-		};
+	public createController(type: string, config: ControllerConfigs, services?: SnapControllerServices, url?: UrlTranslatorConfig): AbstractController {
+		const translatorConfig = deepmerge(this.config.url || {}, url || {});
 
 		switch (type) {
 			case 'search': {

--- a/packages/snap-url-manager/src/Translators/Url/README.md
+++ b/packages/snap-url-manager/src/Translators/Url/README.md
@@ -60,39 +60,15 @@ The `serialize` and `deserialize` methods are abstracted away by the `UrlManager
 | option | description | default value |
 |---|---|:---:|
 | urlRoot | used to redirect to other URLs | ➖ |
-| parameters.settings.type | quickly change the type of all core parameters | ➖ |
-| parameters.settings.implicit | specify how custom parameters should be serialized | 'hash' |
-| parameters.settings.prefix | specify a prefix to all core parameters | ➖ |
+| settings.corePrefix | specify a prefix to all core parameters | ➖ |
+| settings.coreType | quickly change the type of all core parameters | ➖ |
+| settings.customType | specify how custom parameters should be serialized | 'hash' |
+| settings.rootParams | enables addition of urlRoot parameters | true |
 | parameters.core | optional mapping of core param names and types  | ➖ |
 | parameters.custom | optional mapping of custom param types | ➖ |
 
 <br>
 
-### Implicit Type Configuration
-
-The `UrlTranslator` will automatically determine how to handle parameters found in the URL when it is initialized. However for parameters that do not yet exist, the default behavior is to treat them as hash fragments. This can be customized using the `parameters.settings.implicit` configuration. In the example below, the 'view' custom parameter is set as a `query` type and the 'store' custom parameter is implicitly set to a `hash` type (default setting).
-
-```js
-import { UrlManager, UrlTranslator } from '@searchspring/snap-url-manager';
-
-const urlManager = new UrlManager(
-	new UrlTranslator({
-		urlRoot: '/search',
-		parameters: {
-			custom: {
-				view: { type: 'query' },
-			},
-		},
-	})
-);
-
-const setUrlManager = urlManager.set({ store: 'products', view: 'spring' });
-
-console.log(setUrlManager.state.store); // products
-console.log(setUrlManager.state.view); // spring
-console.log(setUrlManager.href); // /search?view=spring#/store:products
-
-```
 
 ### Core Parameter Configuration
 
@@ -118,8 +94,8 @@ const urlManager = new UrlManager(
 		urlRoot: '/search.html',
 		parameters: {
 			core: {
-				query: { name: 'thequery', type: 'hash' },
-				page: { name: 'p' },
+				query: { name: 'thequery' },
+				page: { name: 'p', type: 'hash' },
 			},
 		},
 	})
@@ -127,11 +103,13 @@ const urlManager = new UrlManager(
 
 const setUrlManager = urlManager.set({ query: 'blue shoe', page: 3 });
 
-console.log(setUrlManager.href); // /search.html?p=3#/thequery:blue$2520shoe
+console.log(setUrlManager.href); // /search.html?thequery=blue%20shoe#/p:3
 
 ```
 
-If you wanted to make all of the core parameters `query` or `hash` types you could do so individually as shown above, or as a whole utilizing the `parameters.settings.type` configuration. The `parameters.settings.prifix` configuration allows for all of the core parameters to be prefixed with a string;  this would add the prefix to the default or custom name configuration for each core parameter.
+If you wanted to make all of the core parameters `query` or `hash` types, you could do so individually as shown above, or as a whole utilizing the `settings.coreType` configuration. Individual type configurations under `parameters.core` override the `coreType`.
+
+The `settings.corePrefix` configuration allows for all of the core parameters to be prefixed with a string. This adds the specified prefix to the default or custom name configuration for each core parameter.
 
 ```js
 import { UrlManager, UrlTranslator } from '@searchspring/snap-url-manager';
@@ -139,39 +117,28 @@ import { UrlManager, UrlTranslator } from '@searchspring/snap-url-manager';
 const urlManager = new UrlManager(
 	new UrlTranslator({
 		urlRoot: '/search.html',
+		settings: {
+			coreType: 'hash',
+			corePrefix: 'ss-',
+		},
 		parameters: {
-			settings: {
-				type: 'hash',
-				prefix: 'ss-',
-			},
 			core: {
 				query: { name: 'que' },
 				page: { name: 'p' },
-				filter: { name: 'facet' }
 			},
 		},
 	})
 );
 
-const setUrlManager = urlManager.set({ query: 'bright', page: 3 });
+const setUrlManager = urlManager.set({ query: 'bright', page: 3, filter: { color: ['blue'] } });
 
-console.log(setUrlManager.href); // /search.html#/ss-que:bright/ss-p:3/ss-facet:color:blue
+console.log(setUrlManager.href); // /search.html#/ss-que:bright/ss-p:3/ss-filter:color:blue
 
 ```
 
+### Custom Parameter Configuration
 
-### urlRoot Configuration
-
-`urlRoot` specifies a root URL to use when URLs are created in the `serialize` method.
-
-Consider a website with a different query parameter:
-
-```html
-<form id="search" action="/search">
-	<input type="text" name="search" />
-	<input type="submit" value="Search" />
-</form>
-```
+A custom parameter is any non-core parameter. The `UrlTranslator` will automatically determine how to handle parameters found in the URL when it is initialized. However for parameters that do not yet exist, the default behavior is to treat them as hash fragments. This can be customized using the `settings.customType` configuration. In the example below, the 'view' custom parameter is set as a `query` type and the 'store' custom parameter is set to a `hash` type (default `customType` setting of 'hash').
 
 ```js
 import { UrlManager, UrlTranslator } from '@searchspring/snap-url-manager';
@@ -180,6 +147,32 @@ const urlManager = new UrlManager(
 	new UrlTranslator({
 		urlRoot: '/search',
 		parameters: {
+			custom: {
+				view: { type: 'query' },
+			},
+		},
+	})
+);
+
+const setUrlManager = urlManager.set({ store: 'products', view: 'spring' });
+
+console.log(setUrlManager.state.store); // products
+console.log(setUrlManager.state.view); // spring
+console.log(setUrlManager.href); // /search?view=spring#/store:products
+
+```
+
+### urlRoot Configuration
+
+`urlRoot` specifies a root URL to use when URLs are created in the `serialize` method. By default any parameters in the `urlRoot` will be preserved and added to the final serialized URL; this can be disabled by setting the `settings.rootParams` configuration to `false`.
+
+```js
+import { UrlManager, UrlTranslator } from '@searchspring/snap-url-manager';
+
+const urlManager = new UrlManager(
+	new UrlTranslator({
+		urlRoot: '/search#view:grid',
+		parameters: {
 			core: {
 				query: { name: 'search' },
 			},
@@ -187,8 +180,8 @@ const urlManager = new UrlManager(
 	})
 );
 
-const queriedUrlManager = urlManager.set({ query: 'green shirt' });
+const queriedUrlManager = urlManager.set({ query: 'green shirt', filter: { color: ['green'] } });
 
 console.log(queriedUrlManager.state.query); // green shirt
-console.log(queriedUrlManager.href); // /search?search=green%20shirt
+console.log(queriedUrlManager.href); // /search?search=green%20shirt#/view:grid/filter:color:green
 ```

--- a/packages/snap-url-manager/src/integration.test.ts
+++ b/packages/snap-url-manager/src/integration.test.ts
@@ -330,6 +330,35 @@ describe('UrlManager Integration Tests', () => {
 			expect(search.href).toBe('https://somesite.com/search?query=the%20thing');
 		});
 
+		it('can be given a root URL with params that it appends to the state params', () => {
+			url = 'https://somesite.com?dev#/development';
+			const translatorConfig = {
+				urlRoot: 'https://somesite.com/search',
+				parameters: {
+					core: {
+						query: { name: 'query' },
+					},
+				},
+			};
+
+			const urlManager = new UrlManager(new MockUrlTranslator(translatorConfig));
+			expect(urlManager.href).toBe('https://somesite.com/search?dev#/development');
+
+			const search = urlManager.set('query', 'the thing');
+			expect(search.href).toBe('https://somesite.com/search?query=the%20thing&dev#/development');
+		});
+
+		it('supports setting and merging params with no value', () => {
+			const devMode = new UrlManager(new MockUrlTranslator()).set('dev');
+			expect(devMode.href).toBe('/#/dev');
+
+			const noDevMode = devMode.remove('dev');
+			expect(noDevMode.href).toBe('/');
+
+			const infiniteMode = noDevMode.merge('infinite');
+			expect(infiniteMode.href).toBe('/#/infinite');
+		});
+
 		it('supports typical value filter usage', () => {
 			const colorFilter = new UrlManager(new MockUrlTranslator()).set('filter.color', 'red');
 			expect(colorFilter.href).toBe('/#/filter:color:red');


### PR DESCRIPTION
Several changes to UrlTranslator:
* Adding support for urlRoot parameters
* Support for value-less parameters (eg: ?dev)
* Re-organized UrlTranslator settings (moved out of `parameters` and re-named a few settings)

Changes to Snap Preact:
* `parameters` config renamed to `url` to allow for the above UrlTranslator settings to be utilized