### PR TITLE
feat(autocomplete): linkSlot prop

### DIFF
--- a/packages/snap-preact-components/src/components/Organisms/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/snap-preact-components/src/components/Organisms/Autocomplete/Autocomplete.stories.tsx
@@ -111,6 +111,17 @@ export default {
 			},
 			control: { type: 'boolean' },
 		},
+		hideLink: {
+			defaultValue: false,
+			description: 'prevent the "see n results for keyword" link from rendering (hideContent will also hide this)',
+			table: {
+				type: {
+					summary: 'boolean',
+				},
+				defaultValue: { summary: false },
+			},
+			control: { type: 'boolean' },
+		},
 		horizontalTerms: {
 			defaultValue: false,
 			description: 'display terms horizontally, (not required if vertical prop is true)',
@@ -206,6 +217,14 @@ export default {
 		},
 		contentSlot: {
 			description: 'Slot for custom content component',
+			table: {
+				type: {
+					summary: 'component',
+				},
+			},
+		},
+		linkSlot: {
+			description: 'Slot for custom "see n results for keyword" link component',
 			table: {
 				type: {
 					summary: 'component',

--- a/packages/snap-preact-components/src/components/Organisms/Autocomplete/Autocomplete.tsx
+++ b/packages/snap-preact-components/src/components/Organisms/Autocomplete/Autocomplete.tsx
@@ -215,6 +215,7 @@ export const Autocomplete = observer((properties: AutocompleteProps): JSX.Elemen
 		hideFacets,
 		hideContent,
 		hideBanners,
+		hideLink,
 		horizontalTerms,
 		vertical,
 		termsTitle,
@@ -227,6 +228,7 @@ export const Autocomplete = observer((properties: AutocompleteProps): JSX.Elemen
 		contentSlot,
 		resultsSlot,
 		noResultsSlot,
+		linkSlot,
 		disableStyles,
 		className,
 		width,
@@ -390,7 +392,7 @@ export const Autocomplete = observer((properties: AutocompleteProps): JSX.Elemen
 					{!hideTerms && (
 						<div className={classnames('ss__autocomplete__terms', { 'ss__autocomplete__terms-trending': showTrending })}>
 							{termsSlot ? (
-								cloneWithProps(termsSlot, { terms, trending, controller })
+								cloneWithProps(termsSlot, { terms, trending, termsTitle, trendingTitle, showTrending, controller })
 							) : (
 								<>
 									{terms.length > 0 ? (
@@ -446,7 +448,7 @@ export const Autocomplete = observer((properties: AutocompleteProps): JSX.Elemen
 					{!hideFacets &&
 						(facetsSlot ? (
 							<div className="ss__autocomplete__facets">
-								{cloneWithProps(facetsSlot, { facets: facetsToShow, merchandising, controller, valueProps })}
+								{cloneWithProps(facetsSlot, { facets: facetsToShow, merchandising, facetsTitle, hideBanners, controller, valueProps })}
 							</div>
 						) : (
 							facetsToShow.length > 0 && (
@@ -510,14 +512,18 @@ export const Autocomplete = observer((properties: AutocompleteProps): JSX.Elemen
 
 								{!hideBanners ? <Banner content={merchandising.content} type={BannerType.FOOTER} /> : null}
 
-								{search?.query?.string && results.length > 0 ? (
-									<div className="ss__autocomplete__content__info">
-										<a href={state.url.href}>
-											See {pagination.totalResults} {filters.length > 0 ? 'filtered' : ''} result{pagination.totalResults == 1 ? '' : 's'} for "
-											{search.query.string}"
-											<Icon {...subProps.icon} />
-										</a>
-									</div>
+								{!hideLink ? (
+									linkSlot ? (
+										cloneElement(linkSlot, { search, results, pagination, filters, controller })
+									) : search?.query?.string && results.length > 0 ? (
+										<div className="ss__autocomplete__content__info">
+											<a href={state.url.href}>
+												See {pagination.totalResults} {filters.length > 0 ? 'filtered' : ''} result{pagination.totalResults == 1 ? '' : 's'} for "
+												{search.query.string}"
+												<Icon {...subProps.icon} />
+											</a>
+										</div>
+									) : null
 								) : null}
 							</div>
 						) : null
@@ -566,6 +572,7 @@ export interface AutocompleteProps extends ComponentProps {
 	hideFacets?: boolean;
 	hideContent?: boolean;
 	hideBanners?: boolean;
+	hideLink?: boolean;
 	horizontalTerms?: boolean;
 	vertical?: boolean;
 	termsTitle?: string;
@@ -578,7 +585,8 @@ export interface AutocompleteProps extends ComponentProps {
 	contentSlot?: JSX.Element;
 	resultsSlot?: JSX.Element;
 	noResultsSlot?: JSX.Element;
+	linkSlot?: JSX.Element;
 	breakpoints?: BreakpointsProps;
-	controller?: AutocompleteController;
+	controller: AutocompleteController;
 	width?: string;
 }

--- a/packages/snap-preact-components/src/components/Organisms/Autocomplete/readme.md
+++ b/packages/snap-preact-components/src/components/Organisms/Autocomplete/readme.md
@@ -8,6 +8,7 @@ The autocomplete layout renders terms, facets, banners, and results.
 - Facet
 - Banner
 - Results
+- Icon
 
 ## Usage
 
@@ -36,6 +37,109 @@ The `width` prop specifies a width for the overall component. The default value 
 <Autocomplete controller={controller} input={'#searchInput'} width="800px" />
 ```
 
+### horizontalTerms
+The `horizontalTerms` prop will alter autocomplete's CSS to display terms horizontally.
+
+```jsx
+<Autocomplete controller={controller} input={'#searchInput'} horizontalTerms={true} />
+```
+
+### vertical
+The `vertical` prop will alter autocomplete's CSS to display in a vertical layout.
+
+```jsx
+<Autocomplete controller={controller} input={'#searchInput'} vertical={true} />
+```
+
+### termsTitle
+The `termsTitle` prop will display the given text above the autocomplete terms area. The default value is blank and does not affect the trending terms title `trendingTitle`.
+
+```jsx
+<Autocomplete controller={controller} input={'#searchInput'} termsTitle={'Terms'} />
+```
+
+### trendingTitle
+The `trendingTitle` prop will display the given text above the autocomplete terms area when trending terms are displayed. The default value is 'Popular Searches' and does not affect non-trending terms title `termsTitle`. Also requires `controller.config.settings.trending.limit` to be configured)
+
+```jsx
+<Autocomplete controller={controller} input={'#searchInput'} trendingTitle={'Trending'} />
+```
+
+### facetsTitle
+The `facetsTitle` prop will display the given text above the autocomplete facets area. (default is blank)
+
+```jsx
+<Autocomplete controller={controller} input={'#searchInput'} facetsTitle={'Filter By'} />
+```
+
+### contentTitle
+The `contentTitle` prop will display the given text above the autocomplete content area. (default is blank)
+
+```jsx
+<Autocomplete controller={controller} input={'#searchInput'} contentTitle={'Results'} />
+```
+
+### viewportMaxHeight
+The `viewportMaxHeight` prop will restrict autocomplete from overflowing the viewport. The max height of autocomplete will always be visible in the viewport. 
+
+```jsx
+<Autocomplete controller={controller} input={'#searchInput'} viewportMaxHeight={true} />
+```
+
+### termsSlot
+The `termsSlot` prop accepts a custom JSX element to render instead of the default terms section. This will also replace the trending terms.
+
+The following props are available to be used within your custom component: `terms`, `trending`, `termsTitle`, `trendingTitle`, `showTrending`, `controller`
+
+```jsx
+<Autocomplete controller={controller} input={'#searchInput'} termsSlot={<CustomTermsComponent />} />
+```
+
+### facetsSlot
+The `facetsSlot` prop accepts a custom JSX element to render instead of the default facets section. 
+
+The following props are available to be used within your custom component: `facets`, `merchandising`, `facetsTitle`, `hideBanners`, `controller`, `valueProps`
+
+```jsx
+<Autocomplete controller={controller} input={'#searchInput'} facetsSlot={<CustomFacetsComponent />} />
+```
+
+### contentSlot
+The `contentSlot` prop accepts a custom JSX element to render instead of the default content section. 
+
+The following props are available to be used within your custom component: `results`, `merchandising`, `search`, `pagination`, `filters`, `controller`
+
+```jsx
+<Autocomplete controller={controller} input={'#searchInput'} contentSlot={<CustomContentComponent />} />
+```
+
+### resultsSlot
+The `resultsSlot` prop accepts a custom JSX element to render instead of the default results section. 
+
+The following props are available to be used within your custom component: `results`, `contentTitle`, `controller`
+
+```jsx
+<Autocomplete controller={controller} input={'#searchInput'} resultsSlot={<CustomResultsComponent />} />
+```
+
+### noResultsSlot
+The `noResultsSlot` prop accepts a custom JSX element to render instead of the default no results section. 
+
+The following props are available to be used within your custom component: `search`, `pagination`, `controller`
+
+```jsx
+<Autocomplete controller={controller} input={'#searchInput'} noResultsSlot={<CustomNoResultsComponent />} />
+```
+
+### linkSlot
+The `linkSlot` prop accepts a custom JSX element to render instead of the default "see n results for keyword" link section. 
+
+The following props are available to be used within your custom component: `search`, `results`, `pagination`, `filters`, `controller`
+
+```jsx
+<Autocomplete controller={controller} input={'#searchInput'} linkSlot={<CustomLinkComponent />} />
+```
+
 ### hideFacets
 The `hideFacets` prop specifies if the facets within autocomplete should be rendered.
 
@@ -50,8 +154,31 @@ The `hideTerms` prop specifies if the terms within autocomplete should be render
 <Autocomplete controller={controller} input={'#searchInput'} hideTerms={true} />
 ```
 
+### hideContent
+The `hideContent` prop specifies if the content area within autocomplete should be rendered.
+
+```jsx
+<Autocomplete controller={controller} input={'#searchInput'} hideContent={true} />
+```
+
+### hideBanners
+The `hideBanners` prop specifies if the banners within autocomplete should be rendered. (inline banners not affected)
+
+```jsx
+<Autocomplete controller={controller} input={'#searchInput'} hideBanners={true} />
+```
+
+### hideLink
+The `hideLink` prop specifies if the "see n results for keyword" text within autocomplete should be rendered.
+
+```jsx
+<Autocomplete controller={controller} input={'#searchInput'} hideLink={true} />
+```
+
+
 ### breakpoints
 The `breakpoints` prop contains a breakpoints object that is passed to the `<Results />` sub-component.
+When the viewport is between the Object's key value, those props will be applied to the Autocomplete component.
 
 Default Autocomplete `breakpoints` object:
 
@@ -60,16 +187,15 @@ const breakpoints = {
     0: {
         columns: 2,
         rows: 1,
+        hideFacets: true,
+        vertical: true,
     },
     540: {
         columns: 3,
         rows: 1,
+        vertical: true,
     },
     768: {
-        columns: 4,
-        rows: 1,
-    },
-    991: {
         columns: 2,
         rows: 2,
     },


### PR DESCRIPTION
- add linkSlot & hideLink props to the Autocomplete component
- updated docs with likeSlot, hideLink, and many other missing props
- add missing props that would be used in facetsSlot and termsSlot
- made the controller prop non-optional as the component wouldn't work and the docs say its required