### PR TITLE
fix(storagestore): fallback to empty object

### DIFF
--- a/packages/snap-store-mobx/src/Storage/StorageStore.ts
+++ b/packages/snap-store-mobx/src/Storage/StorageStore.ts
@@ -79,15 +79,15 @@ export class StorageStore {
 	get(path: string): any {
 		switch (this.type) {
 			case StorageType.SESSION:
-				this.state = JSON.parse(window.sessionStorage.getItem(this.key));
+				this.state = JSON.parse(window.sessionStorage.getItem(this.key)) || {};
 				break;
 			case StorageType.LOCAL:
-				this.state = JSON.parse(window.localStorage.getItem(this.key));
+				this.state = JSON.parse(window.localStorage.getItem(this.key)) || {};
 				break;
 			case StorageType.COOKIE:
 				const data = utils.cookies.get(this.key);
 				if (data) {
-					this.state = JSON.parse(data);
+					this.state = JSON.parse(data) || {};
 				}
 				break;
 		}


### PR DESCRIPTION
the `get` method of the StorageStore will set `this.state` to null if it could not retrieve anything from storage. Fallback to empty object. 