### PR TITLE
AC Await Spell Correction

### DIFF
--- a/packages/snap-controller/src/Autocomplete/AutocompleteController.test.ts
+++ b/packages/snap-controller/src/Autocomplete/AutocompleteController.test.ts
@@ -11,6 +11,8 @@ import { AutocompleteController } from './AutocompleteController';
 import { MockClient } from '../__mocks__/MockClient';
 import { SearchData } from '../__mocks__/SearchData';
 
+const INPUT_DELAY = 200;
+
 let acConfig = {
 	id: 'ac',
 	selector: '#search_query',
@@ -289,8 +291,8 @@ describe('Autocomplete Controller', () => {
 		inputEl.dispatchEvent(new Event('focus'));
 		inputEl.dispatchEvent(new KeyboardEvent('keyup', { bubbles: true, keyCode: 13 })); // Enter key
 
-		// timeout needed due to beforeSubmit event
-		await new Promise((resolve) => setTimeout(resolve));
+		// timeout needed due to beforeSubmit event and awaiting further input
+		await new Promise((resolve) => setTimeout(resolve, INPUT_DELAY + 1));
 		expect(window.location.href).toBe(`${acConfig.action}?search_query=${inputEl.value}`);
 	});
 });

--- a/packages/snap-preact-demo/src/index.js
+++ b/packages/snap-preact-demo/src/index.js
@@ -97,6 +97,13 @@ let config = {
 							limit: 5,
 						},
 					},
+					globals: {
+						search: {
+							query: {
+								spellCorrection: true,
+							},
+						},
+					},
 				},
 				targeters: [
 					{

--- a/packages/snap-store-mobx/src/types.ts
+++ b/packages/snap-store-mobx/src/types.ts
@@ -48,6 +48,13 @@ export type AutocompleteStoreConfig = StoreConfig & {
 		personalization?: {
 			disabled: boolean;
 		};
+		search?: {
+			[any: string]: unknown;
+			query?: {
+				[any: string]: unknown;
+				spellCorrection?: boolean;
+			};
+		};
 		[any: string]: unknown;
 	};
 	selector: string;


### PR DESCRIPTION
When spell correction is used the Autocomplete controller will now wait for the response (and future input) before submitting the search.

Closes #270