### PR TITLE
Added a null check for range filters with 0 as low values. 

### DIFF
--- a/packages/snap-url-manager/src/Translators/Url/UrlTranslator.ts
+++ b/packages/snap-url-manager/src/Translators/Url/UrlTranslator.ts
@@ -286,8 +286,8 @@ export class UrlTranslator implements Translator {
 						[param.key[1]]: [
 							...(Array.isArray(currentValue) ? currentValue : [currentValue]),
 							{
-								[RangeValueProperties.LOW]: param.value == '0' ? 0 : +param.value || null,
-								[RangeValueProperties.HIGH]: +nextRangeParam.value || null,
+								[RangeValueProperties.LOW]: isNaN(+param.value) ? null : +param.value,
+								[RangeValueProperties.HIGH]: isNaN(+nextRangeParam.value) ? null : +nextRangeParam.value,
 							},
 						],
 					},


### PR DESCRIPTION
adding a null check inside the urlTranslator so both 0 and * are valid. 