### PR TITLE
Trim AC Input

### DIFF
--- a/packages/snap-controller/src/Autocomplete/AutocompleteController.ts
+++ b/packages/snap-controller/src/Autocomplete/AutocompleteController.ts
@@ -280,7 +280,7 @@ export class AutocompleteController extends AbstractController {
 					this.setFocused(e.target as HTMLInputElement);
 				}
 
-				const value = (e.target as HTMLInputElement).value;
+				const value = (e.target as HTMLInputElement).value.trim();
 
 				// prevent search when value is unchanged
 				if (this.store.state.input == value && this.store.loaded) {


### PR DESCRIPTION
It was noticed that when adding a space to your query when typing multiple word searches that the query + space was triggering a new search, this should not have been. This change trims the input value to prevent additional searches.