### PR TITLE
Observable Stories

### DIFF
--- a/packages/snap-preact-components/src/components/Molecules/Carousel/Carousel.stories.tsx
+++ b/packages/snap-preact-components/src/components/Molecules/Carousel/Carousel.stories.tsx
@@ -5,8 +5,6 @@ import { ArgsTable, PRIMARY_STORY } from '@storybook/addon-docs/blocks';
 import { Carousel } from './Carousel';
 import { Icon, iconPaths } from '../../Atoms/Icon';
 import { componentArgs } from '../../../utilities';
-import { Snapify } from '../../../utilities/snapify';
-import { Result } from '../Result';
 import Readme from './readme.md';
 
 export default {

--- a/packages/snap-preact-components/src/components/Organisms/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/snap-preact-components/src/components/Organisms/Autocomplete/Autocomplete.stories.tsx
@@ -1,5 +1,4 @@
 import { h, Fragment } from 'preact';
-import { observer } from 'mobx-react';
 
 import { ArgsTable, PRIMARY_STORY } from '@storybook/addon-docs/blocks';
 

--- a/packages/snap-preact-components/src/components/Organisms/Facets/Facets.stories.tsx
+++ b/packages/snap-preact-components/src/components/Organisms/Facets/Facets.stories.tsx
@@ -1,5 +1,4 @@
 import { h } from 'preact';
-import { observer } from 'mobx-react';
 
 import { ArgsTable, PRIMARY_STORY } from '@storybook/addon-docs/blocks';
 
@@ -56,12 +55,8 @@ export default {
 
 const snapInstance = Snapify.search({ id: 'Facets', globals: { siteId: '8uyt2m' } });
 
-const ObservableFacets = observer(({ args, controller }) => {
-	return <Facets {...args} controller={controller} />;
-});
-
 const Template = (args: FacetsProps, { loaded: { controller } }) => {
-	return <ObservableFacets args={args} controller={controller} />;
+	return <Facets {...args} controller={controller} />;
 };
 
 export const Default = Template.bind({});

--- a/packages/snap-preact-components/src/components/Organisms/Results/Results.stories.tsx
+++ b/packages/snap-preact-components/src/components/Organisms/Results/Results.stories.tsx
@@ -1,5 +1,4 @@
 import { h } from 'preact';
-import { observer } from 'mobx-react';
 
 import { ArgsTable, PRIMARY_STORY } from '@storybook/addon-docs/blocks';
 
@@ -115,12 +114,8 @@ export default {
 
 const snapInstance = Snapify.search({ id: 'Results', globals: { siteId: '8uyt2m' } });
 
-const ObservableGridResults = observer(({ args, controller }) => {
-	return <Results {...args} controller={controller} results={controller?.store?.results} />;
-});
-
 const GridTemplate = (args: ResultsProp, { loaded: { controller } }) => {
-	return <ObservableGridResults args={args} controller={controller} />;
+	return <Results {...args} controller={controller} results={controller?.store?.results} />;
 };
 
 export const Grid = GridTemplate.bind({});
@@ -133,12 +128,8 @@ Grid.loaders = [
 	},
 ];
 
-const ObservableListResults = observer(({ args, controller }) => {
-	return <Results {...args} controller={controller} results={controller?.store?.results} layout={Layout.LIST} />;
-});
-
 const ListTemplate = (args: ResultsProp, { loaded: { controller } }) => {
-	return <ObservableListResults args={args} controller={controller} />;
+	return <Results {...args} controller={controller} results={controller?.store?.results} layout={Layout.LIST} />;
 };
 
 export const List = ListTemplate.bind({});


### PR DESCRIPTION
Removing mobx observer wrappers from component stories that do not need it. 

Any component that passes the controller directly as a prop, does not need the extra observer wrapper. 