### PR TITLE
Stringify facet value in facet url

### DIFF
--- a/packages/snap-store-mobx/src/Search/Stores/FacetStore.ts
+++ b/packages/snap-store-mobx/src/Search/Stores/FacetStore.ts
@@ -300,7 +300,7 @@ class Value {
 		Object.assign(this, value);
 
 		if (this.filtered) {
-			this.url = services.urlManager?.remove('page').remove(`filter.${facet.field}`, value.value);
+			this.url = services.urlManager?.remove('page').remove(`filter.${facet.field}`, value.value.toString());
 		} else {
 			let valueUrl = services.urlManager?.remove('page');
 			if (facet.multiple == 'single') {

--- a/packages/snap-store-mobx/src/Search/Stores/FacetStore.ts
+++ b/packages/snap-store-mobx/src/Search/Stores/FacetStore.ts
@@ -238,6 +238,8 @@ class ValueFacet extends Facet {
 								const filteredValues = facet.values.filter((value) => value.filtered);
 								return new HierarchyValue(services, this, value, filteredValues);
 							} else {
+								// converting values to strings to ensure UrlManager state matches state created from URL
+								value.value = value.value.toString();
 								return new Value(services, this, value);
 							}
 						case 'range-buckets':
@@ -300,7 +302,7 @@ class Value {
 		Object.assign(this, value);
 
 		if (this.filtered) {
-			this.url = services.urlManager?.remove('page').remove(`filter.${facet.field}`, value.value.toString());
+			this.url = services.urlManager?.remove('page').remove(`filter.${facet.field}`, value.value);
 		} else {
 			let valueUrl = services.urlManager?.remove('page');
 			if (facet.multiple == 'single') {


### PR DESCRIPTION
bugfix for when the applied filter has a value that is a non-string (a number). 