### PR TITLE
Query Parameters with urlRoot

### DIFF
--- a/packages/snap-url-manager/src/Translators/Url/UrlTranslator.ts
+++ b/packages/snap-url-manager/src/Translators/Url/UrlTranslator.ts
@@ -76,7 +76,6 @@ export class UrlTranslator implements Translator {
 
 	constructor(config: UrlTranslatorConfig = {}) {
 		this.config = deepmerge(defaultConfig, config);
-
 		Object.keys(this.config.parameters.core).forEach((param) => {
 			// param prefix
 			if (this.config.settings.corePrefix) {
@@ -353,7 +352,10 @@ export class UrlTranslator implements Translator {
 
 		const rootUrlParams = this.config.settings.rootParams ? this.parseUrlParams(this.config.urlRoot) : [];
 		const stateParams = this.stateToParams(state);
-		const params = [...rootUrlParams, ...stateParams];
+		let params = [...rootUrlParams, ...stateParams];
+		//dedupe the params
+		params = params.filter((object, index) => index === params.findIndex((obj) => JSON.stringify(obj) === JSON.stringify(object)));
+
 		const queryParams = params.filter((p) => p.type == ParamLocationType.QUERY);
 		const hashParams = params.filter((p) => p.type == ParamLocationType.HASH);
 


### PR DESCRIPTION
removing duplicates from the query/hash params after merging state/rooturl params. 

This was happening because params coming from the state have generic array functions attached to it like pop and split while params from the root of do not, and so they both get added when spreading them together.  


![4E51CDCB-E5A6-46D8-B89F-BBAEE70F0580](https://user-images.githubusercontent.com/22894994/152242178-3e8bfafa-b296-4aca-a21e-a4d625296c7f.jpeg)

