### PR TITLE
Controller context

### DIFF
--- a/packages/snap-controller/README.md
+++ b/packages/snap-controller/README.md
@@ -89,6 +89,16 @@ Controllers may need to know how long a certain event took, the `profiler` servi
 ### logger
 The `logger` service provides logging functionality to a controller. Each controller logs when errors in middleware and when controller events occur. The logger is responsible for sending this information to the developer console. In addition the logger may provide additional emoji or colors to use. This service is exposed as `controller.log`.
 
+
+## Context
+Each Controller can optionally take a 3rd parameter for `Context`. This is to allow each individual controller to have its own individual context if so desired. If no Context param is provided, the global context is used by default. 
+
+The context is exposed as `controller.context`
+```typescript
+controller.context;
+```
+
+
 ## Initialization
 Invoking the `init` method is required to subscribe to changes that occur in the UrlManager. It also fires the `init` event which executes attached middleware. This can be fired manually as needed; if it was not manually fired it will happen automatically on the first call to the controller `search` method.
 

--- a/packages/snap-controller/src/Abstract/AbstractController.ts
+++ b/packages/snap-controller/src/Abstract/AbstractController.ts
@@ -10,7 +10,7 @@ import type { Logger } from '@searchspring/snap-logger';
 import type { Tracker } from '@searchspring/snap-tracker';
 import type { Target, OnTarget } from '@searchspring/snap-toolbox';
 
-import type { ControllerServices, ControllerConfig, Attachments } from '../types';
+import type { ControllerServices, ControllerConfig, Attachments, ContextVariables } from '../types';
 
 const SS_DEV_COOKIE = 'ssDev';
 export abstract class AbstractController {
@@ -24,6 +24,8 @@ export abstract class AbstractController {
 	public profiler: Profiler;
 	public log: Logger;
 	public tracker: Tracker;
+	public context: ContextVariables;
+
 	public targeters: {
 		[key: string]: DomTargeter;
 	} = {};
@@ -35,7 +37,11 @@ export abstract class AbstractController {
 		return this._initialized;
 	}
 
-	constructor(config: ControllerConfig, { client, store, urlManager, eventManager, profiler, logger, tracker }: ControllerServices) {
+	constructor(
+		config: ControllerConfig,
+		{ client, store, urlManager, eventManager, profiler, logger, tracker }: ControllerServices,
+		context: ContextVariables = {}
+	) {
 		if (typeof config != 'object' || typeof config.id != 'string' || !config.id.match(/^[a-zA-Z0-9_-]*$/)) {
 			throw new Error(`Invalid config passed to controller. The "id" attribute must be an alphanumeric string.`);
 		}
@@ -93,6 +99,7 @@ export abstract class AbstractController {
 		this.profiler = profiler;
 		this.log = logger;
 		this.tracker = tracker;
+		this.context = context;
 
 		// configure the logger
 		this.log.setNamespace(this.config.id);

--- a/packages/snap-controller/src/Autocomplete/AutocompleteController.ts
+++ b/packages/snap-controller/src/Autocomplete/AutocompleteController.ts
@@ -6,7 +6,15 @@ import { AbstractController } from '../Abstract/AbstractController';
 import { getSearchParams } from '../utils/getParams';
 
 import type { AutocompleteStore } from '@searchspring/snap-store-mobx';
-import type { AutocompleteControllerConfig, BeforeSearchObj, AfterSearchObj, AfterStoreObj, ControllerServices, NextEvent } from '../types';
+import type {
+	AutocompleteControllerConfig,
+	BeforeSearchObj,
+	AfterSearchObj,
+	AfterStoreObj,
+	ControllerServices,
+	NextEvent,
+	ContextVariables,
+} from '../types';
 import type { AutocompleteRequestModel } from '@searchspring/snapi-types';
 
 const INPUT_ATTRIBUTE = 'ss-autocomplete-input';
@@ -42,8 +50,12 @@ export class AutocompleteController extends AbstractController {
 	public config: AutocompleteControllerConfig;
 	public storage: StorageStore;
 
-	constructor(config: AutocompleteControllerConfig, { client, store, urlManager, eventManager, profiler, logger, tracker }: ControllerServices) {
-		super(config, { client, store, urlManager, eventManager, profiler, logger, tracker });
+	constructor(
+		config: AutocompleteControllerConfig,
+		{ client, store, urlManager, eventManager, profiler, logger, tracker }: ControllerServices,
+		context: ContextVariables
+	) {
+		super(config, { client, store, urlManager, eventManager, profiler, logger, tracker }, context);
 
 		// deep merge config with defaults
 		this.config = deepmerge(defaultConfig, this.config);

--- a/packages/snap-controller/src/Autocomplete/AutocompleteController.ts
+++ b/packages/snap-controller/src/Autocomplete/AutocompleteController.ts
@@ -53,7 +53,7 @@ export class AutocompleteController extends AbstractController {
 	constructor(
 		config: AutocompleteControllerConfig,
 		{ client, store, urlManager, eventManager, profiler, logger, tracker }: ControllerServices,
-		context: ContextVariables
+		context?: ContextVariables
 	) {
 		super(config, { client, store, urlManager, eventManager, profiler, logger, tracker }, context);
 

--- a/packages/snap-controller/src/Finder/FinderController.ts
+++ b/packages/snap-controller/src/Finder/FinderController.ts
@@ -21,7 +21,7 @@ export class FinderController extends AbstractController {
 	constructor(
 		config: FinderControllerConfig,
 		{ client, store, urlManager, eventManager, profiler, logger, tracker }: ControllerServices,
-		context: ContextVariables
+		context?: ContextVariables
 	) {
 		super(config, { client, store, urlManager, eventManager, profiler, logger, tracker }, context);
 

--- a/packages/snap-controller/src/Finder/FinderController.ts
+++ b/packages/snap-controller/src/Finder/FinderController.ts
@@ -5,7 +5,7 @@ import { ErrorType } from '@searchspring/snap-store-mobx';
 import { AbstractController } from '../Abstract/AbstractController';
 import { getSearchParams } from '../utils/getParams';
 import type { FinderStore } from '@searchspring/snap-store-mobx';
-import type { FinderControllerConfig, BeforeSearchObj, AfterSearchObj, ControllerServices, NextEvent } from '../types';
+import type { FinderControllerConfig, BeforeSearchObj, AfterSearchObj, ControllerServices, NextEvent, ContextVariables } from '../types';
 
 const defaultConfig: FinderControllerConfig = {
 	id: 'finder',
@@ -18,8 +18,12 @@ export class FinderController extends AbstractController {
 	public store: FinderStore;
 	config: FinderControllerConfig;
 
-	constructor(config: FinderControllerConfig, { client, store, urlManager, eventManager, profiler, logger, tracker }: ControllerServices) {
-		super(config, { client, store, urlManager, eventManager, profiler, logger, tracker });
+	constructor(
+		config: FinderControllerConfig,
+		{ client, store, urlManager, eventManager, profiler, logger, tracker }: ControllerServices,
+		context: ContextVariables
+	) {
+		super(config, { client, store, urlManager, eventManager, profiler, logger, tracker }, context);
 
 		// deep merge config with defaults
 		this.config = deepmerge(defaultConfig, this.config);

--- a/packages/snap-controller/src/Recommendation/RecommendationController.ts
+++ b/packages/snap-controller/src/Recommendation/RecommendationController.ts
@@ -42,7 +42,7 @@ export class RecommendationController extends AbstractController {
 	constructor(
 		config: RecommendationControllerConfig,
 		{ client, store, urlManager, eventManager, profiler, logger, tracker }: ControllerServices,
-		context: ContextVariables
+		context?: ContextVariables
 	) {
 		super(config, { client, store, urlManager, eventManager, profiler, logger, tracker }, context);
 

--- a/packages/snap-controller/src/Recommendation/RecommendationController.ts
+++ b/packages/snap-controller/src/Recommendation/RecommendationController.ts
@@ -7,7 +7,7 @@ import { ErrorType } from '@searchspring/snap-store-mobx';
 
 import type { BeaconEvent } from '@searchspring/snap-tracker';
 import type { RecommendationStore } from '@searchspring/snap-store-mobx';
-import type { RecommendationControllerConfig, BeforeSearchObj, AfterStoreObj, ControllerServices, NextEvent } from '../types';
+import type { RecommendationControllerConfig, BeforeSearchObj, AfterStoreObj, ControllerServices, NextEvent, ContextVariables } from '../types';
 
 type RecommendationTrackMethods = {
 	product: {
@@ -39,8 +39,12 @@ export class RecommendationController extends AbstractController {
 		product: {},
 	};
 
-	constructor(config: RecommendationControllerConfig, { client, store, urlManager, eventManager, profiler, logger, tracker }: ControllerServices) {
-		super(config, { client, store, urlManager, eventManager, profiler, logger, tracker });
+	constructor(
+		config: RecommendationControllerConfig,
+		{ client, store, urlManager, eventManager, profiler, logger, tracker }: ControllerServices,
+		context: ContextVariables
+	) {
+		super(config, { client, store, urlManager, eventManager, profiler, logger, tracker }, context);
 
 		if (!config.tag) {
 			throw new Error(`Invalid config passed to RecommendationController. The "tag" attribute is required.`);

--- a/packages/snap-controller/src/Search/SearchController.ts
+++ b/packages/snap-controller/src/Search/SearchController.ts
@@ -49,7 +49,7 @@ export class SearchController extends AbstractController {
 	constructor(
 		config: SearchControllerConfig,
 		{ client, store, urlManager, eventManager, profiler, logger, tracker }: ControllerServices,
-		context: ContextVariables
+		context?: ContextVariables
 	) {
 		super(config, { client, store, urlManager, eventManager, profiler, logger, tracker }, context);
 

--- a/packages/snap-controller/src/Search/SearchController.ts
+++ b/packages/snap-controller/src/Search/SearchController.ts
@@ -6,7 +6,15 @@ import { getSearchParams } from '../utils/getParams';
 
 import type { BeaconEvent } from '@searchspring/snap-tracker';
 import type { SearchStore } from '@searchspring/snap-store-mobx';
-import type { SearchControllerConfig, BeforeSearchObj, AfterSearchObj, AfterStoreObj, ControllerServices, NextEvent } from '../types';
+import type {
+	SearchControllerConfig,
+	BeforeSearchObj,
+	AfterSearchObj,
+	AfterStoreObj,
+	ControllerServices,
+	NextEvent,
+	ContextVariables,
+} from '../types';
 import type { SearchRequestModel, SearchRequestModelSearchRedirectResponseEnum } from '@searchspring/snapi-types';
 
 const HEIGHT_CHECK_INTERVAL = 50;
@@ -38,8 +46,12 @@ export class SearchController extends AbstractController {
 	config: SearchControllerConfig;
 	storage: StorageStore;
 
-	constructor(config: SearchControllerConfig, { client, store, urlManager, eventManager, profiler, logger, tracker }: ControllerServices) {
-		super(config, { client, store, urlManager, eventManager, profiler, logger, tracker });
+	constructor(
+		config: SearchControllerConfig,
+		{ client, store, urlManager, eventManager, profiler, logger, tracker }: ControllerServices,
+		context: ContextVariables
+	) {
+		super(config, { client, store, urlManager, eventManager, profiler, logger, tracker }, context);
 
 		// deep merge config with defaults
 		this.config = deepmerge(defaultConfig, this.config);

--- a/packages/snap-controller/src/types.ts
+++ b/packages/snap-controller/src/types.ts
@@ -63,6 +63,15 @@ export type Attachments = {
 	[any: string]: unknown;
 };
 
+export type ContextVariables = {
+	shopper?: {
+		id: string;
+		cart?: string[];
+		[variable: string]: any;
+	};
+	[variable: string]: any;
+};
+
 export type ControllerConfig = StoreConfig & Attachments;
 
 // Search Config

--- a/packages/snap-controller/src/types.ts
+++ b/packages/snap-controller/src/types.ts
@@ -10,7 +10,7 @@ import type {
 	AutocompleteStoreConfig,
 	RecommendationStoreConfig,
 } from '@searchspring/snap-store-mobx';
-import type { Tracker } from '@searchspring/snap-tracker';
+import type { Tracker, ProductViewEvent } from '@searchspring/snap-tracker';
 import type { Profiler } from '@searchspring/snap-profiler';
 import type { UrlManager } from '@searchspring/snap-url-manager';
 import type { Logger } from '@searchspring/snap-logger';
@@ -66,7 +66,7 @@ export type Attachments = {
 export type ContextVariables = {
 	shopper?: {
 		id: string;
-		cart?: string[];
+		cart?: ProductViewEvent[];
 		[variable: string]: any;
 	};
 	[variable: string]: any;

--- a/packages/snap-preact/README.md
+++ b/packages/snap-preact/README.md
@@ -218,6 +218,7 @@ type ExtendedTarget = {
 
 `url` - optional `UrlTranslator` config object to be used with the `UrlManager` for this controller
 
+`context` - optional `Context` object to be used to set a controller specific context. Defaults to the global context, if no context prop is provided. 
 
 An example creating a SearchController:
 
@@ -226,6 +227,7 @@ const config = {
 	controllers: {
 		search: [
 			{
+				context: SearchContext,
 				config: {
 					id: 'search',
 				},

--- a/packages/snap-preact/src/Snap.tsx
+++ b/packages/snap-preact/src/Snap.tsx
@@ -17,6 +17,7 @@ import type {
 	FinderControllerConfig,
 	RecommendationControllerConfig,
 	ControllerConfigs,
+	ContextVariables,
 } from '@searchspring/snap-controller';
 import type { Product } from '@searchspring/snap-tracker';
 import type { Target, OnTarget } from '@searchspring/snap-toolbox';
@@ -37,15 +38,6 @@ type ExtendedTarget = Target & {
 	props?: unknown;
 	onTarget?: OnTarget;
 	prefetch?: boolean;
-};
-
-type ContextVariables = {
-	shopper?: {
-		id: string;
-		cart?: Product[];
-		[variable: string]: any;
-	};
-	[variable: string]: any;
 };
 
 export type SnapConfig = {

--- a/packages/snap-preact/src/Snap.tsx
+++ b/packages/snap-preact/src/Snap.tsx
@@ -64,24 +64,28 @@ export type SnapConfig = {
 			targeters?: ExtendedTarget[];
 			services?: SnapControllerServices;
 			url?: UrlTranslatorConfig;
+			context?: ContextVariables;
 		}[];
 		autocomplete?: {
 			config: AutocompleteControllerConfig;
 			targeters: ExtendedTarget[];
 			services?: SnapControllerServices;
 			url?: UrlTranslatorConfig;
+			context?: ContextVariables;
 		}[];
 		finder?: {
 			config: FinderControllerConfig;
 			targeters?: ExtendedTarget[];
 			services?: SnapControllerServices;
 			url?: UrlTranslatorConfig;
+			context?: ContextVariables;
 		}[];
 		recommendation?: {
 			config: RecommendationControllerConfig;
 			targeters?: ExtendedTarget[];
 			services?: SnapControllerServices;
 			url?: UrlTranslatorConfig;
+			context?: ContextVariables;
 		}[];
 	};
 };
@@ -130,7 +134,8 @@ export class Snap {
 		config: ControllerConfigs,
 		services: SnapControllerServices,
 		urlConfig: UrlTranslatorConfig,
-		resolve: (value?: ControllerTypes | PromiseLike<ControllerTypes>) => void
+		resolve: (value?: ControllerTypes | PromiseLike<ControllerTypes>) => void,
+		context?: ContextVariables
 	): Promise<ControllerTypes> => {
 		let importPromise;
 		switch (type) {
@@ -155,7 +160,8 @@ export class Snap {
 						url: deepmerge(this.config.url || {}, urlConfig || {}),
 						controller: config,
 					},
-					{ client: services?.client || this.client, tracker: services?.tracker || this.tracker }
+					{ client: services?.client || this.client, tracker: services?.tracker || this.tracker },
+					context || this.config.context
 				);
 				resolve(this.controllers[config.id]);
 			}
@@ -265,7 +271,8 @@ export class Snap {
 									url: deepmerge(this.config.url || {}, controller.url || {}),
 									controller: controller.config,
 								},
-								{ client: controller.services?.client || this.client, tracker: controller.services?.tracker || this.tracker }
+								{ client: controller.services?.client || this.client, tracker: controller.services?.tracker || this.tracker },
+								controller.context || this.config.context
 							);
 
 							this.controllers[cntrlr.config.id] = cntrlr;
@@ -389,7 +396,14 @@ The error above happened in the following targeter in the Snap Config`,
 								};
 
 								if (!controller?.targeters || controller?.targeters.length === 0) {
-									this.createController(DynamicImportNames.AUTOCOMPLETE, controller.config, controller.services, controller.url, resolve);
+									this.createController(
+										DynamicImportNames.AUTOCOMPLETE,
+										controller.config,
+										controller.services,
+										controller.url,
+										resolve,
+										controller.context
+									);
 								}
 
 								controller?.targeters?.forEach(async (target, target_index) => {
@@ -422,7 +436,8 @@ The error above happened in the following targeter in the Snap Config`,
 												controller.config,
 												controller.services,
 												controller.url,
-												resolve
+												resolve,
+												controller.context
 											);
 											runBind();
 											targetFunction({ controller: cntrlr, ...target }, elem, originalElem);
@@ -461,7 +476,14 @@ The error above happened in the following targeter in the Snap Config`,
 								};
 
 								if (!controller?.targeters || controller?.targeters.length === 0) {
-									this.createController(DynamicImportNames.FINDER, controller.config, controller.services, controller.url, resolve);
+									this.createController(
+										DynamicImportNames.FINDER,
+										controller.config,
+										controller.services,
+										controller.url,
+										resolve,
+										controller.context
+									);
 								}
 
 								controller?.targeters?.forEach(async (target, target_index) => {
@@ -477,7 +499,8 @@ The error above happened in the following targeter in the Snap Config`,
 											controller.config,
 											controller.services,
 											controller.url,
-											resolve
+											resolve,
+											controller.context
 										);
 										runSearch();
 										targetFunction({ controller: cntrlr, ...target }, elem, originalElem);
@@ -515,7 +538,14 @@ The error above happened in the following targeter in the Snap Config`,
 								};
 
 								if (!controller?.targeters || controller?.targeters.length === 0) {
-									this.createController(DynamicImportNames.RECOMMENDATION, controller.config, controller.services, controller.url, resolve);
+									this.createController(
+										DynamicImportNames.RECOMMENDATION,
+										controller.config,
+										controller.services,
+										controller.url,
+										resolve,
+										controller.context
+									);
 								}
 
 								controller?.targeters?.forEach(async (target, target_index) => {
@@ -531,7 +561,8 @@ The error above happened in the following targeter in the Snap Config`,
 											controller.config,
 											controller.services,
 											controller.url,
-											resolve
+											resolve,
+											controller.context
 										);
 										runSearch();
 										targetFunction({ controller: cntrlr, ...target }, elem, originalElem);

--- a/packages/snap-preact/src/create/createAutocompleteController.ts
+++ b/packages/snap-preact/src/create/createAutocompleteController.ts
@@ -13,18 +13,22 @@ import type { SnapControllerServices, SnapAutocompleteControllerConfig } from '.
 
 configureMobx({ useProxies: 'never' });
 
-export default (config: SnapAutocompleteControllerConfig, services?: SnapControllerServices): AutocompleteController => {
+export default (config: SnapAutocompleteControllerConfig, services?: SnapControllerServices, context?: any): AutocompleteController => {
 	const urlManager = services?.urlManager || new UrlManager(new UrlTranslator(config.url), reactLinker).detach();
 
-	const cntrlr = new AutocompleteController(config.controller, {
-		client: services?.client || new Client(config.client.globals, config.client.config),
-		store: services?.store || new AutocompleteStore(config.controller, { urlManager }),
-		urlManager,
-		eventManager: services?.eventManager || new EventManager(),
-		profiler: services?.profiler || new Profiler(),
-		logger: services?.logger || new Logger(),
-		tracker: services?.tracker || new Tracker(config.client.globals),
-	});
+	const cntrlr = new AutocompleteController(
+		config.controller,
+		{
+			client: services?.client || new Client(config.client.globals, config.client.config),
+			store: services?.store || new AutocompleteStore(config.controller, { urlManager }),
+			urlManager,
+			eventManager: services?.eventManager || new EventManager(),
+			profiler: services?.profiler || new Profiler(),
+			logger: services?.logger || new Logger(),
+			tracker: services?.tracker || new Tracker(config.client.globals),
+		},
+		context
+	);
 
 	return cntrlr;
 };

--- a/packages/snap-preact/src/create/createFinderController.ts
+++ b/packages/snap-preact/src/create/createFinderController.ts
@@ -13,18 +13,22 @@ import type { SnapControllerServices, SnapFinderControllerConfig } from '../type
 
 configureMobx({ useProxies: 'never' });
 
-export default (config: SnapFinderControllerConfig, services?: SnapControllerServices): FinderController => {
+export default (config: SnapFinderControllerConfig, services?: SnapControllerServices, context?: any): FinderController => {
 	const urlManager = services?.urlManager || new UrlManager(new UrlTranslator(config.url), reactLinker).detach(true);
 
-	const cntrlr = new FinderController(config.controller, {
-		client: services?.client || new Client(config.client.globals, config.client.config),
-		store: services?.store || new FinderStore(config.controller, { urlManager }),
-		urlManager,
-		eventManager: services?.eventManager || new EventManager(),
-		profiler: services?.profiler || new Profiler(),
-		logger: services?.logger || new Logger(),
-		tracker: services?.tracker || new Tracker(config.client.globals),
-	});
+	const cntrlr = new FinderController(
+		config.controller,
+		{
+			client: services?.client || new Client(config.client.globals, config.client.config),
+			store: services?.store || new FinderStore(config.controller, { urlManager }),
+			urlManager,
+			eventManager: services?.eventManager || new EventManager(),
+			profiler: services?.profiler || new Profiler(),
+			logger: services?.logger || new Logger(),
+			tracker: services?.tracker || new Tracker(config.client.globals),
+		},
+		context
+	);
 
 	return cntrlr;
 };

--- a/packages/snap-preact/src/create/createRecommendationController.ts
+++ b/packages/snap-preact/src/create/createRecommendationController.ts
@@ -13,18 +13,22 @@ import type { SnapControllerServices, SnapRecommendationControllerConfig } from 
 
 configureMobx({ useProxies: 'never' });
 
-export default (config: SnapRecommendationControllerConfig, services?: SnapControllerServices): RecommendationController => {
+export default (config: SnapRecommendationControllerConfig, services?: SnapControllerServices, context?: any): RecommendationController => {
 	const urlManager = services?.urlManager || new UrlManager(new UrlTranslator(config.url), reactLinker).detach(true);
 
-	const cntrlr = new RecommendationController(config.controller, {
-		client: services?.client || new Client(config.client.globals, config.client.config),
-		store: services?.store || new RecommendationStore(config.controller, { urlManager }),
-		urlManager,
-		eventManager: services?.eventManager || new EventManager(),
-		profiler: services?.profiler || new Profiler(),
-		logger: services?.logger || new Logger(),
-		tracker: services?.tracker || new Tracker(config.client.globals),
-	});
+	const cntrlr = new RecommendationController(
+		config.controller,
+		{
+			client: services?.client || new Client(config.client.globals, config.client.config),
+			store: services?.store || new RecommendationStore(config.controller, { urlManager }),
+			urlManager,
+			eventManager: services?.eventManager || new EventManager(),
+			profiler: services?.profiler || new Profiler(),
+			logger: services?.logger || new Logger(),
+			tracker: services?.tracker || new Tracker(config.client.globals),
+		},
+		context
+	);
 
 	return cntrlr;
 };

--- a/packages/snap-preact/src/create/createSearchController.ts
+++ b/packages/snap-preact/src/create/createSearchController.ts
@@ -12,18 +12,22 @@ import type { SnapControllerServices, SnapSearchControllerConfig } from '../type
 
 configureMobx({ useProxies: 'never' });
 
-export default (config: SnapSearchControllerConfig, services?: SnapControllerServices): SearchController => {
+export default (config: SnapSearchControllerConfig, services?: SnapControllerServices, context?: any): SearchController => {
 	const urlManager = services?.urlManager || new UrlManager(new UrlTranslator(config.url), reactLinker);
 
-	const cntrlr = new SearchController(config.controller, {
-		client: services?.client || new Client(config.client.globals, config.client.config),
-		store: services?.store || new SearchStore(config.controller, { urlManager }),
-		urlManager,
-		eventManager: services?.eventManager || new EventManager(),
-		profiler: services?.profiler || new Profiler(),
-		logger: services?.logger || new Logger(),
-		tracker: services?.tracker || new Tracker(config.client.globals),
-	});
+	const cntrlr = new SearchController(
+		config.controller,
+		{
+			client: services?.client || new Client(config.client.globals, config.client.config),
+			store: services?.store || new SearchStore(config.controller, { urlManager }),
+			urlManager,
+			eventManager: services?.eventManager || new EventManager(),
+			profiler: services?.profiler || new Profiler(),
+			logger: services?.logger || new Logger(),
+			tracker: services?.tracker || new Tracker(config.client.globals),
+		},
+		context
+	);
 
 	return cntrlr;
 };


### PR DESCRIPTION
context added on the controller (controller.context)
allow individual controller configs to have their own context, use root context when no context is explicitly passed to the controller config.