### PR TITLE
Finder `autoDrillDown`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 			],
 			"devDependencies": {
 				"@searchspring/prettier": "^1.0.2",
-				"@searchspring/snapi-types": "^0.1.23",
+				"@searchspring/snapi-types": "^0.1.24",
 				"@types/jest": "^27.4.0",
 				"@types/jsdom": "^16.2.14",
 				"@types/seamless-immutable": "^7.1.16",
@@ -2510,9 +2510,9 @@
 			"dev": true
 		},
 		"node_modules/@emotion/core/node_modules/csstype": {
-			"version": "2.6.19",
-			"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.19.tgz",
-			"integrity": "sha512-ZVxXaNy28/k3kJg0Fou5MiYpp88j7H9hLZp8PDC3jV0WFjfH5E9xHb56L0W59cPbKbcHXeP4qyT8PrHp8t6LcQ==",
+			"version": "2.6.20",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.20.tgz",
+			"integrity": "sha512-/WwNkdXfckNgw6S5R125rrW8ez139lBHWouiBvX8dfMFtcn6V81REDqnH7+CRpRipfYlyU1CmOnOxrmGcFOjeA==",
 			"dev": true
 		},
 		"node_modules/@emotion/css": {
@@ -2552,9 +2552,9 @@
 			"dev": true
 		},
 		"node_modules/@emotion/css/node_modules/csstype": {
-			"version": "2.6.19",
-			"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.19.tgz",
-			"integrity": "sha512-ZVxXaNy28/k3kJg0Fou5MiYpp88j7H9hLZp8PDC3jV0WFjfH5E9xHb56L0W59cPbKbcHXeP4qyT8PrHp8t6LcQ==",
+			"version": "2.6.20",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.20.tgz",
+			"integrity": "sha512-/WwNkdXfckNgw6S5R125rrW8ez139lBHWouiBvX8dfMFtcn6V81REDqnH7+CRpRipfYlyU1CmOnOxrmGcFOjeA==",
 			"dev": true
 		},
 		"node_modules/@emotion/hash": {
@@ -2682,9 +2682,9 @@
 			"dev": true
 		},
 		"node_modules/@emotion/styled-base/node_modules/csstype": {
-			"version": "2.6.19",
-			"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.19.tgz",
-			"integrity": "sha512-ZVxXaNy28/k3kJg0Fou5MiYpp88j7H9hLZp8PDC3jV0WFjfH5E9xHb56L0W59cPbKbcHXeP4qyT8PrHp8t6LcQ==",
+			"version": "2.6.20",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.20.tgz",
+			"integrity": "sha512-/WwNkdXfckNgw6S5R125rrW8ez139lBHWouiBvX8dfMFtcn6V81REDqnH7+CRpRipfYlyU1CmOnOxrmGcFOjeA==",
 			"dev": true
 		},
 		"node_modules/@emotion/stylis": {
@@ -2709,9 +2709,9 @@
 			"integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
 		},
 		"node_modules/@eslint/eslintrc": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.1.0.tgz",
-			"integrity": "sha512-C1DfL7XX4nPqGd6jcP01W9pVM1HYCuUkFk1432D7F0v3JSlUIeOYn9oCoi3eoLZ+iwBSb29BMFxxny0YrrEZqg==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.0.tgz",
+			"integrity": "sha512-igm9SjJHNEJRiUnecP/1R5T3wKLEJ7pL6e2P+GUSfCd0dGjPYYZve08uzw8L2J8foVHFz+NGu12JxRcU2gGo6w==",
 			"dev": true,
 			"dependencies": {
 				"ajv": "^6.12.4",
@@ -6236,9 +6236,9 @@
 			"link": true
 		},
 		"node_modules/@searchspring/snapi-types": {
-			"version": "0.1.23",
-			"resolved": "https://registry.npmjs.org/@searchspring/snapi-types/-/snapi-types-0.1.23.tgz",
-			"integrity": "sha512-LQfAEh6HKpvaHhkRRtCy/xwyN8vKfPMVlUQ/aUHmcw9DGjrF0/c2VBCwgc4I1TkRwOzOKA3Fpi5c3OsrCzyryg==",
+			"version": "0.1.24",
+			"resolved": "https://registry.npmjs.org/@searchspring/snapi-types/-/snapi-types-0.1.24.tgz",
+			"integrity": "sha512-GUuTDK64GOnGvYphj5lpaD36sm+68QC93i5qgliR80nRIIHrsJaUzTlsKLI0Mpek8VrpsD1q/wC5Ubj3thm11g==",
 			"dev": true
 		},
 		"node_modules/@sindresorhus/is": {
@@ -8605,9 +8605,9 @@
 			}
 		},
 		"node_modules/@storybook/builder-webpack5/node_modules/postcss": {
-			"version": "8.4.7",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.7.tgz",
-			"integrity": "sha512-L9Ye3r6hkkCeOETQX6iOaWZgjp3LL6Lpqm6EtgbKrgqGGteRMNb9vzBfRL96YOSu8o7x3MfIH9Mo5cPJFGrW6A==",
+			"version": "8.4.8",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.8.tgz",
+			"integrity": "sha512-2tXEqGxrjvAO6U+CJzDL2Fk2kPHTv1jQsYkSoMeOis2SsYaXRO2COxTdQp99cYvif9JTXaAk9lYGc3VhJt7JPQ==",
 			"dev": true,
 			"dependencies": {
 				"nanoid": "^3.3.1",
@@ -12577,9 +12577,9 @@
 			}
 		},
 		"node_modules/@storybook/manager-webpack5/node_modules/postcss": {
-			"version": "8.4.7",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.7.tgz",
-			"integrity": "sha512-L9Ye3r6hkkCeOETQX6iOaWZgjp3LL6Lpqm6EtgbKrgqGGteRMNb9vzBfRL96YOSu8o7x3MfIH9Mo5cPJFGrW6A==",
+			"version": "8.4.8",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.8.tgz",
+			"integrity": "sha512-2tXEqGxrjvAO6U+CJzDL2Fk2kPHTv1jQsYkSoMeOis2SsYaXRO2COxTdQp99cYvif9JTXaAk9lYGc3VhJt7JPQ==",
 			"dev": true,
 			"dependencies": {
 				"nanoid": "^3.3.1",
@@ -14217,9 +14217,9 @@
 			"dev": true
 		},
 		"node_modules/@types/testing-library__jest-dom": {
-			"version": "5.14.2",
-			"resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.2.tgz",
-			"integrity": "sha512-vehbtyHUShPxIa9SioxDwCvgxukDMH//icJG90sXQBUm5lJOHLT5kNeU9tnivhnA/TkOFMzGIXN2cTc4hY8/kg==",
+			"version": "5.14.3",
+			"resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.3.tgz",
+			"integrity": "sha512-oKZe+Mf4ioWlMuzVBaXQ9WDnEm1+umLx0InILg+yvZVBBDmzV5KfZyLrCvadtWcx8+916jLmHafcmqqffl+iIw==",
 			"dev": true,
 			"dependencies": {
 				"@types/jest": "*"
@@ -14287,9 +14287,9 @@
 			}
 		},
 		"node_modules/@types/ws": {
-			"version": "8.5.1",
-			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.1.tgz",
-			"integrity": "sha512-UxlLOfkuQnT2YSBCNq0x86SGOUxas6gAySFeDe2DcnEnA8655UIPoCDorWZCugcvKIL8IUI4oueUfJ1hhZSE2A==",
+			"version": "8.5.2",
+			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.2.tgz",
+			"integrity": "sha512-VXI82ykONr5tacHEojnErTQk+KQSoYbW1NB6iz6wUwrNd+BqfkfggQNoNdCqhJSzbNumShPERbM+Pc5zpfhlbw==",
 			"dev": true,
 			"dependencies": {
 				"@types/node": "*"
@@ -14305,9 +14305,9 @@
 			}
 		},
 		"node_modules/@types/yargs-parser": {
-			"version": "20.2.1",
-			"resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.1.tgz",
-			"integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==",
+			"version": "21.0.0",
+			"resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz",
+			"integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
 			"dev": true
 		},
 		"node_modules/@types/yauzl": {
@@ -14321,14 +14321,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "5.12.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.12.1.tgz",
-			"integrity": "sha512-M499lqa8rnNK7mUv74lSFFttuUsubIRdAbHcVaP93oFcKkEmHmLqy2n7jM9C8DVmFMYK61ExrZU6dLYhQZmUpw==",
+			"version": "5.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.14.0.tgz",
+			"integrity": "sha512-ir0wYI4FfFUDfLcuwKzIH7sMVA+db7WYen47iRSaCGl+HMAZI9fpBwfDo45ZALD3A45ZGyHWDNLhbg8tZrMX4w==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "5.12.1",
-				"@typescript-eslint/type-utils": "5.12.1",
-				"@typescript-eslint/utils": "5.12.1",
+				"@typescript-eslint/scope-manager": "5.14.0",
+				"@typescript-eslint/type-utils": "5.14.0",
+				"@typescript-eslint/utils": "5.14.0",
 				"debug": "^4.3.2",
 				"functional-red-black-tree": "^1.0.1",
 				"ignore": "^5.1.8",
@@ -14354,14 +14354,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "5.12.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.12.1.tgz",
-			"integrity": "sha512-6LuVUbe7oSdHxUWoX/m40Ni8gsZMKCi31rlawBHt7VtW15iHzjbpj2WLiToG2758KjtCCiLRKZqfrOdl3cNKuw==",
+			"version": "5.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.14.0.tgz",
+			"integrity": "sha512-aHJN8/FuIy1Zvqk4U/gcO/fxeMKyoSv/rS46UXMXOJKVsLQ+iYPuXNbpbH7cBLcpSbmyyFbwrniLx5+kutu1pw==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "5.12.1",
-				"@typescript-eslint/types": "5.12.1",
-				"@typescript-eslint/typescript-estree": "5.12.1",
+				"@typescript-eslint/scope-manager": "5.14.0",
+				"@typescript-eslint/types": "5.14.0",
+				"@typescript-eslint/typescript-estree": "5.14.0",
 				"debug": "^4.3.2"
 			},
 			"engines": {
@@ -14381,13 +14381,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "5.12.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.12.1.tgz",
-			"integrity": "sha512-J0Wrh5xS6XNkd4TkOosxdpObzlYfXjAFIm9QxYLCPOcHVv1FyyFCPom66uIh8uBr0sZCrtS+n19tzufhwab8ZQ==",
+			"version": "5.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.14.0.tgz",
+			"integrity": "sha512-LazdcMlGnv+xUc5R4qIlqH0OWARyl2kaP8pVCS39qSL3Pd1F7mI10DbdXeARcE62sVQE4fHNvEqMWsypWO+yEw==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "5.12.1",
-				"@typescript-eslint/visitor-keys": "5.12.1"
+				"@typescript-eslint/types": "5.14.0",
+				"@typescript-eslint/visitor-keys": "5.14.0"
 			},
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -14398,12 +14398,12 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "5.12.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.12.1.tgz",
-			"integrity": "sha512-Gh8feEhsNLeCz6aYqynh61Vsdy+tiNNkQtc+bN3IvQvRqHkXGUhYkUi+ePKzP0Mb42se7FDb+y2SypTbpbR/Sg==",
+			"version": "5.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.14.0.tgz",
+			"integrity": "sha512-d4PTJxsqaUpv8iERTDSQBKUCV7Q5yyXjqXUl3XF7Sd9ogNLuKLkxz82qxokqQ4jXdTPZudWpmNtr/JjbbvUixw==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/utils": "5.12.1",
+				"@typescript-eslint/utils": "5.14.0",
 				"debug": "^4.3.2",
 				"tsutils": "^3.21.0"
 			},
@@ -14424,9 +14424,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "5.12.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.12.1.tgz",
-			"integrity": "sha512-hfcbq4qVOHV1YRdhkDldhV9NpmmAu2vp6wuFODL71Y0Ixak+FLeEU4rnPxgmZMnGreGEghlEucs9UZn5KOfHJA==",
+			"version": "5.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.14.0.tgz",
+			"integrity": "sha512-BR6Y9eE9360LNnW3eEUqAg6HxS9Q35kSIs4rp4vNHRdfg0s+/PgHgskvu5DFTM7G5VKAVjuyaN476LCPrdA7Mw==",
 			"dev": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -14437,13 +14437,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "5.12.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.12.1.tgz",
-			"integrity": "sha512-ahOdkIY9Mgbza7L9sIi205Pe1inCkZWAHE1TV1bpxlU4RZNPtXaDZfiiFWcL9jdxvW1hDYZJXrFm+vlMkXRbBw==",
+			"version": "5.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.14.0.tgz",
+			"integrity": "sha512-QGnxvROrCVtLQ1724GLTHBTR0lZVu13izOp9njRvMkCBgWX26PKvmMP8k82nmXBRD3DQcFFq2oj3cKDwr0FaUA==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "5.12.1",
-				"@typescript-eslint/visitor-keys": "5.12.1",
+				"@typescript-eslint/types": "5.14.0",
+				"@typescript-eslint/visitor-keys": "5.14.0",
 				"debug": "^4.3.2",
 				"globby": "^11.0.4",
 				"is-glob": "^4.0.3",
@@ -14464,15 +14464,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "5.12.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.12.1.tgz",
-			"integrity": "sha512-Qq9FIuU0EVEsi8fS6pG+uurbhNTtoYr4fq8tKjBupsK5Bgbk2I32UGm0Sh+WOyjOPgo/5URbxxSNV6HYsxV4MQ==",
+			"version": "5.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.14.0.tgz",
+			"integrity": "sha512-EHwlII5mvUA0UsKYnVzySb/5EE/t03duUTweVy8Zqt3UQXBrpEVY144OTceFKaOe4xQXZJrkptCf7PjEBeGK4w==",
 			"dev": true,
 			"dependencies": {
 				"@types/json-schema": "^7.0.9",
-				"@typescript-eslint/scope-manager": "5.12.1",
-				"@typescript-eslint/types": "5.12.1",
-				"@typescript-eslint/typescript-estree": "5.12.1",
+				"@typescript-eslint/scope-manager": "5.14.0",
+				"@typescript-eslint/types": "5.14.0",
+				"@typescript-eslint/typescript-estree": "5.14.0",
 				"eslint-scope": "^5.1.1",
 				"eslint-utils": "^3.0.0"
 			},
@@ -14488,12 +14488,12 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "5.12.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.12.1.tgz",
-			"integrity": "sha512-l1KSLfupuwrXx6wc0AuOmC7Ko5g14ZOQ86wJJqRbdLbXLK02pK/DPiDDqCc7BqqiiA04/eAA6ayL0bgOrAkH7A==",
+			"version": "5.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.14.0.tgz",
+			"integrity": "sha512-yL0XxfzR94UEkjBqyymMLgCBdojzEuy/eim7N9/RIcTNxpJudAcqsU8eRyfzBbcEzGoPWfdM3AGak3cN08WOIw==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "5.12.1",
+				"@typescript-eslint/types": "5.14.0",
 				"eslint-visitor-keys": "^3.0.0"
 			},
 			"engines": {
@@ -15818,9 +15818,9 @@
 			"dev": true
 		},
 		"node_modules/babel-plugin-emotion/node_modules/csstype": {
-			"version": "2.6.19",
-			"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.19.tgz",
-			"integrity": "sha512-ZVxXaNy28/k3kJg0Fou5MiYpp88j7H9hLZp8PDC3jV0WFjfH5E9xHb56L0W59cPbKbcHXeP4qyT8PrHp8t6LcQ==",
+			"version": "2.6.20",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.20.tgz",
+			"integrity": "sha512-/WwNkdXfckNgw6S5R125rrW8ez139lBHWouiBvX8dfMFtcn6V81REDqnH7+CRpRipfYlyU1CmOnOxrmGcFOjeA==",
 			"dev": true
 		},
 		"node_modules/babel-plugin-emotion/node_modules/source-map": {
@@ -16517,12 +16517,12 @@
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.19.3",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.19.3.tgz",
-			"integrity": "sha512-XK3X4xtKJ+Txj8G5c30B4gsm71s69lqXlkYui4s6EkKxuv49qjYlY6oVd+IFJ73d4YymtM3+djvvt/R/iJwwDg==",
+			"version": "4.20.0",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.0.tgz",
+			"integrity": "sha512-bnpOoa+DownbciXj0jVGENf8VYQnE2LNWomhYuCsMmmx9Jd9lwq0WXODuwpSsp8AVdKM2/HorrzxAfbKvWTByQ==",
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001312",
-				"electron-to-chromium": "^1.4.71",
+				"caniuse-lite": "^1.0.30001313",
+				"electron-to-chromium": "^1.4.76",
 				"escalade": "^3.1.1",
 				"node-releases": "^2.0.2",
 				"picocolors": "^1.0.0"
@@ -16824,9 +16824,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001312",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001312.tgz",
-			"integrity": "sha512-Wiz1Psk2MEK0pX3rUzWaunLTZzqS2JYZFzNKqAiJGiuxIjRPLgV6+VDPOg6lQOUxmDwhTlh198JsTTi8Hzw6aQ==",
+			"version": "1.0.30001314",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001314.tgz",
+			"integrity": "sha512-0zaSO+TnCHtHJIbpLroX7nsD+vYuOVjl3uzFbJO1wMVbuveJA0RK2WcQA9ZUIOiO0/ArMiMgHJLxfEZhQiC0kw==",
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/browserslist"
@@ -17280,9 +17280,9 @@
 			"dev": true
 		},
 		"node_modules/cli-truncate/node_modules/string-width": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.0.tgz",
-			"integrity": "sha512-7x54QnN21P+XL/v8SuNKvfgsUre6PXpN7mc77N3HlZv+f1SBRGmjxtOud2Z6FZ8DmdkD/IdjCaf9XXbnqmTZGQ==",
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+			"integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
 			"dev": true,
 			"dependencies": {
 				"eastasianwidth": "^0.2.0",
@@ -18247,14 +18247,14 @@
 			}
 		},
 		"node_modules/cosmiconfig-typescript-loader": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-1.0.5.tgz",
-			"integrity": "sha512-FL/YR1nb8hyN0bAcP3MBaIoZravfZtVsN/RuPnoo6UVjqIrDxSNIpXHCGgJe0ZWy5yImpyD6jq5wCJ5f1nUv8g==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-1.0.6.tgz",
+			"integrity": "sha512-2nEotziYJWtNtoTjKbchj9QrdTT6DBxCvqjNKoDKARw+e2yZmTQCa07uRrykLIZuvSgp69YXLH89UHc0WhdMfQ==",
 			"dev": true,
 			"optional": true,
 			"dependencies": {
 				"cosmiconfig": "^7",
-				"ts-node": "^10.5.0"
+				"ts-node": "^10.6.0"
 			},
 			"engines": {
 				"node": ">=12",
@@ -18716,13 +18716,13 @@
 			}
 		},
 		"node_modules/css-loader": {
-			"version": "6.6.0",
-			"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.6.0.tgz",
-			"integrity": "sha512-FK7H2lisOixPT406s5gZM1S3l8GrfhEBT3ZiL2UX1Ng1XWs0y2GPllz/OTyvbaHe12VgQrIXIzuEGVlbUhodqg==",
+			"version": "6.7.1",
+			"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.7.1.tgz",
+			"integrity": "sha512-yB5CNFa14MbPJcomwNh3wLThtkZgcNyI2bNMRt8iE5Z8Vwl7f8vQXFAzn2HDOJvtDq2NTZBUGMSUNNyrv3/+cw==",
 			"dev": true,
 			"dependencies": {
 				"icss-utils": "^5.1.0",
-				"postcss": "^8.4.5",
+				"postcss": "^8.4.7",
 				"postcss-modules-extract-imports": "^3.0.0",
 				"postcss-modules-local-by-default": "^4.0.0",
 				"postcss-modules-scope": "^3.0.0",
@@ -18754,9 +18754,9 @@
 			}
 		},
 		"node_modules/css-loader/node_modules/postcss": {
-			"version": "8.4.7",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.7.tgz",
-			"integrity": "sha512-L9Ye3r6hkkCeOETQX6iOaWZgjp3LL6Lpqm6EtgbKrgqGGteRMNb9vzBfRL96YOSu8o7x3MfIH9Mo5cPJFGrW6A==",
+			"version": "8.4.8",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.8.tgz",
+			"integrity": "sha512-2tXEqGxrjvAO6U+CJzDL2Fk2kPHTv1jQsYkSoMeOis2SsYaXRO2COxTdQp99cYvif9JTXaAk9lYGc3VhJt7JPQ==",
 			"dev": true,
 			"dependencies": {
 				"nanoid": "^3.3.1",
@@ -18901,9 +18901,9 @@
 			"dev": true
 		},
 		"node_modules/csstype": {
-			"version": "3.0.10",
-			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
-			"integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA=="
+			"version": "3.0.11",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.11.tgz",
+			"integrity": "sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw=="
 		},
 		"node_modules/cyclist": {
 			"version": "1.0.1",
@@ -19241,9 +19241,9 @@
 			}
 		},
 		"node_modules/cypress/node_modules/rxjs": {
-			"version": "7.5.4",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.4.tgz",
-			"integrity": "sha512-h5M3Hk78r6wAheJF0a5YahB1yRQKCsZ4MsGdZ5O9ETbVtjPcScGfrMmoOq7EBsCRzd4BDkvDJ7ogP8Sz5tTFiQ==",
+			"version": "7.5.5",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.5.tgz",
+			"integrity": "sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==",
 			"dev": true,
 			"dependencies": {
 				"tslib": "^2.1.0"
@@ -19384,9 +19384,9 @@
 			}
 		},
 		"node_modules/dayjs": {
-			"version": "1.10.7",
-			"resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.7.tgz",
-			"integrity": "sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig==",
+			"version": "1.10.8",
+			"resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.8.tgz",
+			"integrity": "sha512-wbNwDfBHHur9UOzNUjeKUOJ0fCb0a52Wx0xInmQ7Y8FstyajiV1NmK1e00cxsr9YrE9r7yAChE0VvpuY5Rnlow==",
 			"dev": true
 		},
 		"node_modules/debug": {
@@ -19827,9 +19827,9 @@
 			}
 		},
 		"node_modules/dom-accessibility-api": {
-			"version": "0.5.12",
-			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.12.tgz",
-			"integrity": "sha512-gQ2mON6fLWZeM8ubjzL7RtMeHS/g8hb82j4MjHmcQECD7pevWsMlhqwp9BjIRrQvmyJMMyv/XiO1cXzeFlUw4g==",
+			"version": "0.5.13",
+			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.13.tgz",
+			"integrity": "sha512-R305kwb5CcMDIpSHUnLyIAp7SrSPBx6F0VfQFB3M75xVMHhXJJIdePYgbPPh1o57vCHNu5QztokWUPsLjWzFqw==",
 			"dev": true
 		},
 		"node_modules/dom-converter": {
@@ -20130,9 +20130,9 @@
 			"dev": true
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.73",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.73.tgz",
-			"integrity": "sha512-RlCffXkE/LliqfA5m29+dVDPB2r72y2D2egMMfIy3Le8ODrxjuZNVo4NIC2yPL01N4xb4nZQLwzi6Z5tGIGLnA=="
+			"version": "1.4.77",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.77.tgz",
+			"integrity": "sha512-fiDxw8mO9Ph1Z0bjX2sFTPpi0J0QkOiwOJF+5Q0J0baNc/F9lLePAvDPlnoxvbUYYMizqrKPeotRRkJ9LtxAew=="
 		},
 		"node_modules/element-resize-detector": {
 			"version": "1.2.4",
@@ -20248,9 +20248,9 @@
 			}
 		},
 		"node_modules/enhanced-resolve": {
-			"version": "5.9.1",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.9.1.tgz",
-			"integrity": "sha512-jdyZMwCQ5Oj4c5+BTnkxPgDZO/BJzh/ADDmKebayyzNwjVX1AFCeGkOfxNx0mHi2+8BKC5VxUYiw3TIvoT7vhw==",
+			"version": "5.9.2",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.9.2.tgz",
+			"integrity": "sha512-GIm3fQfwLJ8YZx2smuHpBKkXC1yOk+OBEmKckVyL0i/ea8mqDEykK3ld5dgH1QYPNyT/lIllxV2LULnxCHaHkA==",
 			"dev": true,
 			"dependencies": {
 				"graceful-fs": "^4.2.4",
@@ -20545,12 +20545,12 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "8.9.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.9.0.tgz",
-			"integrity": "sha512-PB09IGwv4F4b0/atrbcMFboF/giawbBLVC7fyDamk5Wtey4Jh2K+rYaBhCAbUyEI4QzB1ly09Uglc9iCtFaG2Q==",
+			"version": "8.10.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.10.0.tgz",
+			"integrity": "sha512-tcI1D9lfVec+R4LE1mNDnzoJ/f71Kl/9Cv4nG47jOueCMBrCCKYXr4AUVS7go6mWYGFD4+EoN6+eXSrEbRzXVw==",
 			"dev": true,
 			"dependencies": {
-				"@eslint/eslintrc": "^1.1.0",
+				"@eslint/eslintrc": "^1.2.0",
 				"@humanwhocodes/config-array": "^0.9.2",
 				"ajv": "^6.10.0",
 				"chalk": "^4.0.0",
@@ -20597,9 +20597,9 @@
 			}
 		},
 		"node_modules/eslint-config-prettier": {
-			"version": "8.4.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.4.0.tgz",
-			"integrity": "sha512-CFotdUcMY18nGRo5KGsnNxpznzhkopOcOo0InID+sgQssPrzjvsyKZPvOgymTFeHrFuC3Tzdf2YndhXtULK9Iw==",
+			"version": "8.5.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
+			"integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
 			"dev": true,
 			"bin": {
 				"eslint-config-prettier": "bin/cli.js"
@@ -20609,9 +20609,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-react": {
-			"version": "7.29.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.29.1.tgz",
-			"integrity": "sha512-WtzRpHMhsOX05ZrkyaaqmLl2uXGqmYooCfBxftJKlkYdsltiufGgfU7uuoHwR2lBam2Kh/EIVID4aU9e3kbCMA==",
+			"version": "7.29.3",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.29.3.tgz",
+			"integrity": "sha512-MzW6TuCnDOcta67CkpDyRfRsEVx9FNMDV8wZsDqe1luHPdGTrQIUaUXD27Ja3gHsdOIs/cXzNchWGlqm+qRVRg==",
 			"dev": true,
 			"dependencies": {
 				"array-includes": "^3.1.4",
@@ -21759,13 +21759,13 @@
 			}
 		},
 		"node_modules/find-node-modules": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/find-node-modules/-/find-node-modules-2.1.2.tgz",
-			"integrity": "sha512-x+3P4mbtRPlSiVE1Qco0Z4YLU8WFiFcuWTf3m75OV9Uzcfs2Bg+O9N+r/K0AnmINBW06KpfqKwYJbFlFq4qNug==",
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/find-node-modules/-/find-node-modules-2.1.3.tgz",
+			"integrity": "sha512-UC2I2+nx1ZuOBclWVNdcnbDR5dlrOdVb7xNjmT/lHE+LsgztWks3dG7boJ37yTS/venXw84B/mAW9uHVoC5QRg==",
 			"dev": true,
 			"dependencies": {
 				"findup-sync": "^4.0.0",
-				"merge": "^2.1.0"
+				"merge": "^2.1.1"
 			}
 		},
 		"node_modules/find-root": {
@@ -22990,9 +22990,9 @@
 			}
 		},
 		"node_modules/has-symbols": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-			"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+			"integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
 			"dev": true,
 			"engines": {
 				"node": ">= 0.4"
@@ -23508,9 +23508,9 @@
 			"dev": true
 		},
 		"node_modules/http-parser-js": {
-			"version": "0.5.5",
-			"resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.5.tgz",
-			"integrity": "sha512-x+JVEkO2PoM8qqpbPbOL3cqHPwerep7OwzK7Ay+sMQjKzaKCqWvjoXm5tqMP9tXWWTnTzAjIhXg+J99XYuPhPA==",
+			"version": "0.5.6",
+			"resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.6.tgz",
+			"integrity": "sha512-vDlkRPDJn93swjcjqMSaGSPABbIarsr1TLAui/gLDXzV5VsJNdXNzMYDyNBLQkjWQCJ1uizu8T2oDMhmGt0PRA==",
 			"dev": true
 		},
 		"node_modules/http-proxy": {
@@ -23937,9 +23937,9 @@
 			}
 		},
 		"node_modules/init-package-json/node_modules/read-package-json": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-4.1.1.tgz",
-			"integrity": "sha512-P82sbZJ3ldDrWCOSKxJT0r/CXMWR0OR3KRh55SgKo3p91GSIEEC32v3lSHAvO/UcH3/IoL7uqhOFBduAnwdldw==",
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-4.1.2.tgz",
+			"integrity": "sha512-Dqer4pqzamDE2O4M55xp1qZMuLPqi4ldk2ya648FOMHRjwMzFhuxVrG04wd0c38IsvkVdr3vgHI6z+QTPdAjrQ==",
 			"dev": true,
 			"dependencies": {
 				"glob": "^7.1.1",
@@ -27789,9 +27789,9 @@
 			"integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
 		},
 		"node_modules/lint-staged": {
-			"version": "12.3.4",
-			"resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-12.3.4.tgz",
-			"integrity": "sha512-yv/iK4WwZ7/v0GtVkNb3R82pdL9M+ScpIbJLJNyCXkJ1FGaXvRCOg/SeL59SZtPpqZhE7BD6kPKFLIDUhDx2/w==",
+			"version": "12.3.5",
+			"resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-12.3.5.tgz",
+			"integrity": "sha512-oOH36RUs1It7b9U/C7Nl/a0sLfoIBcMB8ramiB3nuJ6brBqzsWiUAFSR5DQ3yyP/OR7XKMpijtgKl2DV1lQ3lA==",
 			"dev": true,
 			"dependencies": {
 				"cli-truncate": "^3.1.0",
@@ -27916,9 +27916,9 @@
 			}
 		},
 		"node_modules/listr2/node_modules/rxjs": {
-			"version": "7.5.4",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.4.tgz",
-			"integrity": "sha512-h5M3Hk78r6wAheJF0a5YahB1yRQKCsZ4MsGdZ5O9ETbVtjPcScGfrMmoOq7EBsCRzd4BDkvDJ7ogP8Sz5tTFiQ==",
+			"version": "7.5.5",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.5.tgz",
+			"integrity": "sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==",
 			"dev": true,
 			"dependencies": {
 				"tslib": "^2.1.0"
@@ -28598,9 +28598,9 @@
 			}
 		},
 		"node_modules/markdown-to-jsx": {
-			"version": "7.1.6",
-			"resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.1.6.tgz",
-			"integrity": "sha512-1wrIGZYwIG2gR3yfRmbr4FlQmhaAKoKTpRo4wur4fp9p0njU1Hi7vR8fj0AUKKIcPduiJmPprzmCB5B/GvlC7g==",
+			"version": "7.1.7",
+			"resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.1.7.tgz",
+			"integrity": "sha512-VI3TyyHlGkO8uFle0IOibzpO1c1iJDcXcS/zBrQrXQQvJ2tpdwVzVZ7XdKsyRz1NdRmre4dqQkMZzUHaKIG/1w==",
 			"dev": true,
 			"engines": {
 				"node": ">= 10"
@@ -32212,9 +32212,9 @@
 			}
 		},
 		"node_modules/react-router": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/react-router/-/react-router-6.2.1.tgz",
-			"integrity": "sha512-2fG0udBtxou9lXtK97eJeET2ki5//UWfQSl1rlJ7quwe6jrktK9FCCc8dQb5QY6jAv3jua8bBQRhhDOM/kVRsg==",
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/react-router/-/react-router-6.2.2.tgz",
+			"integrity": "sha512-/MbxyLzd7Q7amp4gDOGaYvXwhEojkJD5BtExkuKmj39VEE0m3l/zipf6h2WIB2jyAO0lI6NGETh4RDcktRm4AQ==",
 			"dev": true,
 			"dependencies": {
 				"history": "^5.2.0"
@@ -32224,13 +32224,13 @@
 			}
 		},
 		"node_modules/react-router-dom": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.2.1.tgz",
-			"integrity": "sha512-I6Zax+/TH/cZMDpj3/4Fl2eaNdcvoxxHoH1tYOREsQ22OKDYofGebrNm6CTPUcvLvZm63NL/vzCYdjf9CUhqmA==",
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.2.2.tgz",
+			"integrity": "sha512-AtYEsAST7bDD4dLSQHDnk/qxWLJdad5t1HFa1qJyUrCeGgEuCSw0VB/27ARbF9Fi/W5598ujvJOm3ujUCVzuYQ==",
 			"dev": true,
 			"dependencies": {
 				"history": "^5.2.0",
-				"react-router": "6.2.1"
+				"react-router": "6.2.2"
 			},
 			"peerDependencies": {
 				"react": ">=16.8",
@@ -35704,9 +35704,9 @@
 			}
 		},
 		"node_modules/terser": {
-			"version": "5.11.0",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.11.0.tgz",
-			"integrity": "sha512-uCA9DLanzzWSsN1UirKwylhhRz3aKPInlfmpGfw8VN6jHsAtu8HJtIpeeHHK23rxnE/cDc+yvmq5wqkIC6Kn0A==",
+			"version": "5.12.0",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.12.0.tgz",
+			"integrity": "sha512-R3AUhNBGWiFc77HXag+1fXpAxTAFRQTJemlJKjAgD9r8xXTpjNKqIXwHM/o7Rh+O0kUJtS3WQVdBeMKFk5sw9A==",
 			"dev": true,
 			"dependencies": {
 				"acorn": "^8.5.0",
@@ -36126,9 +36126,9 @@
 			}
 		},
 		"node_modules/ts-loader": {
-			"version": "9.2.6",
-			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.2.6.tgz",
-			"integrity": "sha512-QMTC4UFzHmu9wU2VHZEmWWE9cUajjfcdcws+Gh7FhiO+Dy0RnR1bNz0YCHqhI0yRowCE9arVnNxYHqELOy9Hjw==",
+			"version": "9.2.7",
+			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.2.7.tgz",
+			"integrity": "sha512-Fxh44mKli9QezgbdCXkEJWxnedQ0ead7DXTH+lfXEPedu+Y9EtMJ2aQ9G3Dj1j7Q612E8931rww8NDZha4Tibg==",
 			"dev": true,
 			"dependencies": {
 				"chalk": "^4.1.0",
@@ -36215,9 +36215,9 @@
 			}
 		},
 		"node_modules/ts-node": {
-			"version": "10.5.0",
-			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.5.0.tgz",
-			"integrity": "sha512-6kEJKwVxAJ35W4akuiysfKwKmjkbYxwQMTBaAxo9KKAx/Yd26mPUyhGz3ji+EsJoAgrLqVsYHNuuYwQe22lbtw==",
+			"version": "10.7.0",
+			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.7.0.tgz",
+			"integrity": "sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==",
 			"dev": true,
 			"optional": true,
 			"dependencies": {
@@ -36238,6 +36238,7 @@
 			"bin": {
 				"ts-node": "dist/bin.js",
 				"ts-node-cwd": "dist/bin-cwd.js",
+				"ts-node-esm": "dist/bin-esm.js",
 				"ts-node-script": "dist/bin-script.js",
 				"ts-node-transpile-only": "dist/bin-transpile.js",
 				"ts-script": "dist/bin-script-deprecated.js"
@@ -36388,16 +36389,16 @@
 			}
 		},
 		"node_modules/typedoc": {
-			"version": "0.22.12",
-			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.12.tgz",
-			"integrity": "sha512-FcyC+YuaOpr3rB9QwA1IHOi9KnU2m50sPJW5vcNRPCIdecp+3bFkh7Rq5hBU1Fyn29UR2h4h/H7twZHWDhL0sw==",
+			"version": "0.22.13",
+			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.13.tgz",
+			"integrity": "sha512-NHNI7Dr6JHa/I3+c62gdRNXBIyX7P33O9TafGLd07ur3MqzcKgwTvpg18EtvCLHJyfeSthAtCLpM7WkStUmDuQ==",
 			"dev": true,
 			"dependencies": {
 				"glob": "^7.2.0",
 				"lunr": "^2.3.9",
-				"marked": "^4.0.10",
-				"minimatch": "^3.0.4",
-				"shiki": "^0.10.0"
+				"marked": "^4.0.12",
+				"minimatch": "^5.0.1",
+				"shiki": "^0.10.1"
 			},
 			"bin": {
 				"typedoc": "bin/typedoc"
@@ -36406,7 +36407,7 @@
 				"node": ">= 12.10.0"
 			},
 			"peerDependencies": {
-				"typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x || 4.5.x"
+				"typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x || 4.5.x || 4.6.x"
 			}
 		},
 		"node_modules/typedoc/node_modules/glob": {
@@ -36429,10 +36430,43 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/typedoc/node_modules/glob/node_modules/minimatch": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/typedoc/node_modules/minimatch": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
+			"integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/typedoc/node_modules/minimatch/node_modules/brace-expansion": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"dev": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
 		"node_modules/typescript": {
-			"version": "4.5.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-			"integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
+			"integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",
@@ -36443,9 +36477,9 @@
 			}
 		},
 		"node_modules/uglify-js": {
-			"version": "3.15.1",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.1.tgz",
-			"integrity": "sha512-FAGKF12fWdkpvNJZENacOH0e/83eG6JyVQyanIJaBXCN1J11TUQv1T1/z8S+Z0CG0ZPk1nPcreF/c7lrTd0TEQ==",
+			"version": "3.15.2",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.2.tgz",
+			"integrity": "sha512-peeoTk3hSwYdoc9nrdiEJk+gx1ALCtTjdYuKSXMTDqq7n1W7dHPqWDdSi+BPL0ni2YMeHD7hKUSdbj3TZauY2A==",
 			"dev": true,
 			"optional": true,
 			"bin": {
@@ -38046,9 +38080,9 @@
 			}
 		},
 		"node_modules/webpack": {
-			"version": "5.69.1",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.69.1.tgz",
-			"integrity": "sha512-+VyvOSJXZMT2V5vLzOnDuMz5GxEqLk7hKWQ56YxPW/PQRUuKimPqmEIJOx8jHYeyo65pKbapbW464mvsKbaj4A==",
+			"version": "5.70.0",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.70.0.tgz",
+			"integrity": "sha512-ZMWWy8CeuTTjCxbeaQI21xSswseF2oNOwc70QSKNePvmxE7XW36i7vpBMYZFAUHPwQiEbNGCEYIOOlyRbdGmxw==",
 			"dev": true,
 			"dependencies": {
 				"@types/eslint-scope": "^3.7.3",
@@ -38060,7 +38094,7 @@
 				"acorn-import-assertions": "^1.7.6",
 				"browserslist": "^4.14.5",
 				"chrome-trace-event": "^1.0.2",
-				"enhanced-resolve": "^5.8.3",
+				"enhanced-resolve": "^5.9.2",
 				"es-module-lexer": "^0.9.0",
 				"eslint-scope": "5.1.1",
 				"events": "^3.2.0",
@@ -39183,55 +39217,55 @@
 		},
 		"packages/snap-client": {
 			"name": "@searchspring/snap-client",
-			"version": "0.20.5",
+			"version": "0.21.1",
 			"license": "MIT",
 			"dependencies": {
-				"@searchspring/snap-toolbox": "^0.20.5",
+				"@searchspring/snap-toolbox": "^0.21.1",
 				"deepmerge": "^4.2.2"
 			}
 		},
 		"packages/snap-controller": {
 			"name": "@searchspring/snap-controller",
-			"version": "0.20.5",
+			"version": "0.21.1",
 			"license": "MIT",
 			"dependencies": {
-				"@searchspring/snap-toolbox": "^0.20.5",
+				"@searchspring/snap-toolbox": "^0.21.1",
 				"deepmerge": "^4.2.2"
 			},
 			"devDependencies": {
-				"@searchspring/snap-client": "^0.20.5",
-				"@searchspring/snap-event-manager": "^0.20.5",
-				"@searchspring/snap-logger": "^0.20.5",
-				"@searchspring/snap-profiler": "^0.20.5",
-				"@searchspring/snap-store-mobx": "^0.20.5",
-				"@searchspring/snap-tracker": "^0.20.5",
-				"@searchspring/snap-url-manager": "^0.20.5"
+				"@searchspring/snap-client": "^0.21.1",
+				"@searchspring/snap-event-manager": "^0.21.1",
+				"@searchspring/snap-logger": "^0.21.1",
+				"@searchspring/snap-profiler": "^0.21.1",
+				"@searchspring/snap-store-mobx": "^0.21.1",
+				"@searchspring/snap-tracker": "^0.21.1",
+				"@searchspring/snap-url-manager": "^0.21.1"
 			}
 		},
 		"packages/snap-event-manager": {
 			"name": "@searchspring/snap-event-manager",
-			"version": "0.20.5",
+			"version": "0.21.1",
 			"license": "MIT"
 		},
 		"packages/snap-logger": {
 			"name": "@searchspring/snap-logger",
-			"version": "0.20.5",
+			"version": "0.21.1",
 			"license": "MIT"
 		},
 		"packages/snap-preact": {
 			"name": "@searchspring/snap-preact",
-			"version": "0.20.5",
+			"version": "0.21.1",
 			"license": "MIT",
 			"dependencies": {
-				"@searchspring/snap-client": "^0.20.5",
-				"@searchspring/snap-controller": "^0.20.5",
-				"@searchspring/snap-event-manager": "^0.20.5",
-				"@searchspring/snap-logger": "^0.20.5",
-				"@searchspring/snap-profiler": "^0.20.5",
-				"@searchspring/snap-store-mobx": "^0.20.5",
-				"@searchspring/snap-toolbox": "^0.20.5",
-				"@searchspring/snap-tracker": "^0.20.5",
-				"@searchspring/snap-url-manager": "^0.20.5",
+				"@searchspring/snap-client": "^0.21.1",
+				"@searchspring/snap-controller": "^0.21.1",
+				"@searchspring/snap-event-manager": "^0.21.1",
+				"@searchspring/snap-logger": "^0.21.1",
+				"@searchspring/snap-profiler": "^0.21.1",
+				"@searchspring/snap-store-mobx": "^0.21.1",
+				"@searchspring/snap-toolbox": "^0.21.1",
+				"@searchspring/snap-tracker": "^0.21.1",
+				"@searchspring/snap-url-manager": "^0.21.1",
 				"deepmerge": "^4.2.2",
 				"intersection-observer": "^0.12.0"
 			},
@@ -39241,12 +39275,12 @@
 		},
 		"packages/snap-preact-components": {
 			"name": "@searchspring/snap-preact-components",
-			"version": "0.20.5",
+			"version": "0.21.1",
 			"license": "MIT",
 			"dependencies": {
 				"@emotion/react": "^11.7.1",
-				"@searchspring/snap-preact": "^0.20.5",
-				"@searchspring/snap-toolbox": "^0.20.5",
+				"@searchspring/snap-preact": "^0.21.1",
+				"@searchspring/snap-toolbox": "^0.21.1",
 				"classnames": "^2.3.1",
 				"deepmerge": "^4.2.2",
 				"mobx-react-lite": "^3.2.3",
@@ -39255,13 +39289,13 @@
 			},
 			"devDependencies": {
 				"@mdx-js/loader": "^1.6.22",
-				"@searchspring/snap-client": "^0.20.5",
-				"@searchspring/snap-controller": "^0.20.5",
-				"@searchspring/snap-event-manager": "^0.20.5",
-				"@searchspring/snap-logger": "^0.20.5",
-				"@searchspring/snap-profiler": "^0.20.5",
-				"@searchspring/snap-store-mobx": "^0.20.5",
-				"@searchspring/snap-url-manager": "^0.20.5",
+				"@searchspring/snap-client": "^0.21.1",
+				"@searchspring/snap-controller": "^0.21.1",
+				"@searchspring/snap-event-manager": "^0.21.1",
+				"@searchspring/snap-logger": "^0.21.1",
+				"@searchspring/snap-profiler": "^0.21.1",
+				"@searchspring/snap-store-mobx": "^0.21.1",
+				"@searchspring/snap-url-manager": "^0.21.1",
 				"@storybook/addon-actions": "^6.4.9",
 				"@storybook/addon-controls": "^6.4.9",
 				"@storybook/addon-docs": "^6.4.9",
@@ -39644,11 +39678,11 @@
 		},
 		"packages/snap-preact-demo": {
 			"name": "@searchspring/snap-preact-demo",
-			"version": "0.20.5",
+			"version": "0.21.1",
 			"license": "MIT",
 			"dependencies": {
-				"@searchspring/snap-preact": "^0.20.5",
-				"@searchspring/snap-preact-components": "^0.20.5",
+				"@searchspring/snap-preact": "^0.21.1",
+				"@searchspring/snap-preact-components": "^0.21.1",
 				"deepmerge": "^4.2.2",
 				"mobx": "^6.3.12",
 				"mobx-react": "^7.2.1",
@@ -39682,41 +39716,41 @@
 		},
 		"packages/snap-profiler": {
 			"name": "@searchspring/snap-profiler",
-			"version": "0.20.5",
+			"version": "0.21.1",
 			"license": "MIT"
 		},
 		"packages/snap-shared": {
 			"name": "@searchspring/snap-shared",
-			"version": "0.20.5",
+			"version": "0.21.1",
 			"license": "MIT",
 			"devDependencies": {
-				"@searchspring/snap-client": "^0.20.5"
+				"@searchspring/snap-client": "^0.21.1"
 			}
 		},
 		"packages/snap-store-mobx": {
 			"name": "@searchspring/snap-store-mobx",
-			"version": "0.20.5",
+			"version": "0.21.1",
 			"license": "MIT",
 			"dependencies": {
-				"@searchspring/snap-toolbox": "^0.20.5",
+				"@searchspring/snap-toolbox": "^0.21.1",
 				"mobx": "^6.3.12"
 			},
 			"devDependencies": {
-				"@searchspring/snap-url-manager": "^0.20.5"
+				"@searchspring/snap-url-manager": "^0.21.1"
 			}
 		},
 		"packages/snap-toolbox": {
 			"name": "@searchspring/snap-toolbox",
-			"version": "0.20.5",
+			"version": "0.21.1",
 			"license": "MIT"
 		},
 		"packages/snap-tracker": {
 			"name": "@searchspring/snap-tracker",
-			"version": "0.20.5",
+			"version": "0.21.1",
 			"license": "MIT",
 			"dependencies": {
-				"@searchspring/snap-store-mobx": "^0.20.5",
-				"@searchspring/snap-toolbox": "^0.20.5",
+				"@searchspring/snap-store-mobx": "^0.21.1",
+				"@searchspring/snap-toolbox": "^0.21.1",
 				"deepmerge": "^4.2.2",
 				"uuid": "^8.3.2"
 			}
@@ -39731,7 +39765,7 @@
 		},
 		"packages/snap-url-manager": {
 			"name": "@searchspring/snap-url-manager",
-			"version": "0.20.5",
+			"version": "0.21.1",
 			"license": "MIT",
 			"dependencies": {
 				"deepmerge": "^4.2.2",
@@ -41519,9 +41553,9 @@
 					"dev": true
 				},
 				"csstype": {
-					"version": "2.6.19",
-					"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.19.tgz",
-					"integrity": "sha512-ZVxXaNy28/k3kJg0Fou5MiYpp88j7H9hLZp8PDC3jV0WFjfH5E9xHb56L0W59cPbKbcHXeP4qyT8PrHp8t6LcQ==",
+					"version": "2.6.20",
+					"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.20.tgz",
+					"integrity": "sha512-/WwNkdXfckNgw6S5R125rrW8ez139lBHWouiBvX8dfMFtcn6V81REDqnH7+CRpRipfYlyU1CmOnOxrmGcFOjeA==",
 					"dev": true
 				}
 			}
@@ -41563,9 +41597,9 @@
 					"dev": true
 				},
 				"csstype": {
-					"version": "2.6.19",
-					"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.19.tgz",
-					"integrity": "sha512-ZVxXaNy28/k3kJg0Fou5MiYpp88j7H9hLZp8PDC3jV0WFjfH5E9xHb56L0W59cPbKbcHXeP4qyT8PrHp8t6LcQ==",
+					"version": "2.6.20",
+					"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.20.tgz",
+					"integrity": "sha512-/WwNkdXfckNgw6S5R125rrW8ez139lBHWouiBvX8dfMFtcn6V81REDqnH7+CRpRipfYlyU1CmOnOxrmGcFOjeA==",
 					"dev": true
 				}
 			}
@@ -41677,9 +41711,9 @@
 					"dev": true
 				},
 				"csstype": {
-					"version": "2.6.19",
-					"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.19.tgz",
-					"integrity": "sha512-ZVxXaNy28/k3kJg0Fou5MiYpp88j7H9hLZp8PDC3jV0WFjfH5E9xHb56L0W59cPbKbcHXeP4qyT8PrHp8t6LcQ==",
+					"version": "2.6.20",
+					"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.20.tgz",
+					"integrity": "sha512-/WwNkdXfckNgw6S5R125rrW8ez139lBHWouiBvX8dfMFtcn6V81REDqnH7+CRpRipfYlyU1CmOnOxrmGcFOjeA==",
 					"dev": true
 				}
 			}
@@ -41706,9 +41740,9 @@
 			"integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
 		},
 		"@eslint/eslintrc": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.1.0.tgz",
-			"integrity": "sha512-C1DfL7XX4nPqGd6jcP01W9pVM1HYCuUkFk1432D7F0v3JSlUIeOYn9oCoi3eoLZ+iwBSb29BMFxxny0YrrEZqg==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.0.tgz",
+			"integrity": "sha512-igm9SjJHNEJRiUnecP/1R5T3wKLEJ7pL6e2P+GUSfCd0dGjPYYZve08uzw8L2J8foVHFz+NGu12JxRcU2gGo6w==",
 			"dev": true,
 			"requires": {
 				"ajv": "^6.12.4",
@@ -44486,21 +44520,21 @@
 		"@searchspring/snap-client": {
 			"version": "file:packages/snap-client",
 			"requires": {
-				"@searchspring/snap-toolbox": "^0.20.5",
+				"@searchspring/snap-toolbox": "^0.21.1",
 				"deepmerge": "^4.2.2"
 			}
 		},
 		"@searchspring/snap-controller": {
 			"version": "file:packages/snap-controller",
 			"requires": {
-				"@searchspring/snap-client": "^0.20.5",
-				"@searchspring/snap-event-manager": "^0.20.5",
-				"@searchspring/snap-logger": "^0.20.5",
-				"@searchspring/snap-profiler": "^0.20.5",
-				"@searchspring/snap-store-mobx": "^0.20.5",
-				"@searchspring/snap-toolbox": "^0.20.5",
-				"@searchspring/snap-tracker": "^0.20.5",
-				"@searchspring/snap-url-manager": "^0.20.5",
+				"@searchspring/snap-client": "^0.21.1",
+				"@searchspring/snap-event-manager": "^0.21.1",
+				"@searchspring/snap-logger": "^0.21.1",
+				"@searchspring/snap-profiler": "^0.21.1",
+				"@searchspring/snap-store-mobx": "^0.21.1",
+				"@searchspring/snap-toolbox": "^0.21.1",
+				"@searchspring/snap-tracker": "^0.21.1",
+				"@searchspring/snap-url-manager": "^0.21.1",
 				"deepmerge": "^4.2.2"
 			}
 		},
@@ -44513,15 +44547,15 @@
 		"@searchspring/snap-preact": {
 			"version": "file:packages/snap-preact",
 			"requires": {
-				"@searchspring/snap-client": "^0.20.5",
-				"@searchspring/snap-controller": "^0.20.5",
-				"@searchspring/snap-event-manager": "^0.20.5",
-				"@searchspring/snap-logger": "^0.20.5",
-				"@searchspring/snap-profiler": "^0.20.5",
-				"@searchspring/snap-store-mobx": "^0.20.5",
-				"@searchspring/snap-toolbox": "^0.20.5",
-				"@searchspring/snap-tracker": "^0.20.5",
-				"@searchspring/snap-url-manager": "^0.20.5",
+				"@searchspring/snap-client": "^0.21.1",
+				"@searchspring/snap-controller": "^0.21.1",
+				"@searchspring/snap-event-manager": "^0.21.1",
+				"@searchspring/snap-logger": "^0.21.1",
+				"@searchspring/snap-profiler": "^0.21.1",
+				"@searchspring/snap-store-mobx": "^0.21.1",
+				"@searchspring/snap-toolbox": "^0.21.1",
+				"@searchspring/snap-tracker": "^0.21.1",
+				"@searchspring/snap-url-manager": "^0.21.1",
 				"@types/react": "^17.0.20",
 				"deepmerge": "^4.2.2",
 				"intersection-observer": "^0.12.0"
@@ -44532,15 +44566,15 @@
 			"requires": {
 				"@emotion/react": "^11.7.1",
 				"@mdx-js/loader": "^1.6.22",
-				"@searchspring/snap-client": "^0.20.5",
-				"@searchspring/snap-controller": "^0.20.5",
-				"@searchspring/snap-event-manager": "^0.20.5",
-				"@searchspring/snap-logger": "^0.20.5",
-				"@searchspring/snap-preact": "^0.20.5",
-				"@searchspring/snap-profiler": "^0.20.5",
-				"@searchspring/snap-store-mobx": "^0.20.5",
-				"@searchspring/snap-toolbox": "^0.20.5",
-				"@searchspring/snap-url-manager": "^0.20.5",
+				"@searchspring/snap-client": "^0.21.1",
+				"@searchspring/snap-controller": "^0.21.1",
+				"@searchspring/snap-event-manager": "^0.21.1",
+				"@searchspring/snap-logger": "^0.21.1",
+				"@searchspring/snap-preact": "^0.21.1",
+				"@searchspring/snap-profiler": "^0.21.1",
+				"@searchspring/snap-store-mobx": "^0.21.1",
+				"@searchspring/snap-toolbox": "^0.21.1",
+				"@searchspring/snap-url-manager": "^0.21.1",
 				"@storybook/addon-actions": "^6.4.9",
 				"@storybook/addon-controls": "^6.4.9",
 				"@storybook/addon-docs": "^6.4.9",
@@ -44812,8 +44846,8 @@
 				"@babel/runtime": "^7.16.7",
 				"@lhci/cli": "^0.8.2",
 				"@searchspring/browserslist-config-snap": "^1.0.5",
-				"@searchspring/snap-preact": "^0.20.5",
-				"@searchspring/snap-preact-components": "^0.20.5",
+				"@searchspring/snap-preact": "^0.21.1",
+				"@searchspring/snap-preact-components": "^0.21.1",
 				"babel-loader": "^8.2.3",
 				"core-js": "^3.20.2",
 				"css-loader": "^6.5.1",
@@ -44839,14 +44873,14 @@
 		"@searchspring/snap-shared": {
 			"version": "file:packages/snap-shared",
 			"requires": {
-				"@searchspring/snap-client": "^0.20.5"
+				"@searchspring/snap-client": "^0.21.1"
 			}
 		},
 		"@searchspring/snap-store-mobx": {
 			"version": "file:packages/snap-store-mobx",
 			"requires": {
-				"@searchspring/snap-toolbox": "^0.20.5",
-				"@searchspring/snap-url-manager": "^0.20.5",
+				"@searchspring/snap-toolbox": "^0.21.1",
+				"@searchspring/snap-url-manager": "^0.21.1",
 				"mobx": "^6.3.12"
 			}
 		},
@@ -44856,8 +44890,8 @@
 		"@searchspring/snap-tracker": {
 			"version": "file:packages/snap-tracker",
 			"requires": {
-				"@searchspring/snap-store-mobx": "^0.20.5",
-				"@searchspring/snap-toolbox": "^0.20.5",
+				"@searchspring/snap-store-mobx": "^0.21.1",
+				"@searchspring/snap-toolbox": "^0.21.1",
 				"deepmerge": "^4.2.2",
 				"uuid": "^8.3.2"
 			},
@@ -44877,9 +44911,9 @@
 			}
 		},
 		"@searchspring/snapi-types": {
-			"version": "0.1.23",
-			"resolved": "https://registry.npmjs.org/@searchspring/snapi-types/-/snapi-types-0.1.23.tgz",
-			"integrity": "sha512-LQfAEh6HKpvaHhkRRtCy/xwyN8vKfPMVlUQ/aUHmcw9DGjrF0/c2VBCwgc4I1TkRwOzOKA3Fpi5c3OsrCzyryg==",
+			"version": "0.1.24",
+			"resolved": "https://registry.npmjs.org/@searchspring/snapi-types/-/snapi-types-0.1.24.tgz",
+			"integrity": "sha512-GUuTDK64GOnGvYphj5lpaD36sm+68QC93i5qgliR80nRIIHrsJaUzTlsKLI0Mpek8VrpsD1q/wC5Ubj3thm11g==",
 			"dev": true
 		},
 		"@sindresorhus/is": {
@@ -46621,9 +46655,9 @@
 					"requires": {}
 				},
 				"postcss": {
-					"version": "8.4.7",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.7.tgz",
-					"integrity": "sha512-L9Ye3r6hkkCeOETQX6iOaWZgjp3LL6Lpqm6EtgbKrgqGGteRMNb9vzBfRL96YOSu8o7x3MfIH9Mo5cPJFGrW6A==",
+					"version": "8.4.8",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.8.tgz",
+					"integrity": "sha512-2tXEqGxrjvAO6U+CJzDL2Fk2kPHTv1jQsYkSoMeOis2SsYaXRO2COxTdQp99cYvif9JTXaAk9lYGc3VhJt7JPQ==",
 					"dev": true,
 					"requires": {
 						"nanoid": "^3.3.1",
@@ -49759,9 +49793,9 @@
 					}
 				},
 				"postcss": {
-					"version": "8.4.7",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.7.tgz",
-					"integrity": "sha512-L9Ye3r6hkkCeOETQX6iOaWZgjp3LL6Lpqm6EtgbKrgqGGteRMNb9vzBfRL96YOSu8o7x3MfIH9Mo5cPJFGrW6A==",
+					"version": "8.4.8",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.8.tgz",
+					"integrity": "sha512-2tXEqGxrjvAO6U+CJzDL2Fk2kPHTv1jQsYkSoMeOis2SsYaXRO2COxTdQp99cYvif9JTXaAk9lYGc3VhJt7JPQ==",
 					"dev": true,
 					"requires": {
 						"nanoid": "^3.3.1",
@@ -51088,9 +51122,9 @@
 			"dev": true
 		},
 		"@types/testing-library__jest-dom": {
-			"version": "5.14.2",
-			"resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.2.tgz",
-			"integrity": "sha512-vehbtyHUShPxIa9SioxDwCvgxukDMH//icJG90sXQBUm5lJOHLT5kNeU9tnivhnA/TkOFMzGIXN2cTc4hY8/kg==",
+			"version": "5.14.3",
+			"resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.3.tgz",
+			"integrity": "sha512-oKZe+Mf4ioWlMuzVBaXQ9WDnEm1+umLx0InILg+yvZVBBDmzV5KfZyLrCvadtWcx8+916jLmHafcmqqffl+iIw==",
 			"dev": true,
 			"requires": {
 				"@types/jest": "*"
@@ -51157,9 +51191,9 @@
 			}
 		},
 		"@types/ws": {
-			"version": "8.5.1",
-			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.1.tgz",
-			"integrity": "sha512-UxlLOfkuQnT2YSBCNq0x86SGOUxas6gAySFeDe2DcnEnA8655UIPoCDorWZCugcvKIL8IUI4oueUfJ1hhZSE2A==",
+			"version": "8.5.2",
+			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.2.tgz",
+			"integrity": "sha512-VXI82ykONr5tacHEojnErTQk+KQSoYbW1NB6iz6wUwrNd+BqfkfggQNoNdCqhJSzbNumShPERbM+Pc5zpfhlbw==",
 			"dev": true,
 			"requires": {
 				"@types/node": "*"
@@ -51175,9 +51209,9 @@
 			}
 		},
 		"@types/yargs-parser": {
-			"version": "20.2.1",
-			"resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.1.tgz",
-			"integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==",
+			"version": "21.0.0",
+			"resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz",
+			"integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
 			"dev": true
 		},
 		"@types/yauzl": {
@@ -51191,14 +51225,14 @@
 			}
 		},
 		"@typescript-eslint/eslint-plugin": {
-			"version": "5.12.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.12.1.tgz",
-			"integrity": "sha512-M499lqa8rnNK7mUv74lSFFttuUsubIRdAbHcVaP93oFcKkEmHmLqy2n7jM9C8DVmFMYK61ExrZU6dLYhQZmUpw==",
+			"version": "5.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.14.0.tgz",
+			"integrity": "sha512-ir0wYI4FfFUDfLcuwKzIH7sMVA+db7WYen47iRSaCGl+HMAZI9fpBwfDo45ZALD3A45ZGyHWDNLhbg8tZrMX4w==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/scope-manager": "5.12.1",
-				"@typescript-eslint/type-utils": "5.12.1",
-				"@typescript-eslint/utils": "5.12.1",
+				"@typescript-eslint/scope-manager": "5.14.0",
+				"@typescript-eslint/type-utils": "5.14.0",
+				"@typescript-eslint/utils": "5.14.0",
 				"debug": "^4.3.2",
 				"functional-red-black-tree": "^1.0.1",
 				"ignore": "^5.1.8",
@@ -51208,52 +51242,52 @@
 			}
 		},
 		"@typescript-eslint/parser": {
-			"version": "5.12.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.12.1.tgz",
-			"integrity": "sha512-6LuVUbe7oSdHxUWoX/m40Ni8gsZMKCi31rlawBHt7VtW15iHzjbpj2WLiToG2758KjtCCiLRKZqfrOdl3cNKuw==",
+			"version": "5.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.14.0.tgz",
+			"integrity": "sha512-aHJN8/FuIy1Zvqk4U/gcO/fxeMKyoSv/rS46UXMXOJKVsLQ+iYPuXNbpbH7cBLcpSbmyyFbwrniLx5+kutu1pw==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/scope-manager": "5.12.1",
-				"@typescript-eslint/types": "5.12.1",
-				"@typescript-eslint/typescript-estree": "5.12.1",
+				"@typescript-eslint/scope-manager": "5.14.0",
+				"@typescript-eslint/types": "5.14.0",
+				"@typescript-eslint/typescript-estree": "5.14.0",
 				"debug": "^4.3.2"
 			}
 		},
 		"@typescript-eslint/scope-manager": {
-			"version": "5.12.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.12.1.tgz",
-			"integrity": "sha512-J0Wrh5xS6XNkd4TkOosxdpObzlYfXjAFIm9QxYLCPOcHVv1FyyFCPom66uIh8uBr0sZCrtS+n19tzufhwab8ZQ==",
+			"version": "5.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.14.0.tgz",
+			"integrity": "sha512-LazdcMlGnv+xUc5R4qIlqH0OWARyl2kaP8pVCS39qSL3Pd1F7mI10DbdXeARcE62sVQE4fHNvEqMWsypWO+yEw==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "5.12.1",
-				"@typescript-eslint/visitor-keys": "5.12.1"
+				"@typescript-eslint/types": "5.14.0",
+				"@typescript-eslint/visitor-keys": "5.14.0"
 			}
 		},
 		"@typescript-eslint/type-utils": {
-			"version": "5.12.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.12.1.tgz",
-			"integrity": "sha512-Gh8feEhsNLeCz6aYqynh61Vsdy+tiNNkQtc+bN3IvQvRqHkXGUhYkUi+ePKzP0Mb42se7FDb+y2SypTbpbR/Sg==",
+			"version": "5.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.14.0.tgz",
+			"integrity": "sha512-d4PTJxsqaUpv8iERTDSQBKUCV7Q5yyXjqXUl3XF7Sd9ogNLuKLkxz82qxokqQ4jXdTPZudWpmNtr/JjbbvUixw==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/utils": "5.12.1",
+				"@typescript-eslint/utils": "5.14.0",
 				"debug": "^4.3.2",
 				"tsutils": "^3.21.0"
 			}
 		},
 		"@typescript-eslint/types": {
-			"version": "5.12.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.12.1.tgz",
-			"integrity": "sha512-hfcbq4qVOHV1YRdhkDldhV9NpmmAu2vp6wuFODL71Y0Ixak+FLeEU4rnPxgmZMnGreGEghlEucs9UZn5KOfHJA==",
+			"version": "5.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.14.0.tgz",
+			"integrity": "sha512-BR6Y9eE9360LNnW3eEUqAg6HxS9Q35kSIs4rp4vNHRdfg0s+/PgHgskvu5DFTM7G5VKAVjuyaN476LCPrdA7Mw==",
 			"dev": true
 		},
 		"@typescript-eslint/typescript-estree": {
-			"version": "5.12.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.12.1.tgz",
-			"integrity": "sha512-ahOdkIY9Mgbza7L9sIi205Pe1inCkZWAHE1TV1bpxlU4RZNPtXaDZfiiFWcL9jdxvW1hDYZJXrFm+vlMkXRbBw==",
+			"version": "5.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.14.0.tgz",
+			"integrity": "sha512-QGnxvROrCVtLQ1724GLTHBTR0lZVu13izOp9njRvMkCBgWX26PKvmMP8k82nmXBRD3DQcFFq2oj3cKDwr0FaUA==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "5.12.1",
-				"@typescript-eslint/visitor-keys": "5.12.1",
+				"@typescript-eslint/types": "5.14.0",
+				"@typescript-eslint/visitor-keys": "5.14.0",
 				"debug": "^4.3.2",
 				"globby": "^11.0.4",
 				"is-glob": "^4.0.3",
@@ -51262,26 +51296,26 @@
 			}
 		},
 		"@typescript-eslint/utils": {
-			"version": "5.12.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.12.1.tgz",
-			"integrity": "sha512-Qq9FIuU0EVEsi8fS6pG+uurbhNTtoYr4fq8tKjBupsK5Bgbk2I32UGm0Sh+WOyjOPgo/5URbxxSNV6HYsxV4MQ==",
+			"version": "5.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.14.0.tgz",
+			"integrity": "sha512-EHwlII5mvUA0UsKYnVzySb/5EE/t03duUTweVy8Zqt3UQXBrpEVY144OTceFKaOe4xQXZJrkptCf7PjEBeGK4w==",
 			"dev": true,
 			"requires": {
 				"@types/json-schema": "^7.0.9",
-				"@typescript-eslint/scope-manager": "5.12.1",
-				"@typescript-eslint/types": "5.12.1",
-				"@typescript-eslint/typescript-estree": "5.12.1",
+				"@typescript-eslint/scope-manager": "5.14.0",
+				"@typescript-eslint/types": "5.14.0",
+				"@typescript-eslint/typescript-estree": "5.14.0",
 				"eslint-scope": "^5.1.1",
 				"eslint-utils": "^3.0.0"
 			}
 		},
 		"@typescript-eslint/visitor-keys": {
-			"version": "5.12.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.12.1.tgz",
-			"integrity": "sha512-l1KSLfupuwrXx6wc0AuOmC7Ko5g14ZOQ86wJJqRbdLbXLK02pK/DPiDDqCc7BqqiiA04/eAA6ayL0bgOrAkH7A==",
+			"version": "5.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.14.0.tgz",
+			"integrity": "sha512-yL0XxfzR94UEkjBqyymMLgCBdojzEuy/eim7N9/RIcTNxpJudAcqsU8eRyfzBbcEzGoPWfdM3AGak3cN08WOIw==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "5.12.1",
+				"@typescript-eslint/types": "5.14.0",
 				"eslint-visitor-keys": "^3.0.0"
 			}
 		},
@@ -52376,9 +52410,9 @@
 					"dev": true
 				},
 				"csstype": {
-					"version": "2.6.19",
-					"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.19.tgz",
-					"integrity": "sha512-ZVxXaNy28/k3kJg0Fou5MiYpp88j7H9hLZp8PDC3jV0WFjfH5E9xHb56L0W59cPbKbcHXeP4qyT8PrHp8t6LcQ==",
+					"version": "2.6.20",
+					"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.20.tgz",
+					"integrity": "sha512-/WwNkdXfckNgw6S5R125rrW8ez139lBHWouiBvX8dfMFtcn6V81REDqnH7+CRpRipfYlyU1CmOnOxrmGcFOjeA==",
 					"dev": true
 				},
 				"source-map": {
@@ -52946,12 +52980,12 @@
 			}
 		},
 		"browserslist": {
-			"version": "4.19.3",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.19.3.tgz",
-			"integrity": "sha512-XK3X4xtKJ+Txj8G5c30B4gsm71s69lqXlkYui4s6EkKxuv49qjYlY6oVd+IFJ73d4YymtM3+djvvt/R/iJwwDg==",
+			"version": "4.20.0",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.0.tgz",
+			"integrity": "sha512-bnpOoa+DownbciXj0jVGENf8VYQnE2LNWomhYuCsMmmx9Jd9lwq0WXODuwpSsp8AVdKM2/HorrzxAfbKvWTByQ==",
 			"requires": {
-				"caniuse-lite": "^1.0.30001312",
-				"electron-to-chromium": "^1.4.71",
+				"caniuse-lite": "^1.0.30001313",
+				"electron-to-chromium": "^1.4.76",
 				"escalade": "^3.1.1",
 				"node-releases": "^2.0.2",
 				"picocolors": "^1.0.0"
@@ -53190,9 +53224,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001312",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001312.tgz",
-			"integrity": "sha512-Wiz1Psk2MEK0pX3rUzWaunLTZzqS2JYZFzNKqAiJGiuxIjRPLgV6+VDPOg6lQOUxmDwhTlh198JsTTi8Hzw6aQ=="
+			"version": "1.0.30001314",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001314.tgz",
+			"integrity": "sha512-0zaSO+TnCHtHJIbpLroX7nsD+vYuOVjl3uzFbJO1wMVbuveJA0RK2WcQA9ZUIOiO0/ArMiMgHJLxfEZhQiC0kw=="
 		},
 		"capture-exit": {
 			"version": "2.0.0",
@@ -53532,9 +53566,9 @@
 					"dev": true
 				},
 				"string-width": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.0.tgz",
-					"integrity": "sha512-7x54QnN21P+XL/v8SuNKvfgsUre6PXpN7mc77N3HlZv+f1SBRGmjxtOud2Z6FZ8DmdkD/IdjCaf9XXbnqmTZGQ==",
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+					"integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
 					"dev": true,
 					"requires": {
 						"eastasianwidth": "^0.2.0",
@@ -54303,14 +54337,14 @@
 			}
 		},
 		"cosmiconfig-typescript-loader": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-1.0.5.tgz",
-			"integrity": "sha512-FL/YR1nb8hyN0bAcP3MBaIoZravfZtVsN/RuPnoo6UVjqIrDxSNIpXHCGgJe0ZWy5yImpyD6jq5wCJ5f1nUv8g==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-1.0.6.tgz",
+			"integrity": "sha512-2nEotziYJWtNtoTjKbchj9QrdTT6DBxCvqjNKoDKARw+e2yZmTQCa07uRrykLIZuvSgp69YXLH89UHc0WhdMfQ==",
 			"dev": true,
 			"optional": true,
 			"requires": {
 				"cosmiconfig": "^7",
-				"ts-node": "^10.5.0"
+				"ts-node": "^10.6.0"
 			}
 		},
 		"cp-file": {
@@ -54690,13 +54724,13 @@
 			}
 		},
 		"css-loader": {
-			"version": "6.6.0",
-			"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.6.0.tgz",
-			"integrity": "sha512-FK7H2lisOixPT406s5gZM1S3l8GrfhEBT3ZiL2UX1Ng1XWs0y2GPllz/OTyvbaHe12VgQrIXIzuEGVlbUhodqg==",
+			"version": "6.7.1",
+			"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.7.1.tgz",
+			"integrity": "sha512-yB5CNFa14MbPJcomwNh3wLThtkZgcNyI2bNMRt8iE5Z8Vwl7f8vQXFAzn2HDOJvtDq2NTZBUGMSUNNyrv3/+cw==",
 			"dev": true,
 			"requires": {
 				"icss-utils": "^5.1.0",
-				"postcss": "^8.4.5",
+				"postcss": "^8.4.7",
 				"postcss-modules-extract-imports": "^3.0.0",
 				"postcss-modules-local-by-default": "^4.0.0",
 				"postcss-modules-scope": "^3.0.0",
@@ -54713,9 +54747,9 @@
 					"requires": {}
 				},
 				"postcss": {
-					"version": "8.4.7",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.7.tgz",
-					"integrity": "sha512-L9Ye3r6hkkCeOETQX6iOaWZgjp3LL6Lpqm6EtgbKrgqGGteRMNb9vzBfRL96YOSu8o7x3MfIH9Mo5cPJFGrW6A==",
+					"version": "8.4.8",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.8.tgz",
+					"integrity": "sha512-2tXEqGxrjvAO6U+CJzDL2Fk2kPHTv1jQsYkSoMeOis2SsYaXRO2COxTdQp99cYvif9JTXaAk9lYGc3VhJt7JPQ==",
 					"dev": true,
 					"requires": {
 						"nanoid": "^3.3.1",
@@ -54816,9 +54850,9 @@
 			}
 		},
 		"csstype": {
-			"version": "3.0.10",
-			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
-			"integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA=="
+			"version": "3.0.11",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.11.tgz",
+			"integrity": "sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw=="
 		},
 		"cyclist": {
 			"version": "1.0.1",
@@ -55069,9 +55103,9 @@
 					}
 				},
 				"rxjs": {
-					"version": "7.5.4",
-					"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.4.tgz",
-					"integrity": "sha512-h5M3Hk78r6wAheJF0a5YahB1yRQKCsZ4MsGdZ5O9ETbVtjPcScGfrMmoOq7EBsCRzd4BDkvDJ7ogP8Sz5tTFiQ==",
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.5.tgz",
+					"integrity": "sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==",
 					"dev": true,
 					"requires": {
 						"tslib": "^2.1.0"
@@ -55179,9 +55213,9 @@
 			"dev": true
 		},
 		"dayjs": {
-			"version": "1.10.7",
-			"resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.7.tgz",
-			"integrity": "sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig==",
+			"version": "1.10.8",
+			"resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.8.tgz",
+			"integrity": "sha512-wbNwDfBHHur9UOzNUjeKUOJ0fCb0a52Wx0xInmQ7Y8FstyajiV1NmK1e00cxsr9YrE9r7yAChE0VvpuY5Rnlow==",
 			"dev": true
 		},
 		"debug": {
@@ -55537,9 +55571,9 @@
 			}
 		},
 		"dom-accessibility-api": {
-			"version": "0.5.12",
-			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.12.tgz",
-			"integrity": "sha512-gQ2mON6fLWZeM8ubjzL7RtMeHS/g8hb82j4MjHmcQECD7pevWsMlhqwp9BjIRrQvmyJMMyv/XiO1cXzeFlUw4g==",
+			"version": "0.5.13",
+			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.13.tgz",
+			"integrity": "sha512-R305kwb5CcMDIpSHUnLyIAp7SrSPBx6F0VfQFB3M75xVMHhXJJIdePYgbPPh1o57vCHNu5QztokWUPsLjWzFqw==",
 			"dev": true
 		},
 		"dom-converter": {
@@ -55796,9 +55830,9 @@
 			"dev": true
 		},
 		"electron-to-chromium": {
-			"version": "1.4.73",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.73.tgz",
-			"integrity": "sha512-RlCffXkE/LliqfA5m29+dVDPB2r72y2D2egMMfIy3Le8ODrxjuZNVo4NIC2yPL01N4xb4nZQLwzi6Z5tGIGLnA=="
+			"version": "1.4.77",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.77.tgz",
+			"integrity": "sha512-fiDxw8mO9Ph1Z0bjX2sFTPpi0J0QkOiwOJF+5Q0J0baNc/F9lLePAvDPlnoxvbUYYMizqrKPeotRRkJ9LtxAew=="
 		},
 		"element-resize-detector": {
 			"version": "1.2.4",
@@ -55899,9 +55933,9 @@
 			}
 		},
 		"enhanced-resolve": {
-			"version": "5.9.1",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.9.1.tgz",
-			"integrity": "sha512-jdyZMwCQ5Oj4c5+BTnkxPgDZO/BJzh/ADDmKebayyzNwjVX1AFCeGkOfxNx0mHi2+8BKC5VxUYiw3TIvoT7vhw==",
+			"version": "5.9.2",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.9.2.tgz",
+			"integrity": "sha512-GIm3fQfwLJ8YZx2smuHpBKkXC1yOk+OBEmKckVyL0i/ea8mqDEykK3ld5dgH1QYPNyT/lIllxV2LULnxCHaHkA==",
 			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.2.4",
@@ -56130,12 +56164,12 @@
 			}
 		},
 		"eslint": {
-			"version": "8.9.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.9.0.tgz",
-			"integrity": "sha512-PB09IGwv4F4b0/atrbcMFboF/giawbBLVC7fyDamk5Wtey4Jh2K+rYaBhCAbUyEI4QzB1ly09Uglc9iCtFaG2Q==",
+			"version": "8.10.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.10.0.tgz",
+			"integrity": "sha512-tcI1D9lfVec+R4LE1mNDnzoJ/f71Kl/9Cv4nG47jOueCMBrCCKYXr4AUVS7go6mWYGFD4+EoN6+eXSrEbRzXVw==",
 			"dev": true,
 			"requires": {
-				"@eslint/eslintrc": "^1.1.0",
+				"@eslint/eslintrc": "^1.2.0",
 				"@humanwhocodes/config-array": "^0.9.2",
 				"ajv": "^6.10.0",
 				"chalk": "^4.0.0",
@@ -56246,16 +56280,16 @@
 			}
 		},
 		"eslint-config-prettier": {
-			"version": "8.4.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.4.0.tgz",
-			"integrity": "sha512-CFotdUcMY18nGRo5KGsnNxpznzhkopOcOo0InID+sgQssPrzjvsyKZPvOgymTFeHrFuC3Tzdf2YndhXtULK9Iw==",
+			"version": "8.5.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
+			"integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
 			"dev": true,
 			"requires": {}
 		},
 		"eslint-plugin-react": {
-			"version": "7.29.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.29.1.tgz",
-			"integrity": "sha512-WtzRpHMhsOX05ZrkyaaqmLl2uXGqmYooCfBxftJKlkYdsltiufGgfU7uuoHwR2lBam2Kh/EIVID4aU9e3kbCMA==",
+			"version": "7.29.3",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.29.3.tgz",
+			"integrity": "sha512-MzW6TuCnDOcta67CkpDyRfRsEVx9FNMDV8wZsDqe1luHPdGTrQIUaUXD27Ja3gHsdOIs/cXzNchWGlqm+qRVRg==",
 			"dev": true,
 			"requires": {
 				"array-includes": "^3.1.4",
@@ -57081,13 +57115,13 @@
 			}
 		},
 		"find-node-modules": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/find-node-modules/-/find-node-modules-2.1.2.tgz",
-			"integrity": "sha512-x+3P4mbtRPlSiVE1Qco0Z4YLU8WFiFcuWTf3m75OV9Uzcfs2Bg+O9N+r/K0AnmINBW06KpfqKwYJbFlFq4qNug==",
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/find-node-modules/-/find-node-modules-2.1.3.tgz",
+			"integrity": "sha512-UC2I2+nx1ZuOBclWVNdcnbDR5dlrOdVb7xNjmT/lHE+LsgztWks3dG7boJ37yTS/venXw84B/mAW9uHVoC5QRg==",
 			"dev": true,
 			"requires": {
 				"findup-sync": "^4.0.0",
-				"merge": "^2.1.0"
+				"merge": "^2.1.1"
 			}
 		},
 		"find-root": {
@@ -58042,9 +58076,9 @@
 			}
 		},
 		"has-symbols": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-			"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+			"integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
 			"dev": true
 		},
 		"has-tostringtag": {
@@ -58452,9 +58486,9 @@
 			"dev": true
 		},
 		"http-parser-js": {
-			"version": "0.5.5",
-			"resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.5.tgz",
-			"integrity": "sha512-x+JVEkO2PoM8qqpbPbOL3cqHPwerep7OwzK7Ay+sMQjKzaKCqWvjoXm5tqMP9tXWWTnTzAjIhXg+J99XYuPhPA==",
+			"version": "0.5.6",
+			"resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.6.tgz",
+			"integrity": "sha512-vDlkRPDJn93swjcjqMSaGSPABbIarsr1TLAui/gLDXzV5VsJNdXNzMYDyNBLQkjWQCJ1uizu8T2oDMhmGt0PRA==",
 			"dev": true
 		},
 		"http-proxy": {
@@ -58765,9 +58799,9 @@
 			},
 			"dependencies": {
 				"read-package-json": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-4.1.1.tgz",
-					"integrity": "sha512-P82sbZJ3ldDrWCOSKxJT0r/CXMWR0OR3KRh55SgKo3p91GSIEEC32v3lSHAvO/UcH3/IoL7uqhOFBduAnwdldw==",
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-4.1.2.tgz",
+					"integrity": "sha512-Dqer4pqzamDE2O4M55xp1qZMuLPqi4ldk2ya648FOMHRjwMzFhuxVrG04wd0c38IsvkVdr3vgHI6z+QTPdAjrQ==",
 					"dev": true,
 					"requires": {
 						"glob": "^7.1.1",
@@ -61678,9 +61712,9 @@
 			"integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
 		},
 		"lint-staged": {
-			"version": "12.3.4",
-			"resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-12.3.4.tgz",
-			"integrity": "sha512-yv/iK4WwZ7/v0GtVkNb3R82pdL9M+ScpIbJLJNyCXkJ1FGaXvRCOg/SeL59SZtPpqZhE7BD6kPKFLIDUhDx2/w==",
+			"version": "12.3.5",
+			"resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-12.3.5.tgz",
+			"integrity": "sha512-oOH36RUs1It7b9U/C7Nl/a0sLfoIBcMB8ramiB3nuJ6brBqzsWiUAFSR5DQ3yyP/OR7XKMpijtgKl2DV1lQ3lA==",
 			"dev": true,
 			"requires": {
 				"cli-truncate": "^3.1.0",
@@ -61763,9 +61797,9 @@
 					"dev": true
 				},
 				"rxjs": {
-					"version": "7.5.4",
-					"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.4.tgz",
-					"integrity": "sha512-h5M3Hk78r6wAheJF0a5YahB1yRQKCsZ4MsGdZ5O9ETbVtjPcScGfrMmoOq7EBsCRzd4BDkvDJ7ogP8Sz5tTFiQ==",
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.5.tgz",
+					"integrity": "sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==",
 					"dev": true,
 					"requires": {
 						"tslib": "^2.1.0"
@@ -62307,9 +62341,9 @@
 			"dev": true
 		},
 		"markdown-to-jsx": {
-			"version": "7.1.6",
-			"resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.1.6.tgz",
-			"integrity": "sha512-1wrIGZYwIG2gR3yfRmbr4FlQmhaAKoKTpRo4wur4fp9p0njU1Hi7vR8fj0AUKKIcPduiJmPprzmCB5B/GvlC7g==",
+			"version": "7.1.7",
+			"resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.1.7.tgz",
+			"integrity": "sha512-VI3TyyHlGkO8uFle0IOibzpO1c1iJDcXcS/zBrQrXQQvJ2tpdwVzVZ7XdKsyRz1NdRmre4dqQkMZzUHaKIG/1w==",
 			"dev": true,
 			"requires": {}
 		},
@@ -65144,9 +65178,9 @@
 			"requires": {}
 		},
 		"react-router": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/react-router/-/react-router-6.2.1.tgz",
-			"integrity": "sha512-2fG0udBtxou9lXtK97eJeET2ki5//UWfQSl1rlJ7quwe6jrktK9FCCc8dQb5QY6jAv3jua8bBQRhhDOM/kVRsg==",
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/react-router/-/react-router-6.2.2.tgz",
+			"integrity": "sha512-/MbxyLzd7Q7amp4gDOGaYvXwhEojkJD5BtExkuKmj39VEE0m3l/zipf6h2WIB2jyAO0lI6NGETh4RDcktRm4AQ==",
 			"dev": true,
 			"requires": {
 				"history": "^5.2.0"
@@ -65164,13 +65198,13 @@
 			}
 		},
 		"react-router-dom": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.2.1.tgz",
-			"integrity": "sha512-I6Zax+/TH/cZMDpj3/4Fl2eaNdcvoxxHoH1tYOREsQ22OKDYofGebrNm6CTPUcvLvZm63NL/vzCYdjf9CUhqmA==",
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.2.2.tgz",
+			"integrity": "sha512-AtYEsAST7bDD4dLSQHDnk/qxWLJdad5t1HFa1qJyUrCeGgEuCSw0VB/27ARbF9Fi/W5598ujvJOm3ujUCVzuYQ==",
 			"dev": true,
 			"requires": {
 				"history": "^5.2.0",
-				"react-router": "6.2.1"
+				"react-router": "6.2.2"
 			},
 			"dependencies": {
 				"history": {
@@ -67898,9 +67932,9 @@
 			}
 		},
 		"terser": {
-			"version": "5.11.0",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.11.0.tgz",
-			"integrity": "sha512-uCA9DLanzzWSsN1UirKwylhhRz3aKPInlfmpGfw8VN6jHsAtu8HJtIpeeHHK23rxnE/cDc+yvmq5wqkIC6Kn0A==",
+			"version": "5.12.0",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.12.0.tgz",
+			"integrity": "sha512-R3AUhNBGWiFc77HXag+1fXpAxTAFRQTJemlJKjAgD9r8xXTpjNKqIXwHM/o7Rh+O0kUJtS3WQVdBeMKFk5sw9A==",
 			"dev": true,
 			"requires": {
 				"acorn": "^8.5.0",
@@ -68196,9 +68230,9 @@
 			}
 		},
 		"ts-loader": {
-			"version": "9.2.6",
-			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.2.6.tgz",
-			"integrity": "sha512-QMTC4UFzHmu9wU2VHZEmWWE9cUajjfcdcws+Gh7FhiO+Dy0RnR1bNz0YCHqhI0yRowCE9arVnNxYHqELOy9Hjw==",
+			"version": "9.2.7",
+			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.2.7.tgz",
+			"integrity": "sha512-Fxh44mKli9QezgbdCXkEJWxnedQ0ead7DXTH+lfXEPedu+Y9EtMJ2aQ9G3Dj1j7Q612E8931rww8NDZha4Tibg==",
 			"dev": true,
 			"requires": {
 				"chalk": "^4.1.0",
@@ -68259,9 +68293,9 @@
 			}
 		},
 		"ts-node": {
-			"version": "10.5.0",
-			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.5.0.tgz",
-			"integrity": "sha512-6kEJKwVxAJ35W4akuiysfKwKmjkbYxwQMTBaAxo9KKAx/Yd26mPUyhGz3ji+EsJoAgrLqVsYHNuuYwQe22lbtw==",
+			"version": "10.7.0",
+			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.7.0.tgz",
+			"integrity": "sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==",
 			"dev": true,
 			"optional": true,
 			"requires": {
@@ -68378,16 +68412,16 @@
 			}
 		},
 		"typedoc": {
-			"version": "0.22.12",
-			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.12.tgz",
-			"integrity": "sha512-FcyC+YuaOpr3rB9QwA1IHOi9KnU2m50sPJW5vcNRPCIdecp+3bFkh7Rq5hBU1Fyn29UR2h4h/H7twZHWDhL0sw==",
+			"version": "0.22.13",
+			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.13.tgz",
+			"integrity": "sha512-NHNI7Dr6JHa/I3+c62gdRNXBIyX7P33O9TafGLd07ur3MqzcKgwTvpg18EtvCLHJyfeSthAtCLpM7WkStUmDuQ==",
 			"dev": true,
 			"requires": {
 				"glob": "^7.2.0",
 				"lunr": "^2.3.9",
-				"marked": "^4.0.10",
-				"minimatch": "^3.0.4",
-				"shiki": "^0.10.0"
+				"marked": "^4.0.12",
+				"minimatch": "^5.0.1",
+				"shiki": "^0.10.1"
 			},
 			"dependencies": {
 				"glob": {
@@ -68402,20 +68436,51 @@
 						"minimatch": "^3.0.4",
 						"once": "^1.3.0",
 						"path-is-absolute": "^1.0.0"
+					},
+					"dependencies": {
+						"minimatch": {
+							"version": "3.1.2",
+							"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+							"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+							"dev": true,
+							"requires": {
+								"brace-expansion": "^1.1.7"
+							}
+						}
+					}
+				},
+				"minimatch": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
+					"integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
+					"dev": true,
+					"requires": {
+						"brace-expansion": "^2.0.1"
+					},
+					"dependencies": {
+						"brace-expansion": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+							"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+							"dev": true,
+							"requires": {
+								"balanced-match": "^1.0.0"
+							}
+						}
 					}
 				}
 			}
 		},
 		"typescript": {
-			"version": "4.5.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-			"integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
+			"integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
 			"dev": true
 		},
 		"uglify-js": {
-			"version": "3.15.1",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.1.tgz",
-			"integrity": "sha512-FAGKF12fWdkpvNJZENacOH0e/83eG6JyVQyanIJaBXCN1J11TUQv1T1/z8S+Z0CG0ZPk1nPcreF/c7lrTd0TEQ==",
+			"version": "3.15.2",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.2.tgz",
+			"integrity": "sha512-peeoTk3hSwYdoc9nrdiEJk+gx1ALCtTjdYuKSXMTDqq7n1W7dHPqWDdSi+BPL0ni2YMeHD7hKUSdbj3TZauY2A==",
 			"dev": true,
 			"optional": true
 		},
@@ -69670,9 +69735,9 @@
 			"dev": true
 		},
 		"webpack": {
-			"version": "5.69.1",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.69.1.tgz",
-			"integrity": "sha512-+VyvOSJXZMT2V5vLzOnDuMz5GxEqLk7hKWQ56YxPW/PQRUuKimPqmEIJOx8jHYeyo65pKbapbW464mvsKbaj4A==",
+			"version": "5.70.0",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.70.0.tgz",
+			"integrity": "sha512-ZMWWy8CeuTTjCxbeaQI21xSswseF2oNOwc70QSKNePvmxE7XW36i7vpBMYZFAUHPwQiEbNGCEYIOOlyRbdGmxw==",
 			"dev": true,
 			"requires": {
 				"@types/eslint-scope": "^3.7.3",
@@ -69684,7 +69749,7 @@
 				"acorn-import-assertions": "^1.7.6",
 				"browserslist": "^4.14.5",
 				"chrome-trace-event": "^1.0.2",
-				"enhanced-resolve": "^5.8.3",
+				"enhanced-resolve": "^5.9.2",
 				"es-module-lexer": "^0.9.0",
 				"eslint-scope": "5.1.1",
 				"events": "^3.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 			"devDependencies": {
 				"@searchspring/prettier": "^1.0.2",
 				"@searchspring/snapi-types": "^0.1.24",
-				"@types/jest": "^27.4.0",
+				"@types/jest": "^27.4.1",
 				"@types/jsdom": "^16.2.14",
 				"@types/seamless-immutable": "^7.1.16",
 				"@typescript-eslint/eslint-plugin": "^5.9.0",
@@ -23,15 +23,15 @@
 				"eslint-plugin-react": "^7.28.0",
 				"http-server": "^14.0.0",
 				"husky": "^7.0.4",
-				"jest": "^27.4.7",
+				"jest": "^27.5.1",
 				"jsdom": "^19.0.0",
 				"lerna": "^4.0.0",
 				"lint-staged": "^12.1.5",
 				"prettier": "^2.5.1",
 				"standard-version": "^9.3.2",
-				"ts-jest": "^27.1.2",
+				"ts-jest": "^27.1.3",
 				"typedoc": "^0.22.10",
-				"typescript": "^4.5.4",
+				"typescript": "^4.6.2",
 				"whatwg-fetch": "^3.6.2"
 			}
 		},
@@ -20130,9 +20130,9 @@
 			"dev": true
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.77",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.77.tgz",
-			"integrity": "sha512-fiDxw8mO9Ph1Z0bjX2sFTPpi0J0QkOiwOJF+5Q0J0baNc/F9lLePAvDPlnoxvbUYYMizqrKPeotRRkJ9LtxAew=="
+			"version": "1.4.78",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.78.tgz",
+			"integrity": "sha512-o61+D/Lx7j/E0LIin/efOqeHpXhwi1TaQco9vUcRmr91m25SfZY6L5hWJDv/r+6kNjboFKgBw1LbfM0lbhuK6Q=="
 		},
 		"node_modules/element-resize-detector": {
 			"version": "1.2.4",
@@ -27831,9 +27831,9 @@
 			}
 		},
 		"node_modules/listr2": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/listr2/-/listr2-4.0.4.tgz",
-			"integrity": "sha512-vJOm5KD6uZXjSsrwajr+mNacIjf87gWvlBEltPWLbTkslUscWAzquyK4xfe9Zd4RDgO5nnwFyV06FC+uVR+5mg==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/listr2/-/listr2-4.0.5.tgz",
+			"integrity": "sha512-juGHV1doQdpNT3GSTs9IUN43QJb7KHdF9uqg7Vufs/tG9VTzpFphqF4pm/ICdAABGQxsyNn9CiYA3StkI6jpwA==",
 			"dev": true,
 			"dependencies": {
 				"cli-truncate": "^2.1.0",
@@ -27841,7 +27841,7 @@
 				"log-update": "^4.0.0",
 				"p-map": "^4.0.0",
 				"rfdc": "^1.3.0",
-				"rxjs": "^7.5.4",
+				"rxjs": "^7.5.5",
 				"through": "^2.3.8",
 				"wrap-ansi": "^7.0.0"
 			},
@@ -55830,9 +55830,9 @@
 			"dev": true
 		},
 		"electron-to-chromium": {
-			"version": "1.4.77",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.77.tgz",
-			"integrity": "sha512-fiDxw8mO9Ph1Z0bjX2sFTPpi0J0QkOiwOJF+5Q0J0baNc/F9lLePAvDPlnoxvbUYYMizqrKPeotRRkJ9LtxAew=="
+			"version": "1.4.78",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.78.tgz",
+			"integrity": "sha512-o61+D/Lx7j/E0LIin/efOqeHpXhwi1TaQco9vUcRmr91m25SfZY6L5hWJDv/r+6kNjboFKgBw1LbfM0lbhuK6Q=="
 		},
 		"element-resize-detector": {
 			"version": "1.2.4",
@@ -61741,9 +61741,9 @@
 			}
 		},
 		"listr2": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/listr2/-/listr2-4.0.4.tgz",
-			"integrity": "sha512-vJOm5KD6uZXjSsrwajr+mNacIjf87gWvlBEltPWLbTkslUscWAzquyK4xfe9Zd4RDgO5nnwFyV06FC+uVR+5mg==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/listr2/-/listr2-4.0.5.tgz",
+			"integrity": "sha512-juGHV1doQdpNT3GSTs9IUN43QJb7KHdF9uqg7Vufs/tG9VTzpFphqF4pm/ICdAABGQxsyNn9CiYA3StkI6jpwA==",
 			"dev": true,
 			"requires": {
 				"cli-truncate": "^2.1.0",
@@ -61751,7 +61751,7 @@
 				"log-update": "^4.0.0",
 				"p-map": "^4.0.0",
 				"rfdc": "^1.3.0",
-				"rxjs": "^7.5.4",
+				"rxjs": "^7.5.5",
 				"through": "^2.3.8",
 				"wrap-ansi": "^7.0.0"
 			},

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 	"devDependencies": {
 		"@searchspring/prettier": "^1.0.2",
 		"@searchspring/snapi-types": "^0.1.24",
-		"@types/jest": "^27.4.0",
+		"@types/jest": "^27.4.1",
 		"@types/jsdom": "^16.2.14",
 		"@types/seamless-immutable": "^7.1.16",
 		"@typescript-eslint/eslint-plugin": "^5.9.0",
@@ -37,15 +37,15 @@
 		"eslint-plugin-react": "^7.28.0",
 		"http-server": "^14.0.0",
 		"husky": "^7.0.4",
-		"jest": "^27.4.7",
+		"jest": "^27.5.1",
 		"jsdom": "^19.0.0",
 		"lerna": "^4.0.0",
 		"lint-staged": "^12.1.5",
 		"prettier": "^2.5.1",
 		"standard-version": "^9.3.2",
-		"ts-jest": "^27.1.2",
+		"ts-jest": "^27.1.3",
 		"typedoc": "^0.22.10",
-		"typescript": "^4.5.4",
+		"typescript": "^4.6.2",
 		"whatwg-fetch": "^3.6.2"
 	},
 	"lint-staged": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 	"prettier": "@searchspring/prettier",
 	"devDependencies": {
 		"@searchspring/prettier": "^1.0.2",
-		"@searchspring/snapi-types": "^0.1.23",
+		"@searchspring/snapi-types": "^0.1.24",
 		"@types/jest": "^27.4.0",
 		"@types/jsdom": "^16.2.14",
 		"@types/seamless-immutable": "^7.1.16",

--- a/packages/snap-client/src/Client/transforms/searchRequest.test.ts
+++ b/packages/snap-client/src/Client/transforms/searchRequest.test.ts
@@ -371,4 +371,24 @@ describe('request facets transform', () => {
 		expect(p1).toEqual({});
 		expect(p2).toEqual({});
 	});
+
+	it(`can toggle 'disableFacetDrillDown'`, () => {
+		const params = transformSearchRequest.facets({
+			facets: {
+				autoDrillDown: false,
+			},
+		});
+
+		expect(params).toEqual({ disableFacetDrillDown: true });
+	});
+
+	it(`does not set 'disableFacetDrillDown' as false`, () => {
+		const params = transformSearchRequest.facets({
+			facets: {
+				autoDrillDown: true,
+			},
+		});
+
+		expect(params).toEqual({});
+	});
 });

--- a/packages/snap-client/src/Client/transforms/searchRequest.ts
+++ b/packages/snap-client/src/Client/transforms/searchRequest.ts
@@ -139,20 +139,29 @@ transformSearchRequest.siteId = (request: SearchRequestModel = {}) => {
 
 transformSearchRequest.facets = (request: SearchRequestModel = {}) => {
 	const facets = request.facets || {};
+	const params: {
+		includedFacets?: string[];
+		excludedFacets?: string[];
+		disableFacetDrillDown?: boolean;
+	} = {};
 
 	if (facets.include && facets.include.length && facets.exclude && facets.exclude.length) {
 		throw 'cannot use facet include and exclude at the same time';
 	}
 
 	if (facets.include?.length) {
-		return { includedFacets: facets.include };
+		params.includedFacets = facets.include;
 	}
 
 	if (facets.exclude?.length) {
-		return { excludedFacets: facets.exclude };
+		params.excludedFacets = facets.exclude;
 	}
 
-	return {};
+	if (facets.autoDrillDown === false) {
+		params.disableFacetDrillDown = true;
+	}
+
+	return params;
 };
 
 transformSearchRequest.tracking = (request: SearchRequestModel = {}) => {

--- a/packages/snap-controller/src/Finder/FinderController.test.ts
+++ b/packages/snap-controller/src/Finder/FinderController.test.ts
@@ -47,6 +47,57 @@ describe('Finder Controller', () => {
 	});
 
 	describe('Hierarchy Type', () => {
+		it(`sets search params for 'include' and 'autoDrillDown'`, async () => {
+			const controller = new FinderController(finderHierarchyConfig, {
+				client: new MockClient(globals, { meta: { prefetch: false } }),
+				store: new FinderStore(finderHierarchyConfig, services),
+				urlManager,
+				eventManager: new EventManager(),
+				profiler: new Profiler(),
+				logger: new Logger(),
+				tracker: new Tracker(globals),
+			});
+
+			controller.client.mockData.updateConfig({ search: 'finder.include.ss_accessory' });
+			controller.init();
+
+			const params = controller.params;
+			expect(params.facets).toStrictEqual({
+				include: finderHierarchyConfig.fields.map((field) => field.field),
+				autoDrillDown: false,
+			});
+		});
+
+		it(`allows for config globals to overwrite / merge with default parameters`, async () => {
+			const config = {
+				...finderHierarchyConfig,
+				globals: {
+					facets: {
+						include: ['ss-special'],
+						autoDrillDown: true,
+					},
+				},
+			};
+			const controller = new FinderController(config, {
+				client: new MockClient(globals, { meta: { prefetch: false } }),
+				store: new FinderStore(finderHierarchyConfig, services),
+				urlManager,
+				eventManager: new EventManager(),
+				profiler: new Profiler(),
+				logger: new Logger(),
+				tracker: new Tracker(globals),
+			});
+
+			controller.client.mockData.updateConfig({ search: 'finder.include.ss_accessory' });
+			controller.init();
+
+			const params = controller.params;
+			expect(params.facets).toStrictEqual({
+				include: finderHierarchyConfig.fields.map((field) => field.field).concat('ss-special'),
+				autoDrillDown: true,
+			});
+		});
+
 		it('can make selection', async () => {
 			const controller = new FinderController(finderHierarchyConfig, {
 				client: new MockClient(globals, { meta: { prefetch: false } }),
@@ -148,7 +199,57 @@ describe('Finder Controller', () => {
 	});
 
 	describe('Non-hierarchy Type', () => {
-		it('Non-hierarchy type can make selection', async () => {
+		it(`sets search params for 'include' and 'autoDrillDown'`, async () => {
+			const controller = new FinderController(finderNonhierarchyConfig, {
+				client: new MockClient(globals, { meta: { prefetch: false } }),
+				store: new FinderStore(finderNonhierarchyConfig, services),
+				urlManager,
+				eventManager: new EventManager(),
+				profiler: new Profiler(),
+				logger: new Logger(),
+				tracker: new Tracker(globals),
+			});
+
+			controller.init();
+
+			const params = controller.params;
+			expect(params.facets).toStrictEqual({
+				include: finderNonhierarchyConfig.fields.map((field) => field.field),
+				autoDrillDown: false,
+			});
+		});
+
+		it(`allows for config globals to overwrite / merge with default parameters`, async () => {
+			const config = {
+				...finderNonhierarchyConfig,
+				globals: {
+					facets: {
+						include: ['ss-special'],
+						autoDrillDown: true,
+					},
+				},
+			};
+			const controller = new FinderController(config, {
+				client: new MockClient(globals, { meta: { prefetch: false } }),
+				store: new FinderStore(finderNonhierarchyConfig, services),
+				urlManager,
+				eventManager: new EventManager(),
+				profiler: new Profiler(),
+				logger: new Logger(),
+				tracker: new Tracker(globals),
+			});
+
+			controller.client.mockData.updateConfig({ search: 'finder.include.ss_accessory' });
+			controller.init();
+
+			const params = controller.params;
+			expect(params.facets).toStrictEqual({
+				include: finderNonhierarchyConfig.fields.map((field) => field.field).concat('ss-special'),
+				autoDrillDown: true,
+			});
+		});
+
+		it('can make selection', async () => {
 			const controller = new FinderController(finderNonhierarchyConfig, {
 				client: new MockClient(globals, { meta: { prefetch: false } }),
 				store: new FinderStore(finderNonhierarchyConfig, services),

--- a/packages/snap-controller/src/Finder/FinderController.ts
+++ b/packages/snap-controller/src/Finder/FinderController.ts
@@ -60,12 +60,16 @@ export class FinderController extends AbstractController {
 
 	get params(): Record<string, any> {
 		const urlState = this.urlManager.state;
-		const params: Record<string, any> = deepmerge({ ...getSearchParams(urlState) }, this.config.globals);
 
-		// get only the finder fields
-		params.facets = {
-			include: this.config.fields.map((fieldConfig) => fieldConfig.field),
+		// get only the finder fields and disable auto drill down
+		const defaultParams = {
+			facets: {
+				include: this.config.fields.map((fieldConfig) => fieldConfig.field),
+				autoDrillDown: false,
+			},
 		};
+
+		const params: Record<string, any> = deepmerge({ ...getSearchParams(urlState) }, deepmerge(defaultParams, this.config.globals));
 
 		return params;
 	}

--- a/packages/snap-preact-demo/package.json
+++ b/packages/snap-preact-demo/package.json
@@ -8,7 +8,7 @@
 	"scripts": {
 		"analyze": "webpack --config webpack.modern.js --analyze",
 		"analyze:universal": "webpack --config webpack.universal.js --analyze",
-		"build": "rm -rf ./dist && webpack --config webpack.modern.js && webpack --config webpack.universal.js",
+		"build": "echo 'not building demo store'",
 		"build:docs": "echo 'no docs for snap-preact-demo'",
 		"cypress": "cypress open --project tests",
 		"dev": "kill $(lsof -ti:2222,8888); webpack serve --config webpack.dev.js",

--- a/packages/snap-store-mobx/src/Finder/Stores/SelectionStore.ts
+++ b/packages/snap-store-mobx/src/Finder/Stores/SelectionStore.ts
@@ -15,48 +15,48 @@ export class SelectionStore extends Array {
 		loading: boolean,
 		storage: StorageStore
 	) {
-		if (!facets || !meta) {
-			super();
-			return;
-		}
-		// re-order facets to match our config
-		config?.fields &&
-			facets.sort((a, b) => {
-				const fields = config.fields.map((fieldConfig) => fieldConfig.field);
-				return fields.indexOf(a.field) - fields.indexOf(b.field);
-			});
 		const selections = [];
-		config?.fields?.forEach((fieldObj) => {
-			let facet: any = facets?.filter((facet) => facet.field == fieldObj.field).pop();
 
-			facet = {
-				...meta?.facets[fieldObj.field],
-				...facet,
-			};
-
-			const isHierarchy = facet.display === 'hierarchy';
-			if (isHierarchy) {
-				// filter out history/current hierarchy values
-				const filtered = facet.filtered && facet.values.filter((value) => value.filtered).pop();
-
-				if (filtered) {
-					const filteredLevel = filtered.value.split(facet.hierarchyDelimiter).length;
-
-					facet.values = facet.values.filter((value, index) => {
-						return (value.value && value.value.split(facet.hierarchyDelimiter).length > filteredLevel) || index == facet.values.length - 1;
-					});
-				}
-
-				const levels = fieldObj?.levels || facet?.values[facet?.values.length - 1]?.value.split(facet.hierarchyDelimiter);
-
-				levels?.map((level, index) => {
-					const levelConfig: LevelConfig = { index, label: fieldObj.levels ? level : '', key: `ss-${index}` };
-					selections.push(new SelectionHierarchy(services, config.id, facet, levelConfig, loading, storage));
+		if (facets && meta) {
+			// re-order facets to match our config
+			config?.fields &&
+				facets.sort((a, b) => {
+					const fields = config.fields.map((fieldConfig) => fieldConfig.field);
+					return fields.indexOf(a.field) - fields.indexOf(b.field);
 				});
-			} else {
-				selections.push(new Selection(services, config.id, facet, fieldObj, loading, storage));
-			}
-		});
+
+			config?.fields?.forEach((fieldObj) => {
+				let facet: any = facets?.filter((facet) => facet.field == fieldObj.field).pop();
+
+				facet = {
+					...meta?.facets[fieldObj.field],
+					...facet,
+				};
+
+				const isHierarchy = facet.display === 'hierarchy';
+				if (isHierarchy) {
+					// filter out history/current hierarchy values
+					const filtered = facet.filtered && facet.values.filter((value) => value.filtered).pop();
+
+					if (filtered) {
+						const filteredLevel = filtered.value.split(facet.hierarchyDelimiter).length;
+
+						facet.values = facet.values.filter((value, index) => {
+							return (value.value && value.value.split(facet.hierarchyDelimiter).length > filteredLevel) || index == facet.values.length - 1;
+						});
+					}
+
+					const levels = fieldObj?.levels || facet?.values[facet?.values.length - 1]?.value.split(facet.hierarchyDelimiter);
+
+					levels?.map((level, index) => {
+						const levelConfig: LevelConfig = { index, label: fieldObj.levels ? level : '', key: `ss-${index}` };
+						selections.push(new SelectionHierarchy(services, config.id, facet, levelConfig, loading, storage));
+					});
+				} else {
+					selections.push(new Selection(services, config.id, facet, fieldObj, loading, storage));
+				}
+			});
+		}
 
 		super(...selections);
 	}


### PR DESCRIPTION
Adding `facets.autoDrillDown` as a default request parameter for the `FinderController`. This parameter prevents hierarchy type facets from automatically drilling down to a level with a singular selection. This is necessary to ensure that the levels display properly.