### PR TITLE
Fixing `snap-preact` Config for Services

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2388,9 +2388,9 @@
 			}
 		},
 		"node_modules/@discoveryjs/json-ext": {
-			"version": "0.5.6",
-			"resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.6.tgz",
-			"integrity": "sha512-ws57AidsDvREKrZKYffXddNkyaF14iHNHm8VQnZH6t99E8gczjNN0GpvcGny0imC80yQ0tHz1xVUKk/KFQSUyA==",
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
+			"integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
 			"dev": true,
 			"engines": {
 				"node": ">=10.0.0"
@@ -2583,15 +2583,14 @@
 			"integrity": "sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ=="
 		},
 		"node_modules/@emotion/react": {
-			"version": "11.8.1",
-			"resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.8.1.tgz",
-			"integrity": "sha512-XGaie4nRxmtP1BZYBXqC5JGqMYF2KRKKI7vjqNvQxyRpekVAZhb6QqrElmZCAYXH1L90lAelADSVZC4PFsrJ8Q==",
+			"version": "11.8.2",
+			"resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.8.2.tgz",
+			"integrity": "sha512-+1bcHBaNJv5nkIIgnGKVsie3otS0wF9f1T1hteF3WeVvMNQEtfZ4YyFpnphGoot3ilU/wWMgP2SgIDuHLE/wAA==",
 			"dependencies": {
 				"@babel/runtime": "^7.13.10",
 				"@emotion/babel-plugin": "^11.7.1",
 				"@emotion/cache": "^11.7.1",
 				"@emotion/serialize": "^1.0.2",
-				"@emotion/sheet": "^1.1.0",
 				"@emotion/utils": "^1.1.0",
 				"@emotion/weak-memoize": "^0.2.5",
 				"hoist-non-react-statics": "^3.3.1"
@@ -14121,9 +14120,9 @@
 			"dev": true
 		},
 		"node_modules/@types/react": {
-			"version": "17.0.39",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.39.tgz",
-			"integrity": "sha512-UVavlfAxDd/AgAacMa60Azl7ygyQNRwC/DsHZmKgNvPmRR5p70AJ5Q9EAmL2NWOJmeV+vVUI4IAP7GZrN8h8Ug==",
+			"version": "17.0.40",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.40.tgz",
+			"integrity": "sha512-UrXhD/JyLH+W70nNSufXqMZNuUD2cXHu6UjCllC6pmOQgBX4SGXOH8fjRka0O0Ee0HrFxapDD8Bwn81Kmiz6jQ==",
 			"dev": true,
 			"dependencies": {
 				"@types/prop-types": "*",
@@ -20130,9 +20129,9 @@
 			"dev": true
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.78",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.78.tgz",
-			"integrity": "sha512-o61+D/Lx7j/E0LIin/efOqeHpXhwi1TaQco9vUcRmr91m25SfZY6L5hWJDv/r+6kNjboFKgBw1LbfM0lbhuK6Q=="
+			"version": "1.4.81",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.81.tgz",
+			"integrity": "sha512-Gs7xVpIZ7tYYSDA+WgpzwpPvfGwUk3KSIjJ0akuj5XQHFdyQnsUoM76EA4CIHXNLPiVwTwOFay9RMb0ChG3OBw=="
 		},
 		"node_modules/element-resize-detector": {
 			"version": "1.2.4",
@@ -24530,7 +24529,6 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
 			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -36126,9 +36124,9 @@
 			}
 		},
 		"node_modules/ts-loader": {
-			"version": "9.2.7",
-			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.2.7.tgz",
-			"integrity": "sha512-Fxh44mKli9QezgbdCXkEJWxnedQ0ead7DXTH+lfXEPedu+Y9EtMJ2aQ9G3Dj1j7Q612E8931rww8NDZha4Tibg==",
+			"version": "9.2.8",
+			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.2.8.tgz",
+			"integrity": "sha512-gxSak7IHUuRtwKf3FIPSW1VpZcqF9+MBrHOvBp9cjHh+525SjtCIJKVGjRKIAfxBwDGDGCFF00rTfzB1quxdSw==",
 			"dev": true,
 			"dependencies": {
 				"chalk": "^4.1.0",
@@ -36477,9 +36475,9 @@
 			}
 		},
 		"node_modules/uglify-js": {
-			"version": "3.15.2",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.2.tgz",
-			"integrity": "sha512-peeoTk3hSwYdoc9nrdiEJk+gx1ALCtTjdYuKSXMTDqq7n1W7dHPqWDdSi+BPL0ni2YMeHD7hKUSdbj3TZauY2A==",
+			"version": "3.15.3",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.3.tgz",
+			"integrity": "sha512-6iCVm2omGJbsu3JWac+p6kUiOpg3wFO2f8lIXjfEb8RrmLjzog1wTPMmwKB7swfzzqxj9YM+sGUM++u1qN4qJg==",
 			"dev": true,
 			"optional": true,
 			"bin": {
@@ -39217,57 +39215,58 @@
 		},
 		"packages/snap-client": {
 			"name": "@searchspring/snap-client",
-			"version": "0.21.1",
+			"version": "0.22.0",
 			"license": "MIT",
 			"dependencies": {
-				"@searchspring/snap-toolbox": "^0.21.1",
+				"@searchspring/snap-toolbox": "^0.22.0",
 				"deepmerge": "^4.2.2"
 			}
 		},
 		"packages/snap-controller": {
 			"name": "@searchspring/snap-controller",
-			"version": "0.21.1",
+			"version": "0.22.0",
 			"license": "MIT",
 			"dependencies": {
-				"@searchspring/snap-toolbox": "^0.21.1",
+				"@searchspring/snap-toolbox": "^0.22.0",
 				"deepmerge": "^4.2.2"
 			},
 			"devDependencies": {
-				"@searchspring/snap-client": "^0.21.1",
-				"@searchspring/snap-event-manager": "^0.21.1",
-				"@searchspring/snap-logger": "^0.21.1",
-				"@searchspring/snap-profiler": "^0.21.1",
-				"@searchspring/snap-store-mobx": "^0.21.1",
-				"@searchspring/snap-tracker": "^0.21.1",
-				"@searchspring/snap-url-manager": "^0.21.1"
+				"@searchspring/snap-client": "^0.22.0",
+				"@searchspring/snap-event-manager": "^0.22.0",
+				"@searchspring/snap-logger": "^0.22.0",
+				"@searchspring/snap-profiler": "^0.22.0",
+				"@searchspring/snap-store-mobx": "^0.22.0",
+				"@searchspring/snap-tracker": "^0.22.0",
+				"@searchspring/snap-url-manager": "^0.22.0"
 			}
 		},
 		"packages/snap-event-manager": {
 			"name": "@searchspring/snap-event-manager",
-			"version": "0.21.1",
+			"version": "0.22.0",
 			"license": "MIT"
 		},
 		"packages/snap-logger": {
 			"name": "@searchspring/snap-logger",
-			"version": "0.21.1",
+			"version": "0.22.0",
 			"license": "MIT"
 		},
 		"packages/snap-preact": {
 			"name": "@searchspring/snap-preact",
-			"version": "0.21.1",
+			"version": "0.22.0",
 			"license": "MIT",
 			"dependencies": {
-				"@searchspring/snap-client": "^0.21.1",
-				"@searchspring/snap-controller": "^0.21.1",
-				"@searchspring/snap-event-manager": "^0.21.1",
-				"@searchspring/snap-logger": "^0.21.1",
-				"@searchspring/snap-profiler": "^0.21.1",
-				"@searchspring/snap-store-mobx": "^0.21.1",
-				"@searchspring/snap-toolbox": "^0.21.1",
-				"@searchspring/snap-tracker": "^0.21.1",
-				"@searchspring/snap-url-manager": "^0.21.1",
+				"@searchspring/snap-client": "^0.22.0",
+				"@searchspring/snap-controller": "^0.22.0",
+				"@searchspring/snap-event-manager": "^0.22.0",
+				"@searchspring/snap-logger": "^0.22.0",
+				"@searchspring/snap-profiler": "^0.22.0",
+				"@searchspring/snap-store-mobx": "^0.22.0",
+				"@searchspring/snap-toolbox": "^0.22.0",
+				"@searchspring/snap-tracker": "^0.22.0",
+				"@searchspring/snap-url-manager": "^0.22.0",
 				"deepmerge": "^4.2.2",
-				"intersection-observer": "^0.12.0"
+				"intersection-observer": "^0.12.0",
+				"is-plain-object": "^5.0.0"
 			},
 			"devDependencies": {
 				"@types/react": "^17.0.20"
@@ -39275,12 +39274,12 @@
 		},
 		"packages/snap-preact-components": {
 			"name": "@searchspring/snap-preact-components",
-			"version": "0.21.1",
+			"version": "0.22.0",
 			"license": "MIT",
 			"dependencies": {
 				"@emotion/react": "^11.7.1",
-				"@searchspring/snap-preact": "^0.21.1",
-				"@searchspring/snap-toolbox": "^0.21.1",
+				"@searchspring/snap-preact": "^0.22.0",
+				"@searchspring/snap-toolbox": "^0.22.0",
 				"classnames": "^2.3.1",
 				"deepmerge": "^4.2.2",
 				"mobx-react-lite": "^3.2.3",
@@ -39289,13 +39288,13 @@
 			},
 			"devDependencies": {
 				"@mdx-js/loader": "^1.6.22",
-				"@searchspring/snap-client": "^0.21.1",
-				"@searchspring/snap-controller": "^0.21.1",
-				"@searchspring/snap-event-manager": "^0.21.1",
-				"@searchspring/snap-logger": "^0.21.1",
-				"@searchspring/snap-profiler": "^0.21.1",
-				"@searchspring/snap-store-mobx": "^0.21.1",
-				"@searchspring/snap-url-manager": "^0.21.1",
+				"@searchspring/snap-client": "^0.22.0",
+				"@searchspring/snap-controller": "^0.22.0",
+				"@searchspring/snap-event-manager": "^0.22.0",
+				"@searchspring/snap-logger": "^0.22.0",
+				"@searchspring/snap-profiler": "^0.22.0",
+				"@searchspring/snap-store-mobx": "^0.22.0",
+				"@searchspring/snap-url-manager": "^0.22.0",
 				"@storybook/addon-actions": "^6.4.9",
 				"@storybook/addon-controls": "^6.4.9",
 				"@storybook/addon-docs": "^6.4.9",
@@ -39678,11 +39677,11 @@
 		},
 		"packages/snap-preact-demo": {
 			"name": "@searchspring/snap-preact-demo",
-			"version": "0.21.1",
+			"version": "0.22.0",
 			"license": "MIT",
 			"dependencies": {
-				"@searchspring/snap-preact": "^0.21.1",
-				"@searchspring/snap-preact-components": "^0.21.1",
+				"@searchspring/snap-preact": "^0.22.0",
+				"@searchspring/snap-preact-components": "^0.22.0",
 				"deepmerge": "^4.2.2",
 				"mobx": "^6.3.12",
 				"mobx-react": "^7.2.1",
@@ -39716,41 +39715,41 @@
 		},
 		"packages/snap-profiler": {
 			"name": "@searchspring/snap-profiler",
-			"version": "0.21.1",
+			"version": "0.22.0",
 			"license": "MIT"
 		},
 		"packages/snap-shared": {
 			"name": "@searchspring/snap-shared",
-			"version": "0.21.1",
+			"version": "0.22.0",
 			"license": "MIT",
 			"devDependencies": {
-				"@searchspring/snap-client": "^0.21.1"
+				"@searchspring/snap-client": "^0.22.0"
 			}
 		},
 		"packages/snap-store-mobx": {
 			"name": "@searchspring/snap-store-mobx",
-			"version": "0.21.1",
+			"version": "0.22.0",
 			"license": "MIT",
 			"dependencies": {
-				"@searchspring/snap-toolbox": "^0.21.1",
+				"@searchspring/snap-toolbox": "^0.22.0",
 				"mobx": "^6.3.12"
 			},
 			"devDependencies": {
-				"@searchspring/snap-url-manager": "^0.21.1"
+				"@searchspring/snap-url-manager": "^0.22.0"
 			}
 		},
 		"packages/snap-toolbox": {
 			"name": "@searchspring/snap-toolbox",
-			"version": "0.21.1",
+			"version": "0.22.0",
 			"license": "MIT"
 		},
 		"packages/snap-tracker": {
 			"name": "@searchspring/snap-tracker",
-			"version": "0.21.1",
+			"version": "0.22.0",
 			"license": "MIT",
 			"dependencies": {
-				"@searchspring/snap-store-mobx": "^0.21.1",
-				"@searchspring/snap-toolbox": "^0.21.1",
+				"@searchspring/snap-store-mobx": "^0.22.0",
+				"@searchspring/snap-toolbox": "^0.22.0",
 				"deepmerge": "^4.2.2",
 				"uuid": "^8.3.2"
 			}
@@ -39765,7 +39764,7 @@
 		},
 		"packages/snap-url-manager": {
 			"name": "@searchspring/snap-url-manager",
-			"version": "0.21.1",
+			"version": "0.22.0",
 			"license": "MIT",
 			"dependencies": {
 				"deepmerge": "^4.2.2",
@@ -41447,9 +41446,9 @@
 			}
 		},
 		"@discoveryjs/json-ext": {
-			"version": "0.5.6",
-			"resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.6.tgz",
-			"integrity": "sha512-ws57AidsDvREKrZKYffXddNkyaF14iHNHm8VQnZH6t99E8gczjNN0GpvcGny0imC80yQ0tHz1xVUKk/KFQSUyA==",
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
+			"integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
 			"dev": true
 		},
 		"@emotion/babel-plugin": {
@@ -41632,15 +41631,14 @@
 			"integrity": "sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ=="
 		},
 		"@emotion/react": {
-			"version": "11.8.1",
-			"resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.8.1.tgz",
-			"integrity": "sha512-XGaie4nRxmtP1BZYBXqC5JGqMYF2KRKKI7vjqNvQxyRpekVAZhb6QqrElmZCAYXH1L90lAelADSVZC4PFsrJ8Q==",
+			"version": "11.8.2",
+			"resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.8.2.tgz",
+			"integrity": "sha512-+1bcHBaNJv5nkIIgnGKVsie3otS0wF9f1T1hteF3WeVvMNQEtfZ4YyFpnphGoot3ilU/wWMgP2SgIDuHLE/wAA==",
 			"requires": {
 				"@babel/runtime": "^7.13.10",
 				"@emotion/babel-plugin": "^11.7.1",
 				"@emotion/cache": "^11.7.1",
 				"@emotion/serialize": "^1.0.2",
-				"@emotion/sheet": "^1.1.0",
 				"@emotion/utils": "^1.1.0",
 				"@emotion/weak-memoize": "^0.2.5",
 				"hoist-non-react-statics": "^3.3.1"
@@ -44520,21 +44518,21 @@
 		"@searchspring/snap-client": {
 			"version": "file:packages/snap-client",
 			"requires": {
-				"@searchspring/snap-toolbox": "^0.21.1",
+				"@searchspring/snap-toolbox": "^0.22.0",
 				"deepmerge": "^4.2.2"
 			}
 		},
 		"@searchspring/snap-controller": {
 			"version": "file:packages/snap-controller",
 			"requires": {
-				"@searchspring/snap-client": "^0.21.1",
-				"@searchspring/snap-event-manager": "^0.21.1",
-				"@searchspring/snap-logger": "^0.21.1",
-				"@searchspring/snap-profiler": "^0.21.1",
-				"@searchspring/snap-store-mobx": "^0.21.1",
-				"@searchspring/snap-toolbox": "^0.21.1",
-				"@searchspring/snap-tracker": "^0.21.1",
-				"@searchspring/snap-url-manager": "^0.21.1",
+				"@searchspring/snap-client": "^0.22.0",
+				"@searchspring/snap-event-manager": "^0.22.0",
+				"@searchspring/snap-logger": "^0.22.0",
+				"@searchspring/snap-profiler": "^0.22.0",
+				"@searchspring/snap-store-mobx": "^0.22.0",
+				"@searchspring/snap-toolbox": "^0.22.0",
+				"@searchspring/snap-tracker": "^0.22.0",
+				"@searchspring/snap-url-manager": "^0.22.0",
 				"deepmerge": "^4.2.2"
 			}
 		},
@@ -44547,18 +44545,19 @@
 		"@searchspring/snap-preact": {
 			"version": "file:packages/snap-preact",
 			"requires": {
-				"@searchspring/snap-client": "^0.21.1",
-				"@searchspring/snap-controller": "^0.21.1",
-				"@searchspring/snap-event-manager": "^0.21.1",
-				"@searchspring/snap-logger": "^0.21.1",
-				"@searchspring/snap-profiler": "^0.21.1",
-				"@searchspring/snap-store-mobx": "^0.21.1",
-				"@searchspring/snap-toolbox": "^0.21.1",
-				"@searchspring/snap-tracker": "^0.21.1",
-				"@searchspring/snap-url-manager": "^0.21.1",
+				"@searchspring/snap-client": "^0.22.0",
+				"@searchspring/snap-controller": "^0.22.0",
+				"@searchspring/snap-event-manager": "^0.22.0",
+				"@searchspring/snap-logger": "^0.22.0",
+				"@searchspring/snap-profiler": "^0.22.0",
+				"@searchspring/snap-store-mobx": "^0.22.0",
+				"@searchspring/snap-toolbox": "^0.22.0",
+				"@searchspring/snap-tracker": "^0.22.0",
+				"@searchspring/snap-url-manager": "^0.22.0",
 				"@types/react": "^17.0.20",
 				"deepmerge": "^4.2.2",
-				"intersection-observer": "^0.12.0"
+				"intersection-observer": "^0.12.0",
+				"is-plain-object": "^5.0.0"
 			}
 		},
 		"@searchspring/snap-preact-components": {
@@ -44566,15 +44565,15 @@
 			"requires": {
 				"@emotion/react": "^11.7.1",
 				"@mdx-js/loader": "^1.6.22",
-				"@searchspring/snap-client": "^0.21.1",
-				"@searchspring/snap-controller": "^0.21.1",
-				"@searchspring/snap-event-manager": "^0.21.1",
-				"@searchspring/snap-logger": "^0.21.1",
-				"@searchspring/snap-preact": "^0.21.1",
-				"@searchspring/snap-profiler": "^0.21.1",
-				"@searchspring/snap-store-mobx": "^0.21.1",
-				"@searchspring/snap-toolbox": "^0.21.1",
-				"@searchspring/snap-url-manager": "^0.21.1",
+				"@searchspring/snap-client": "^0.22.0",
+				"@searchspring/snap-controller": "^0.22.0",
+				"@searchspring/snap-event-manager": "^0.22.0",
+				"@searchspring/snap-logger": "^0.22.0",
+				"@searchspring/snap-preact": "^0.22.0",
+				"@searchspring/snap-profiler": "^0.22.0",
+				"@searchspring/snap-store-mobx": "^0.22.0",
+				"@searchspring/snap-toolbox": "^0.22.0",
+				"@searchspring/snap-url-manager": "^0.22.0",
 				"@storybook/addon-actions": "^6.4.9",
 				"@storybook/addon-controls": "^6.4.9",
 				"@storybook/addon-docs": "^6.4.9",
@@ -44846,8 +44845,8 @@
 				"@babel/runtime": "^7.16.7",
 				"@lhci/cli": "^0.8.2",
 				"@searchspring/browserslist-config-snap": "^1.0.5",
-				"@searchspring/snap-preact": "^0.21.1",
-				"@searchspring/snap-preact-components": "^0.21.1",
+				"@searchspring/snap-preact": "^0.22.0",
+				"@searchspring/snap-preact-components": "^0.22.0",
 				"babel-loader": "^8.2.3",
 				"core-js": "^3.20.2",
 				"css-loader": "^6.5.1",
@@ -44873,14 +44872,14 @@
 		"@searchspring/snap-shared": {
 			"version": "file:packages/snap-shared",
 			"requires": {
-				"@searchspring/snap-client": "^0.21.1"
+				"@searchspring/snap-client": "^0.22.0"
 			}
 		},
 		"@searchspring/snap-store-mobx": {
 			"version": "file:packages/snap-store-mobx",
 			"requires": {
-				"@searchspring/snap-toolbox": "^0.21.1",
-				"@searchspring/snap-url-manager": "^0.21.1",
+				"@searchspring/snap-toolbox": "^0.22.0",
+				"@searchspring/snap-url-manager": "^0.22.0",
 				"mobx": "^6.3.12"
 			}
 		},
@@ -44890,8 +44889,8 @@
 		"@searchspring/snap-tracker": {
 			"version": "file:packages/snap-tracker",
 			"requires": {
-				"@searchspring/snap-store-mobx": "^0.21.1",
-				"@searchspring/snap-toolbox": "^0.21.1",
+				"@searchspring/snap-store-mobx": "^0.22.0",
+				"@searchspring/snap-toolbox": "^0.22.0",
 				"deepmerge": "^4.2.2",
 				"uuid": "^8.3.2"
 			},
@@ -51026,9 +51025,9 @@
 			"dev": true
 		},
 		"@types/react": {
-			"version": "17.0.39",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.39.tgz",
-			"integrity": "sha512-UVavlfAxDd/AgAacMa60Azl7ygyQNRwC/DsHZmKgNvPmRR5p70AJ5Q9EAmL2NWOJmeV+vVUI4IAP7GZrN8h8Ug==",
+			"version": "17.0.40",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.40.tgz",
+			"integrity": "sha512-UrXhD/JyLH+W70nNSufXqMZNuUD2cXHu6UjCllC6pmOQgBX4SGXOH8fjRka0O0Ee0HrFxapDD8Bwn81Kmiz6jQ==",
 			"dev": true,
 			"requires": {
 				"@types/prop-types": "*",
@@ -55830,9 +55829,9 @@
 			"dev": true
 		},
 		"electron-to-chromium": {
-			"version": "1.4.78",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.78.tgz",
-			"integrity": "sha512-o61+D/Lx7j/E0LIin/efOqeHpXhwi1TaQco9vUcRmr91m25SfZY6L5hWJDv/r+6kNjboFKgBw1LbfM0lbhuK6Q=="
+			"version": "1.4.81",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.81.tgz",
+			"integrity": "sha512-Gs7xVpIZ7tYYSDA+WgpzwpPvfGwUk3KSIjJ0akuj5XQHFdyQnsUoM76EA4CIHXNLPiVwTwOFay9RMb0ChG3OBw=="
 		},
 		"element-resize-detector": {
 			"version": "1.2.4",
@@ -59234,8 +59233,7 @@
 		"is-plain-object": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-			"dev": true
+			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
 		},
 		"is-potential-custom-element-name": {
 			"version": "1.0.1",
@@ -68230,9 +68228,9 @@
 			}
 		},
 		"ts-loader": {
-			"version": "9.2.7",
-			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.2.7.tgz",
-			"integrity": "sha512-Fxh44mKli9QezgbdCXkEJWxnedQ0ead7DXTH+lfXEPedu+Y9EtMJ2aQ9G3Dj1j7Q612E8931rww8NDZha4Tibg==",
+			"version": "9.2.8",
+			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.2.8.tgz",
+			"integrity": "sha512-gxSak7IHUuRtwKf3FIPSW1VpZcqF9+MBrHOvBp9cjHh+525SjtCIJKVGjRKIAfxBwDGDGCFF00rTfzB1quxdSw==",
 			"dev": true,
 			"requires": {
 				"chalk": "^4.1.0",
@@ -68478,9 +68476,9 @@
 			"dev": true
 		},
 		"uglify-js": {
-			"version": "3.15.2",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.2.tgz",
-			"integrity": "sha512-peeoTk3hSwYdoc9nrdiEJk+gx1ALCtTjdYuKSXMTDqq7n1W7dHPqWDdSi+BPL0ni2YMeHD7hKUSdbj3TZauY2A==",
+			"version": "3.15.3",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.3.tgz",
+			"integrity": "sha512-6iCVm2omGJbsu3JWac+p6kUiOpg3wFO2f8lIXjfEb8RrmLjzog1wTPMmwKB7swfzzqxj9YM+sGUM++u1qN4qJg==",
 			"dev": true,
 			"optional": true
 		},

--- a/packages/snap-preact/package.json
+++ b/packages/snap-preact/package.json
@@ -30,7 +30,8 @@
 		"@searchspring/snap-tracker": "^0.22.0",
 		"@searchspring/snap-url-manager": "^0.22.0",
 		"deepmerge": "^4.2.2",
-		"intersection-observer": "^0.12.0"
+		"intersection-observer": "^0.12.0",
+		"is-plain-object": "^5.0.0"
 	},
 	"devDependencies": {
 		"@types/react": "^17.0.20"

--- a/packages/snap-preact/src/Snap.tsx
+++ b/packages/snap-preact/src/Snap.tsx
@@ -1,4 +1,5 @@
 import deepmerge from 'deepmerge';
+import { isPlainObject } from 'is-plain-object';
 import { h, render } from 'preact';
 import { Client } from '@searchspring/snap-client';
 import { Logger, LogMode } from '@searchspring/snap-logger';
@@ -155,7 +156,15 @@ export class Snap {
 						controller: config,
 						context: deepmerge(this.context || {}, context || {}),
 					},
-					{ client: services?.client || this.client, tracker: services?.tracker || this.tracker }
+					{
+						client: services?.client || this.client,
+						store: services?.store,
+						urlManager: services?.urlManager,
+						eventManager: services?.eventManager,
+						profiler: services?.profiler,
+						logger: services?.logger,
+						tracker: services?.tracker || this.tracker,
+					}
 				);
 				resolve(this.controllers[config.id]);
 			}
@@ -177,7 +186,11 @@ export class Snap {
 			this.logger.error('failed to find global context');
 		}
 
-		this.config = deepmerge(this.config || {}, (globalContext.config as SnapConfig) || {});
+		// merge configs - but only merge plain objects
+		this.config = deepmerge(this.config || {}, (globalContext.config as SnapConfig) || {}, {
+			isMergeableObject: isPlainObject,
+		});
+
 		this.context = deepmerge(globalContext || {}, this.config.context || {});
 
 		if (!this.config?.client?.globals?.siteId) {
@@ -280,7 +293,15 @@ export class Snap {
 									controller: controller.config,
 									context: deepmerge(this.context || {}, controller.context || {}),
 								},
-								{ client: controller.services?.client || this.client, tracker: controller.services?.tracker || this.tracker }
+								{
+									client: controller.services?.client || this.client,
+									store: controller.services?.store,
+									urlManager: controller.services?.urlManager,
+									eventManager: controller.services?.eventManager,
+									profiler: controller.services?.profiler,
+									logger: controller.services?.logger,
+									tracker: controller.services?.tracker || this.tracker,
+								}
 							);
 
 							this.controllers[cntrlr.config.id] = cntrlr;

--- a/packages/snap-preact/src/create/createAutocompleteController.ts
+++ b/packages/snap-preact/src/create/createAutocompleteController.ts
@@ -14,7 +14,10 @@ import type { SnapControllerServices, SnapAutocompleteControllerConfig } from '.
 configureMobx({ useProxies: 'never' });
 
 export default (config: SnapAutocompleteControllerConfig, services?: SnapControllerServices): AutocompleteController => {
-	const urlManager = services?.urlManager || new UrlManager(new UrlTranslator(config.url), reactLinker).detach();
+	console.log('AC services?', services);
+	const urlManager = (services?.urlManager || new UrlManager(new UrlTranslator(config.url), reactLinker)).detach();
+
+	console.log('URLAMANATERER! - ', urlManager, urlManager.subscribe);
 
 	const cntrlr = new AutocompleteController(
 		config.controller,

--- a/packages/snap-preact/src/create/createFinderController.ts
+++ b/packages/snap-preact/src/create/createFinderController.ts
@@ -14,7 +14,7 @@ import type { SnapControllerServices, SnapFinderControllerConfig } from '../type
 configureMobx({ useProxies: 'never' });
 
 export default (config: SnapFinderControllerConfig, services?: SnapControllerServices): FinderController => {
-	const urlManager = services?.urlManager || new UrlManager(new UrlTranslator(config.url), reactLinker).detach(true);
+	const urlManager = (services?.urlManager || new UrlManager(new UrlTranslator(config.url), reactLinker)).detach(true);
 
 	const cntrlr = new FinderController(
 		config.controller,

--- a/packages/snap-preact/src/create/createRecommendationController.ts
+++ b/packages/snap-preact/src/create/createRecommendationController.ts
@@ -14,7 +14,7 @@ import type { SnapControllerServices, SnapRecommendationControllerConfig } from 
 configureMobx({ useProxies: 'never' });
 
 export default (config: SnapRecommendationControllerConfig, services?: SnapControllerServices): RecommendationController => {
-	const urlManager = services?.urlManager || new UrlManager(new UrlTranslator(config.url), reactLinker).detach(true);
+	const urlManager = (services?.urlManager || new UrlManager(new UrlTranslator(config.url), reactLinker)).detach(true);
 	const cntrlr = new RecommendationController(
 		config.controller,
 		{


### PR DESCRIPTION
* fully wiring config services
* add configuration to `deepmerge` to prevent loss of special object prototypes when passed via config (eg: services like UrlTranslator)