### PR TITLE
Autocomplete Controller Changes

### DIFF
--- a/packages/snap-controller/src/Autocomplete/AutocompleteController.test.ts
+++ b/packages/snap-controller/src/Autocomplete/AutocompleteController.test.ts
@@ -287,7 +287,7 @@ describe('Autocomplete Controller', () => {
 
 		inputEl.value = 'wh';
 		inputEl.dispatchEvent(new Event('focus'));
-		inputEl.dispatchEvent(new KeyboardEvent('keyup', { bubbles: true, keyCode: 13 })); // Enter key
+		inputEl.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, keyCode: 13 })); // Enter key
 
 		// timeout needed due to beforeSubmit event and awaiting further input
 		await new Promise((resolve) => setTimeout(resolve, INPUT_DELAY + 1));

--- a/packages/snap-controller/src/Autocomplete/AutocompleteController.ts
+++ b/packages/snap-controller/src/Autocomplete/AutocompleteController.ts
@@ -170,8 +170,14 @@ export class AutocompleteController extends AbstractController {
 			}
 		}
 
-		//auto select first trending term?
-		if (!this.store.state?.input && this.store.trending?.length && !this.store.terms?.length && this.config.settings?.trending?.showResults) {
+		// auto select first trending term?
+		if (
+			inputElement &&
+			!this.store.state?.input &&
+			this.store.trending?.length &&
+			!this.store.terms?.length &&
+			this.config.settings?.trending?.showResults
+		) {
 			this.store.trending[0].preview();
 		} else {
 			inputElement?.dispatchEvent(new Event('keyup'));
@@ -189,10 +195,12 @@ export class AutocompleteController extends AbstractController {
 
 	handlers = {
 		input: {
-			enterKey: async (e: KeyboardEvent): Promise<void> => {
+			enterKey: async (e: KeyboardEvent): Promise<boolean> => {
 				if (e.keyCode == KEY_ENTER) {
-					const actionUrl = url(this.config.action);
 					const input = e.target as HTMLInputElement;
+					let actionUrl = this.store.services.urlManager;
+
+					e.preventDefault();
 
 					// when spellCorrection is enabled
 					if (this.config.globals?.search?.query?.spellCorrection) {
@@ -206,12 +214,11 @@ export class AutocompleteController extends AbstractController {
 						// use corrected query and originalQuery
 						if (this.store.search.originalQuery) {
 							input.value = this.store.search.query.string;
-							actionUrl.params.query[PARAM_ORIGINAL_QUERY] = this.store.search.originalQuery.string;
+							actionUrl = actionUrl.set(PARAM_ORIGINAL_QUERY, this.store.search.originalQuery.string);
 						}
 					}
 
-					const inputParam = input.name || (this.urlManager.getTranslatorConfig().queryParameter as string);
-					actionUrl.params.query[inputParam] = input.value;
+					actionUrl = actionUrl.set('query', input.value);
 
 					// TODO expected spell correct behavior queryAssumption
 
@@ -230,8 +237,7 @@ export class AutocompleteController extends AbstractController {
 						}
 					}
 
-					const newUrl = actionUrl.url();
-					window.location.href = newUrl;
+					window.location.href = actionUrl.href;
 				}
 			},
 			escKey: (e: KeyboardEvent): void => {
@@ -345,8 +351,8 @@ export class AutocompleteController extends AbstractController {
 		const inputs = document.querySelectorAll(`input[${INPUT_ATTRIBUTE}]`);
 		inputs?.forEach((input: HTMLInputElement) => {
 			input.removeEventListener('keyup', this.handlers.input.keyUp);
-			input.removeEventListener('keyup', this.handlers.input.enterKey);
-			input.removeEventListener('keyup', this.handlers.input.escKey);
+			input.removeEventListener('keydown', this.handlers.input.enterKey);
+			input.removeEventListener('keydown', this.handlers.input.escKey);
 			input.removeEventListener('focus', this.handlers.input.focus);
 			input.form?.removeEventListener('submit', this.handlers.input.formSubmit);
 		});
@@ -374,21 +380,16 @@ export class AutocompleteController extends AbstractController {
 			}
 
 			input.addEventListener('focus', this.handlers.input.focus);
-			input.addEventListener('keyup', this.handlers.input.escKey);
+			input.addEventListener('keydown', this.handlers.input.escKey);
 
 			const form = input.form;
+			let formActionUrl;
 
-			let formActionUrl = this.config.action;
-
-			if (!form && this.config.action) {
-				input.addEventListener('keyup', this.handlers.input.enterKey);
+			if (this.config.action) {
+				formActionUrl = this.config.action;
+				input.addEventListener('keydown', this.handlers.input.enterKey);
 			} else if (form) {
-				if (this.config.action) {
-					form.action = this.config.action;
-				} else {
-					formActionUrl = form.action;
-				}
-
+				formActionUrl = form.action;
 				form.addEventListener('submit', this.handlers.input.formSubmit);
 			}
 


### PR DESCRIPTION
* utilize UrlManager translation to generate URL on `enterKey` handler
* change the way `config.action` is utilized
* move to `keydown` for certain handlers

Previously `config.action` would alter the existing form action - but this prevented complete override of a form entirely. It makes more sense to ignore the form entirely if `config.action` is provided as the form action can easily be modified separately. Additionally the URL generated by the `enterKey` handler was not utilizing the UrlManager, this is necessary in order to handle special URLs that may not be using query parameters. In order to override form submission the `enterKey` handler was moved to `keydown` instead of `keyup` in order to catch the event and prevent it. It was also decided to move `escKey` to `keydown` as well.