### PR TITLE
Skeleton documentation

### DIFF
--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -64,6 +64,15 @@ Similar to the above context variables however these do not apply globally. They
         branch: 'production',
         batched: true
 	};
+    shopper = {
+		id: 'snapdev',
+		cart: [
+			{
+                sku: 'product123', 
+                childSku: 'product123_a' ,
+            }
+		]
+	};
 </script>
 ```
 

--- a/docs/PREACT_CONFIG.md
+++ b/docs/PREACT_CONFIG.md
@@ -26,11 +26,13 @@ const config = {
 					{
 						selector: '#searchspring-content',
 						component: () => Content,
+						skeleton: () => ContentSkel,
 						hideTarget: true,
 					},
 					{
 						selector: '#searchspring-sidebar',
 						component: () => Sidebar,
+						skeleton: () => SidebarSkel,
 						hideTarget: true,
 					},
 				],
@@ -101,6 +103,8 @@ We also have a `targeters` array of DomTargeter `targeter` configuration objects
 `targeter.component` specifies a function that returns a reference to the component to render at the target selector. 
 
 `targeter.hideTarget` boolean that specifies if the target node should be hidden before the component is mounted and rendered. It is recommended to enable this to prevent flashy behaviour. 
+
+`targeter.skeleton` (optional) meant to be used as a "loading" component. This specifies a function that returns a reference to the component to render immediately at the target selector to show briefly while the data is returning and the real component is rendering. You can use any component you want for this, although `snap-preact-components` provides a `skeleton` component for you to use if preferred.
 
 `targeter.props` (optional) convenient way of passing additional props to the component, by default we pass `controller`
 

--- a/packages/snap-preact-components/src/components/Atoms/Skeleton/Skeleton.stories.tsx
+++ b/packages/snap-preact-components/src/components/Atoms/Skeleton/Skeleton.stories.tsx
@@ -5,7 +5,7 @@ import { ArgsTable, PRIMARY_STORY } from '@storybook/addon-docs/blocks';
 
 import { componentArgs } from '../../../utilities';
 import { Skeleton } from './Skeleton';
-import Readme from '../Badge/readme.md';
+import Readme from '../Skeleton/readme.md';
 
 export default {
 	title: `Atoms/Skeleton`,

--- a/packages/snap-tracker/README.md
+++ b/packages/snap-tracker/README.md
@@ -61,7 +61,9 @@ This method will call the `retarget` method on all `DomTargeters` set in the Tra
 
 ```html
 <script type="searchspring/track/shopper/login">
-    id = 'snapdev';
+    shopper = {
+		id: 'snapdev',
+	};
 </script>
 ```
 


### PR DESCRIPTION
correcting docs tabs for the Skeleton storybook component
added skeleton usage and info to our main docs. 
updated INTEGRATION.md under recommendation context - added shopper.id and shopper.cart
updated tracker readme.md example to have shopper.id