### PR TITLE
fix(searchrequest): allow queries with leading and trailing spaces

### DIFF
--- a/packages/snap-client/src/Client/transforms/searchRequest.test.ts
+++ b/packages/snap-client/src/Client/transforms/searchRequest.test.ts
@@ -79,7 +79,7 @@ describe('search request search transform', () => {
 		expect(params).toEqual({});
 	});
 
-	it('generates trimmed query', () => {
+	it('should not trim query', () => {
 		const params = transformSearchRequest.search({
 			search: {
 				query: {
@@ -88,19 +88,7 @@ describe('search request search transform', () => {
 			},
 		});
 
-		expect(params.q).toEqual('a query');
-	});
-
-	it("accepts extended 'string' syntax", () => {
-		const params = transformSearchRequest.search({
-			search: {
-				query: {
-					string: ' extended query ',
-				},
-			},
-		});
-
-		expect(params.q).toEqual('extended query');
+		expect(params.q).toEqual(' a query ');
 	});
 
 	it('generates trimmed subQuery parameter', () => {

--- a/packages/snap-client/src/Client/transforms/searchRequest.ts
+++ b/packages/snap-client/src/Client/transforms/searchRequest.ts
@@ -46,7 +46,7 @@ transformSearchRequest.search = (request: SearchRequestModel = {}) => {
 	} = {};
 
 	if (reqSearch.query && reqSearch.query.string) {
-		search.q = reqSearch.query.string.trim();
+		search.q = reqSearch.query.string;
 	}
 
 	if (reqSearch.subQuery) {


### PR DESCRIPTION
This is the quick fix that allows for queries with spaces to be pasted and searched for in autocomplete. 

cc #447 