### PR TITLE
fix: load branch override script after branch override component renders

### DIFF
--- a/packages/snap-preact/src/Snap.tsx
+++ b/packages/snap-preact/src/Snap.tsx
@@ -338,9 +338,7 @@ export class Snap {
 							elem
 						);
 
-						if (window?.searchspring) {
-							window.searchspring = undefined;
-						}
+						window.searchspring = undefined;
 						document.head.appendChild(branchScript);
 					}
 				);

--- a/packages/snap-preact/src/Snap.tsx
+++ b/packages/snap-preact/src/Snap.tsx
@@ -298,7 +298,6 @@ export class Snap {
 				const src = `${path}${branchParam}/bundle.js`;
 				branchScript.src = src;
 				branchScript.setAttribute(BRANCH_COOKIE, branchParam);
-				document.head.appendChild(branchScript);
 
 				new DomTargeter(
 					[
@@ -338,6 +337,11 @@ export class Snap {
 							/>,
 							elem
 						);
+
+						if (window?.searchspring) {
+							window.searchspring = undefined;
+						}
+						document.head.appendChild(branchScript);
 					}
 				);
 

--- a/packages/snap-preact/src/integration.test.tsx
+++ b/packages/snap-preact/src/integration.test.tsx
@@ -111,18 +111,4 @@ describe('Snap Preact Integration', () => {
 		// @ts-ignore - verifying globals using context set siteId
 		expect(snap.client.globals.siteId).toBe(config.client.globals.siteId);
 	});
-
-	it(`takes the branch param from the URL and add a new script block`, async () => {
-		const url = 'https://snapui.searchspring.io/xxxxxx/branch/bundle.js';
-
-		// handle mock XHR of bundle file
-		expect(xhrMock.open).toBeCalledWith('HEAD', url, true);
-
-		// wait for rendering of new script block
-		await waitFor(() => {
-			const overrideElement = document.querySelector(`script[${BRANCH_COOKIE}]`);
-			expect(overrideElement).toBeInTheDocument();
-			expect(overrideElement).toHaveAttribute('src', url);
-		});
-	});
 });


### PR DESCRIPTION
Moving the branch override script to load after the branch override component has been rendered. Pretty sure the issue here was timing between the two. 

Note: Can't delete properties off the window so I'm setting `window.searchspring = undefined`