### PR TITLE
`withController` and `withStore` Fix

### DIFF
--- a/packages/snap-preact-components/src/providers/controller.tsx
+++ b/packages/snap-preact-components/src/providers/controller.tsx
@@ -12,6 +12,7 @@ export const useController = () => useContext(ControllerContext);
 
 export function withController<C extends ComponentType>(Component: C): C {
 	return ((props: any) => (
-		<ControllerContext.Consumer>{(controller) => <Component {...props} controller={controller} />}</ControllerContext.Consumer>
+		// additional props must come after controller prop
+		<Component controller={useController()} {...props} />
 	)) as C;
 }

--- a/packages/snap-preact-components/src/providers/store.tsx
+++ b/packages/snap-preact-components/src/providers/store.tsx
@@ -1,4 +1,4 @@
-import preact, { h, createContext, ComponentChildren, ComponentType } from 'preact';
+import { h, createContext, ComponentChildren, ComponentType } from 'preact';
 import { useContext } from 'preact/hooks';
 import type { AbstractStore } from '@searchspring/snap-store-mobx';
 
@@ -11,5 +11,8 @@ export const StoreProvider = ({ children, store }: { children: ComponentChildren
 export const useStore = () => useContext(StoreContext);
 
 export function withStore<C extends ComponentType>(Component: C): C {
-	return ((props: any) => <StoreContext.Consumer>{(store) => <Component {...props} store={store} />}</StoreContext.Consumer>) as C;
+	return ((props: any) => (
+		// additional props must come after store prop
+		<Component store={useStore()} {...props} />
+	)) as C;
 }


### PR DESCRIPTION
* withStore and withController prop order reversion - order is important when provider is mistakenly used on root components