### PR TITLE
fix: remove empty search object from stringyParams key

### DIFF
--- a/packages/snap-controller/src/Search/SearchController.ts
+++ b/packages/snap-controller/src/Search/SearchController.ts
@@ -153,6 +153,10 @@ export class SearchController extends AbstractController {
 					const paramsObj = JSON.parse(stringyParams);
 					if (paramsObj?.search?.redirectResponse) {
 						delete paramsObj?.search?.redirectResponse;
+						if (paramsObj?.search && Object.keys(paramsObj?.search).length === 0) {
+							// if redirectResponse was the only key, also delete the empty search object
+							delete paramsObj.search;
+						}
 					}
 					if (paramsObj?.personalization) {
 						delete paramsObj?.personalization;


### PR DESCRIPTION
To recreate the issue:
- paginate with infinite scroll (ie. go to page 3)
- refresh page
- click on product to save location to storage
- click back, page should jump to scrolled location
- paginate to next page
- click on product, gets save to storage but includes `search: {}` within key
- click back, page does not jump because the request params no longer contains `search: {}`

After we `delete paramsObj?.search?.redirectResponse;` we should also `delete paramsObj?.search` if it is empty which looks to resolve this. 

