### PR TITLE
Form Parameters

### DIFF
--- a/packages/snap-controller/src/Autocomplete/AutocompleteController.ts
+++ b/packages/snap-controller/src/Autocomplete/AutocompleteController.ts
@@ -627,10 +627,7 @@ function getFormParameters(form: HTMLFormElement, filterFn: any): { [formName: s
 			}
 
 			if (elem.name && !INPUT_TYPE_BLACKLIST.includes(elem.type)) {
-				// parameters[elem.name] = elem.value;
-
 				if ((elem.type != 'checkbox' && elem.type != 'radio') || elem.checked) {
-					// parameters[elem.name] = undefined;
 					parameters[elem.name] = elem.value;
 				}
 			}

--- a/packages/snap-controller/src/Autocomplete/README.md
+++ b/packages/snap-controller/src/Autocomplete/README.md
@@ -12,6 +12,7 @@ The `AutocompleteController` is used when making queries to the API `autocomplet
 | globals | keys defined here will be passed to the [API request](https://snapi.kube.searchspring.io/api/v1/) (can overwrite global config)| ➖ |   |
 | settings.initializeFromUrl | initialize the controller with query parameter from URL (pre-fill input with current search) | true |   |
 | settings.syncInputs | if the selector targets multiple inputs, the value of those inputs will be synced | true |   |
+| settings.serializeForm | if no action is specified in the config and a form element is found for the input, additional elements that are found will be added to the generated URLs (eg. hidden form input) | true |   |
 | settings.facets.trim | facets that do not change results will be removed | true |   |
 | settings.trending.limit | when set, trending (popular) queries will be fetched and made available in the trending store | ➖ |   |
 

--- a/packages/snap-preact-components/src/components/Molecules/Select/Select.tsx
+++ b/packages/snap-preact-components/src/components/Molecules/Select/Select.tsx
@@ -137,20 +137,11 @@ export const Select = observer((properties: SelectProps): JSX.Element => {
 		},
 	};
 
-	// only single selection support for now
-	let selection: Option | undefined = selected;
-	let setSelection: StateUpdater<Option | undefined>;
-
 	// open state
 	const [open, setOpen] = useState<boolean>(Boolean(startOpen));
 
 	// selection state
-	const stateful = selection === undefined;
-	if (stateful) {
-		[selection, setSelection] = useState<Option | undefined>(undefined);
-	} else {
-		selection = Array.isArray(selected) ? selected[0] : selection;
-	}
+	const [selection, setSelection] = useState<Option | undefined>(selected);
 
 	if (selection && clearSelection) {
 		options = [
@@ -163,15 +154,11 @@ export const Select = observer((properties: SelectProps): JSX.Element => {
 	}
 
 	const makeSelection = (e: React.ChangeEvent<HTMLSelectElement>, option?: Option) => {
-		option = option?.value ? option : undefined;
-
 		if (option != selection) {
 			onSelect && onSelect(e, option);
 		}
 
-		if (stateful) {
-			setSelection(option);
-		}
+		setSelection(option);
 
 		!stayOpenOnSelection && setOpen(false);
 	};
@@ -187,7 +174,8 @@ export const Select = observer((properties: SelectProps): JSX.Element => {
 		styling.css = [style];
 	}
 
-	return Array.isArray(options) && options.length ? (
+	// options can be an Array or ObservableArray - but should have length
+	return typeof options == 'object' && options?.length ? (
 		<CacheProvider>
 			<div {...styling} className={classnames('ss__select', { 'ss__select--disabled': disabled }, className)}>
 				{native ? (

--- a/packages/snap-preact-components/src/components/Molecules/Select/Select.tsx
+++ b/packages/snap-preact-components/src/components/Molecules/Select/Select.tsx
@@ -137,11 +137,20 @@ export const Select = observer((properties: SelectProps): JSX.Element => {
 		},
 	};
 
+	// only single selection support for now
+	let selection: Option | undefined = selected;
+	let setSelection: StateUpdater<Option | undefined>;
+
 	// open state
 	const [open, setOpen] = useState<boolean>(Boolean(startOpen));
 
 	// selection state
-	const [selection, setSelection] = useState<Option | undefined>(selected);
+	const stateful = selection === undefined;
+	if (stateful) {
+		[selection, setSelection] = useState<Option | undefined>(undefined);
+	} else {
+		selection = Array.isArray(selected) ? selected[0] : selection;
+	}
 
 	if (selection && clearSelection) {
 		options = [
@@ -154,11 +163,15 @@ export const Select = observer((properties: SelectProps): JSX.Element => {
 	}
 
 	const makeSelection = (e: React.ChangeEvent<HTMLSelectElement>, option?: Option) => {
+		option = option?.value ? option : undefined;
+
 		if (option != selection) {
 			onSelect && onSelect(e, option);
 		}
 
-		setSelection(option);
+		if (stateful) {
+			setSelection(option);
+		}
 
 		!stayOpenOnSelection && setOpen(false);
 	};
@@ -174,8 +187,7 @@ export const Select = observer((properties: SelectProps): JSX.Element => {
 		styling.css = [style];
 	}
 
-	// options can be an Array or ObservableArray - but should have length
-	return typeof options == 'object' && options?.length ? (
+	return Array.isArray(options) && options.length ? (
 		<CacheProvider>
 			<div {...styling} className={classnames('ss__select', { 'ss__select--disabled': disabled }, className)}>
 				{native ? (

--- a/packages/snap-preact/src/create/createAutocompleteController.ts
+++ b/packages/snap-preact/src/create/createAutocompleteController.ts
@@ -14,7 +14,7 @@ import type { SnapControllerServices, SnapAutocompleteControllerConfig } from '.
 configureMobx({ useProxies: 'never' });
 
 export default (config: SnapAutocompleteControllerConfig, services?: SnapControllerServices): AutocompleteController => {
-	const urlManager = (services?.urlManager || new UrlManager(new UrlTranslator(config.url), reactLinker)).detach();
+	const urlManager = (services?.urlManager || new UrlManager(new UrlTranslator(config.url), reactLinker)).detach(true);
 
 	// set client mode
 	if (config.mode && config.client) {

--- a/packages/snap-store-mobx/src/types.ts
+++ b/packages/snap-store-mobx/src/types.ts
@@ -58,6 +58,7 @@ export type AutocompleteStoreConfig = StoreConfig & {
 	settings?: {
 		initializeFromUrl?: boolean;
 		syncInputs?: boolean;
+		serializeForm?: boolean;
 		facets?: FacetStoreConfig & {
 			fields?: {
 				[field: string]: FacetStoreConfig;

--- a/packages/snap-url-manager/src/Translators/QueryString/QueryStringTranslator.test.ts
+++ b/packages/snap-url-manager/src/Translators/QueryString/QueryStringTranslator.test.ts
@@ -2,6 +2,19 @@ import { QueryStringTranslator } from './QueryStringTranslator';
 import { UrlState } from '../../types';
 
 describe('QueryStringTranslator', () => {
+	it('has default configuration', () => {
+		const queryString = new QueryStringTranslator();
+		const defaultConfig = queryString.getConfig();
+
+		expect(defaultConfig.urlRoot).toEqual('');
+
+		expect(defaultConfig.settings).toEqual({
+			serializeUrlRoot: true,
+		});
+
+		expect(defaultConfig.queryParameter).toEqual('q');
+	});
+
 	it('generates relative URL by default', () => {
 		const url = 'http://example.com?bar=baz';
 		const queryString = new QueryStringTranslator();

--- a/packages/snap-url-manager/src/Translators/QueryString/README.md
+++ b/packages/snap-url-manager/src/Translators/QueryString/README.md
@@ -61,6 +61,7 @@ The `serialize` and `deserialize` methods are abstracted away by the `UrlManager
 |---|---|:---:|
 | queryParameter | used to specify a different query parameter for 'query' | 'q' |
 | urlRoot | used to redirect to other URLs | ➖ |
+| settings.serializeUrlRoot | sets parameters found within urlRoot to global state in UrlManager | true |
 
 <br>
 
@@ -88,4 +89,24 @@ urlManager.set({ query: 'green shirt' }).go();
 
 console.log(urlManager.state.query); // green shirt
 console.log(urlManager.href); // /search?search=green%20shirt
+```
+
+### urlRoot Configuration
+
+`urlRoot` specifies a root URL to use when URLs are created in the `serialize` method. By default any parameters in the `urlRoot` will be preserved and added to the final serialized URL; this can be disabled by setting the `settings.serializeUrlRoot` configuration to `false`.
+
+```js
+import { UrlManager, QueryStringTranslator } from '@searchspring/snap-url-manager';
+
+const urlManager = new UrlManager(
+	new QueryStringTranslator({
+		urlRoot: '/search?view=shop',
+		queryParameter: 'search'
+	});
+);
+
+const queriedUrlManager = urlManager.set({ query: 'green shirt', filter: { color: ['green'] } });
+
+console.log(queriedUrlManager.state.query); // green shirt
+console.log(queriedUrlManager.href); // /search?view=shop&search=green%20shirt&filter.color=green
 ```

--- a/packages/snap-url-manager/src/Translators/Url/README.md
+++ b/packages/snap-url-manager/src/Translators/Url/README.md
@@ -63,7 +63,7 @@ The `serialize` and `deserialize` methods are abstracted away by the `UrlManager
 | settings.corePrefix | specify a prefix to all core parameters | ➖ |
 | settings.coreType | quickly change the type of all core parameters | ➖ |
 | settings.customType | specify how custom parameters should be serialized | 'hash' |
-| settings.rootParams | enables addition of urlRoot parameters | true |
+| settings.serializeUrlRoot | sets parameters found within urlRoot to global state in UrlManager | true |
 | parameters.core | optional mapping of core param names and types  | ➖ |
 | parameters.custom | optional mapping of custom param types | ➖ |
 
@@ -164,14 +164,14 @@ console.log(setUrlManager.href); // /search?view=spring#/store:products
 
 ### urlRoot Configuration
 
-`urlRoot` specifies a root URL to use when URLs are created in the `serialize` method. By default any parameters in the `urlRoot` will be preserved and added to the final serialized URL; this can be disabled by setting the `settings.rootParams` configuration to `false`.
+`urlRoot` specifies a root URL to use when URLs are created in the `serialize` method. By default any parameters in the `urlRoot` will be preserved and added to the final serialized URL; this can be disabled by setting the `settings.serializeUrlRoot` configuration to `false`.
 
 ```js
 import { UrlManager, UrlTranslator } from '@searchspring/snap-url-manager';
 
 const urlManager = new UrlManager(
 	new UrlTranslator({
-		urlRoot: '/search#view:grid',
+		urlRoot: '/search?view=shop',
 		parameters: {
 			core: {
 				query: { name: 'search' },
@@ -183,5 +183,5 @@ const urlManager = new UrlManager(
 const queriedUrlManager = urlManager.set({ query: 'green shirt', filter: { color: ['green'] } });
 
 console.log(queriedUrlManager.state.query); // green shirt
-console.log(queriedUrlManager.href); // /search?search=green%20shirt#/view:grid/filter:color:green
+console.log(queriedUrlManager.href); // /search?view=shop&search=green%20shirt#/filter:color:green
 ```

--- a/packages/snap-url-manager/src/types.ts
+++ b/packages/snap-url-manager/src/types.ts
@@ -48,8 +48,12 @@ export interface Translator {
 }
 
 export interface TranslatorConfig {
-	queryParameter?: string;
 	urlRoot?: string;
+	settings?: {
+		serializeUrlRoot?: boolean;
+		[any: string]: unknown;
+	};
+	[any: string]: unknown;
 }
 
 export enum ParamLocationType {


### PR DESCRIPTION
* adding support for UrlManager rootUrl parameter ingestion via `serializeUrlRoot` setting
* adding support for picking up additional form parameters in AutocompleteController via `serializeForm` setting
* changed order of custom parameters in UrlTranslator and QueryStringTranslator to be at the beginning
* changed UrlTranslator to use query type as default