### PR TITLE
Release v0.34.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 			],
 			"devDependencies": {
 				"@searchspring/prettier": "1.0.2",
-				"@searchspring/snapi-types": "0.1.27",
+				"@searchspring/snapi-types": "0.1.28",
 				"@types/jest": "27.5.1",
 				"@types/jsdom": "16.2.14",
 				"@typescript-eslint/eslint-plugin": "5.25.0",
@@ -10578,9 +10578,9 @@
 			"link": true
 		},
 		"node_modules/@searchspring/snapi-types": {
-			"version": "0.1.27",
-			"resolved": "https://registry.npmjs.org/@searchspring/snapi-types/-/snapi-types-0.1.27.tgz",
-			"integrity": "sha512-M85nygXz9LWnR2oKZD4we3b8U87owO8pTxOQ5A6XIrc/uPWqJz2GlUzI0c1ClGgqSeGmcnDTrqzHF5l6SYC2zw==",
+			"version": "0.1.28",
+			"resolved": "https://registry.npmjs.org/@searchspring/snapi-types/-/snapi-types-0.1.28.tgz",
+			"integrity": "sha512-aWfXHj31gZETinA+7NDwV/g0mFOGyp0GbW/c0AlDLvSVMkbX0vsLKbiMO8H9/rIHCylZbvBxp+5zhP8Sfl5apg==",
 			"dev": true
 		},
 		"node_modules/@sindresorhus/is": {
@@ -43904,59 +43904,59 @@
 		},
 		"packages/snap-client": {
 			"name": "@searchspring/snap-client",
-			"version": "0.30.1",
+			"version": "0.33.0",
 			"license": "MIT",
 			"dependencies": {
-				"@searchspring/snap-toolbox": "^0.30.1",
+				"@searchspring/snap-toolbox": "^0.33.0",
 				"deepmerge": "4.2.2"
 			}
 		},
 		"packages/snap-controller": {
 			"name": "@searchspring/snap-controller",
-			"version": "0.30.1",
+			"version": "0.33.0",
 			"license": "MIT",
 			"dependencies": {
-				"@searchspring/snap-toolbox": "^0.30.1",
+				"@searchspring/snap-toolbox": "^0.33.0",
 				"deepmerge": "4.2.2"
 			},
 			"devDependencies": {
-				"@searchspring/snap-client": "^0.30.1",
-				"@searchspring/snap-event-manager": "^0.30.1",
-				"@searchspring/snap-logger": "^0.30.1",
-				"@searchspring/snap-profiler": "^0.30.1",
-				"@searchspring/snap-store-mobx": "^0.30.1",
-				"@searchspring/snap-tracker": "^0.30.1",
-				"@searchspring/snap-url-manager": "^0.30.1"
+				"@searchspring/snap-client": "^0.33.0",
+				"@searchspring/snap-event-manager": "^0.33.0",
+				"@searchspring/snap-logger": "^0.33.0",
+				"@searchspring/snap-profiler": "^0.33.0",
+				"@searchspring/snap-store-mobx": "^0.33.0",
+				"@searchspring/snap-tracker": "^0.33.0",
+				"@searchspring/snap-url-manager": "^0.33.0"
 			}
 		},
 		"packages/snap-event-manager": {
 			"name": "@searchspring/snap-event-manager",
-			"version": "0.30.1",
+			"version": "0.33.0",
 			"license": "MIT"
 		},
 		"packages/snap-logger": {
 			"name": "@searchspring/snap-logger",
-			"version": "0.30.1",
+			"version": "0.33.0",
 			"license": "MIT",
 			"dependencies": {
-				"@searchspring/snap-toolbox": "^0.30.1"
+				"@searchspring/snap-toolbox": "^0.33.0"
 			}
 		},
 		"packages/snap-preact": {
 			"name": "@searchspring/snap-preact",
-			"version": "0.30.1",
+			"version": "0.33.0",
 			"license": "MIT",
 			"dependencies": {
-				"@searchspring/snap-client": "^0.30.1",
-				"@searchspring/snap-controller": "^0.30.1",
-				"@searchspring/snap-event-manager": "^0.30.1",
-				"@searchspring/snap-logger": "^0.30.1",
-				"@searchspring/snap-preact-components": "^0.30.1",
-				"@searchspring/snap-profiler": "^0.30.1",
-				"@searchspring/snap-store-mobx": "^0.30.1",
-				"@searchspring/snap-toolbox": "^0.30.1",
-				"@searchspring/snap-tracker": "^0.30.1",
-				"@searchspring/snap-url-manager": "^0.30.1",
+				"@searchspring/snap-client": "^0.33.0",
+				"@searchspring/snap-controller": "^0.33.0",
+				"@searchspring/snap-event-manager": "^0.33.0",
+				"@searchspring/snap-logger": "^0.33.0",
+				"@searchspring/snap-preact-components": "^0.33.0",
+				"@searchspring/snap-profiler": "^0.33.0",
+				"@searchspring/snap-store-mobx": "^0.33.0",
+				"@searchspring/snap-toolbox": "^0.33.0",
+				"@searchspring/snap-tracker": "^0.33.0",
+				"@searchspring/snap-url-manager": "^0.33.0",
 				"deepmerge": "4.2.2",
 				"intersection-observer": "0.12.0",
 				"is-plain-object": "5.0.0"
@@ -43967,11 +43967,11 @@
 		},
 		"packages/snap-preact-components": {
 			"name": "@searchspring/snap-preact-components",
-			"version": "0.30.1",
+			"version": "0.33.0",
 			"license": "MIT",
 			"dependencies": {
 				"@emotion/react": "11.9.0",
-				"@searchspring/snap-toolbox": "^0.30.1",
+				"@searchspring/snap-toolbox": "^0.33.0",
 				"classnames": "2.3.1",
 				"deepmerge": "4.2.2",
 				"mobx-react-lite": "3.4.0",
@@ -43979,14 +43979,14 @@
 				"swiper": "6.8.4"
 			},
 			"devDependencies": {
-				"@searchspring/snap-client": "^0.30.1",
-				"@searchspring/snap-controller": "^0.30.1",
-				"@searchspring/snap-event-manager": "^0.30.1",
-				"@searchspring/snap-logger": "^0.30.1",
-				"@searchspring/snap-profiler": "^0.30.1",
-				"@searchspring/snap-store-mobx": "^0.30.1",
-				"@searchspring/snap-tracker": "^0.30.1",
-				"@searchspring/snap-url-manager": "^0.30.1",
+				"@searchspring/snap-client": "^0.33.0",
+				"@searchspring/snap-controller": "^0.33.0",
+				"@searchspring/snap-event-manager": "^0.33.0",
+				"@searchspring/snap-logger": "^0.33.0",
+				"@searchspring/snap-profiler": "^0.33.0",
+				"@searchspring/snap-store-mobx": "^0.33.0",
+				"@searchspring/snap-tracker": "^0.33.0",
+				"@searchspring/snap-url-manager": "^0.33.0",
 				"@storybook/addon-actions": "6.4.22",
 				"@storybook/addon-controls": "6.4.22",
 				"@storybook/addon-docs": "6.4.22",
@@ -44393,11 +44393,11 @@
 		},
 		"packages/snap-preact-demo": {
 			"name": "@searchspring/snap-preact-demo",
-			"version": "0.30.1",
+			"version": "0.33.0",
 			"license": "MIT",
 			"dependencies": {
-				"@searchspring/snap-preact": "^0.30.1",
-				"@searchspring/snap-preact-components": "^0.30.1",
+				"@searchspring/snap-preact": "^0.33.0",
+				"@searchspring/snap-preact-components": "^0.33.0",
 				"deepmerge": "4.2.2",
 				"mobx": "6.6.0",
 				"mobx-react": "7.5.0",
@@ -44568,42 +44568,42 @@
 		},
 		"packages/snap-profiler": {
 			"name": "@searchspring/snap-profiler",
-			"version": "0.30.1",
+			"version": "0.33.0",
 			"license": "MIT"
 		},
 		"packages/snap-shared": {
 			"name": "@searchspring/snap-shared",
-			"version": "0.30.1",
+			"version": "0.33.0",
 			"license": "MIT",
 			"devDependencies": {
-				"@searchspring/snap-client": "^0.30.1"
+				"@searchspring/snap-client": "^0.33.0"
 			}
 		},
 		"packages/snap-store-mobx": {
 			"name": "@searchspring/snap-store-mobx",
-			"version": "0.30.1",
+			"version": "0.33.0",
 			"license": "MIT",
 			"dependencies": {
-				"@searchspring/snap-toolbox": "^0.30.1",
+				"@searchspring/snap-toolbox": "^0.33.0",
 				"mobx": "6.6.0"
 			},
 			"devDependencies": {
-				"@searchspring/snap-client": "^0.30.1",
-				"@searchspring/snap-url-manager": "^0.30.1"
+				"@searchspring/snap-client": "^0.33.0",
+				"@searchspring/snap-url-manager": "^0.33.0"
 			}
 		},
 		"packages/snap-toolbox": {
 			"name": "@searchspring/snap-toolbox",
-			"version": "0.30.1",
+			"version": "0.33.0",
 			"license": "MIT"
 		},
 		"packages/snap-tracker": {
 			"name": "@searchspring/snap-tracker",
-			"version": "0.30.1",
+			"version": "0.33.0",
 			"license": "MIT",
 			"dependencies": {
-				"@searchspring/snap-store-mobx": "^0.30.1",
-				"@searchspring/snap-toolbox": "^0.30.1",
+				"@searchspring/snap-store-mobx": "^0.33.0",
+				"@searchspring/snap-toolbox": "^0.33.0",
 				"@types/uuid": "8.3.4",
 				"deepmerge": "4.2.2",
 				"uuid": "8.3.2"
@@ -44611,7 +44611,7 @@
 		},
 		"packages/snap-url-manager": {
 			"name": "@searchspring/snap-url-manager",
-			"version": "0.30.1",
+			"version": "0.33.0",
 			"license": "MIT",
 			"dependencies": {
 				"deepmerge": "4.2.2",
@@ -53257,21 +53257,21 @@
 		"@searchspring/snap-client": {
 			"version": "file:packages/snap-client",
 			"requires": {
-				"@searchspring/snap-toolbox": "^0.30.1",
+				"@searchspring/snap-toolbox": "^0.33.0",
 				"deepmerge": "4.2.2"
 			}
 		},
 		"@searchspring/snap-controller": {
 			"version": "file:packages/snap-controller",
 			"requires": {
-				"@searchspring/snap-client": "^0.30.1",
-				"@searchspring/snap-event-manager": "^0.30.1",
-				"@searchspring/snap-logger": "^0.30.1",
-				"@searchspring/snap-profiler": "^0.30.1",
-				"@searchspring/snap-store-mobx": "^0.30.1",
-				"@searchspring/snap-toolbox": "^0.30.1",
-				"@searchspring/snap-tracker": "^0.30.1",
-				"@searchspring/snap-url-manager": "^0.30.1",
+				"@searchspring/snap-client": "^0.33.0",
+				"@searchspring/snap-event-manager": "^0.33.0",
+				"@searchspring/snap-logger": "^0.33.0",
+				"@searchspring/snap-profiler": "^0.33.0",
+				"@searchspring/snap-store-mobx": "^0.33.0",
+				"@searchspring/snap-toolbox": "^0.33.0",
+				"@searchspring/snap-tracker": "^0.33.0",
+				"@searchspring/snap-url-manager": "^0.33.0",
 				"deepmerge": "4.2.2"
 			}
 		},
@@ -53281,22 +53281,22 @@
 		"@searchspring/snap-logger": {
 			"version": "file:packages/snap-logger",
 			"requires": {
-				"@searchspring/snap-toolbox": "^0.30.1"
+				"@searchspring/snap-toolbox": "^0.33.0"
 			}
 		},
 		"@searchspring/snap-preact": {
 			"version": "file:packages/snap-preact",
 			"requires": {
-				"@searchspring/snap-client": "^0.30.1",
-				"@searchspring/snap-controller": "^0.30.1",
-				"@searchspring/snap-event-manager": "^0.30.1",
-				"@searchspring/snap-logger": "^0.30.1",
-				"@searchspring/snap-preact-components": "^0.30.1",
-				"@searchspring/snap-profiler": "^0.30.1",
-				"@searchspring/snap-store-mobx": "^0.30.1",
-				"@searchspring/snap-toolbox": "^0.30.1",
-				"@searchspring/snap-tracker": "^0.30.1",
-				"@searchspring/snap-url-manager": "^0.30.1",
+				"@searchspring/snap-client": "^0.33.0",
+				"@searchspring/snap-controller": "^0.33.0",
+				"@searchspring/snap-event-manager": "^0.33.0",
+				"@searchspring/snap-logger": "^0.33.0",
+				"@searchspring/snap-preact-components": "^0.33.0",
+				"@searchspring/snap-profiler": "^0.33.0",
+				"@searchspring/snap-store-mobx": "^0.33.0",
+				"@searchspring/snap-toolbox": "^0.33.0",
+				"@searchspring/snap-tracker": "^0.33.0",
+				"@searchspring/snap-url-manager": "^0.33.0",
 				"@types/react": "16.14.28",
 				"deepmerge": "4.2.2",
 				"intersection-observer": "0.12.0",
@@ -53314,15 +53314,15 @@
 			"version": "file:packages/snap-preact-components",
 			"requires": {
 				"@emotion/react": "11.9.0",
-				"@searchspring/snap-client": "^0.30.1",
-				"@searchspring/snap-controller": "^0.30.1",
-				"@searchspring/snap-event-manager": "^0.30.1",
-				"@searchspring/snap-logger": "^0.30.1",
-				"@searchspring/snap-profiler": "^0.30.1",
-				"@searchspring/snap-store-mobx": "^0.30.1",
-				"@searchspring/snap-toolbox": "^0.30.1",
-				"@searchspring/snap-tracker": "^0.30.1",
-				"@searchspring/snap-url-manager": "^0.30.1",
+				"@searchspring/snap-client": "^0.33.0",
+				"@searchspring/snap-controller": "^0.33.0",
+				"@searchspring/snap-event-manager": "^0.33.0",
+				"@searchspring/snap-logger": "^0.33.0",
+				"@searchspring/snap-profiler": "^0.33.0",
+				"@searchspring/snap-store-mobx": "^0.33.0",
+				"@searchspring/snap-toolbox": "^0.33.0",
+				"@searchspring/snap-tracker": "^0.33.0",
+				"@searchspring/snap-url-manager": "^0.33.0",
 				"@storybook/addon-actions": "6.4.22",
 				"@storybook/addon-controls": "6.4.22",
 				"@storybook/addon-docs": "6.4.22",
@@ -53614,8 +53614,8 @@
 				"@babel/runtime": "7.18.3",
 				"@lhci/cli": "0.8.2",
 				"@searchspring/browserslist-config-snap": "1.0.6",
-				"@searchspring/snap-preact": "^0.30.1",
-				"@searchspring/snap-preact-components": "^0.30.1",
+				"@searchspring/snap-preact": "^0.33.0",
+				"@searchspring/snap-preact-components": "^0.33.0",
 				"babel-loader": "8.2.5",
 				"core-js": "3.22.8",
 				"css-loader": "6.7.1",
@@ -53736,15 +53736,15 @@
 		"@searchspring/snap-shared": {
 			"version": "file:packages/snap-shared",
 			"requires": {
-				"@searchspring/snap-client": "^0.30.1"
+				"@searchspring/snap-client": "^0.33.0"
 			}
 		},
 		"@searchspring/snap-store-mobx": {
 			"version": "file:packages/snap-store-mobx",
 			"requires": {
-				"@searchspring/snap-client": "^0.30.1",
-				"@searchspring/snap-toolbox": "^0.30.1",
-				"@searchspring/snap-url-manager": "^0.30.1",
+				"@searchspring/snap-client": "^0.33.0",
+				"@searchspring/snap-toolbox": "^0.33.0",
+				"@searchspring/snap-url-manager": "^0.33.0",
 				"mobx": "6.6.0"
 			}
 		},
@@ -53754,8 +53754,8 @@
 		"@searchspring/snap-tracker": {
 			"version": "file:packages/snap-tracker",
 			"requires": {
-				"@searchspring/snap-store-mobx": "^0.30.1",
-				"@searchspring/snap-toolbox": "^0.30.1",
+				"@searchspring/snap-store-mobx": "^0.33.0",
+				"@searchspring/snap-toolbox": "^0.33.0",
 				"@types/uuid": "8.3.4",
 				"deepmerge": "4.2.2",
 				"uuid": "8.3.2"
@@ -53770,9 +53770,9 @@
 			}
 		},
 		"@searchspring/snapi-types": {
-			"version": "0.1.27",
-			"resolved": "https://registry.npmjs.org/@searchspring/snapi-types/-/snapi-types-0.1.27.tgz",
-			"integrity": "sha512-M85nygXz9LWnR2oKZD4we3b8U87owO8pTxOQ5A6XIrc/uPWqJz2GlUzI0c1ClGgqSeGmcnDTrqzHF5l6SYC2zw==",
+			"version": "0.1.28",
+			"resolved": "https://registry.npmjs.org/@searchspring/snapi-types/-/snapi-types-0.1.28.tgz",
+			"integrity": "sha512-aWfXHj31gZETinA+7NDwV/g0mFOGyp0GbW/c0AlDLvSVMkbX0vsLKbiMO8H9/rIHCylZbvBxp+5zhP8Sfl5apg==",
 			"dev": true
 		},
 		"@sindresorhus/is": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 	"prettier": "@searchspring/prettier",
 	"devDependencies": {
 		"@searchspring/prettier": "1.0.2",
-		"@searchspring/snapi-types": "0.1.27",
+		"@searchspring/snapi-types": "0.1.28",
 		"@types/jest": "27.5.1",
 		"@types/jsdom": "16.2.14",
 		"@typescript-eslint/eslint-plugin": "5.25.0",

--- a/packages/snap-client/src/Client/apis/Legacy.ts
+++ b/packages/snap-client/src/Client/apis/Legacy.ts
@@ -7,6 +7,10 @@ export class LegacyAPI extends API {
 		queryParameters.resultsFormat = 'native';
 		const headerParameters: HTTPHeaders = {};
 
+		//remove pageLoadId from cache key query params
+		let cacheParameters = { ...queryParameters };
+		delete cacheParameters.pageLoadId;
+
 		const legacyResponse = await this.request(
 			{
 				path,
@@ -14,7 +18,7 @@ export class LegacyAPI extends API {
 				headers: headerParameters,
 				query: queryParameters,
 			},
-			path + JSON.stringify(queryParameters)
+			path + JSON.stringify(cacheParameters)
 		);
 
 		return legacyResponse;

--- a/packages/snap-client/src/Client/transforms/searchRequest.ts
+++ b/packages/snap-client/src/Client/transforms/searchRequest.ts
@@ -191,6 +191,8 @@ transformSearchRequest.tracking = (request: SearchRequestModel = {}) => {
 	const params: {
 		userId?: string;
 		domain?: string;
+		sessionId?: string;
+		pageLoadId?: string;
 	} = {};
 
 	if (reqTracking.userId) {
@@ -198,6 +200,12 @@ transformSearchRequest.tracking = (request: SearchRequestModel = {}) => {
 	}
 	if (reqTracking.domain) {
 		params.domain = reqTracking.domain;
+	}
+	if (reqTracking.sessionId) {
+		params.sessionId = reqTracking.sessionId;
+	}
+	if (reqTracking.pageLoadId) {
+		params.pageLoadId = reqTracking.pageLoadId;
 	}
 
 	return params;

--- a/packages/snap-controller/src/Autocomplete/AutocompleteController.ts
+++ b/packages/snap-controller/src/Autocomplete/AutocompleteController.ts
@@ -113,9 +113,20 @@ export class AutocompleteController extends AbstractController {
 		const params: AutocompleteRequestModel = deepmerge({ ...getSearchParams(urlState) }, this.config.globals!);
 
 		const userId = this.tracker.getUserId();
+		const sessionId = this.tracker.getContext().sessionId;
+		const pageLoadId = this.tracker.getContext().pageLoadId;
+		params.tracking = params.tracking || {};
+
+		params.tracking.domain = window.location.href;
+
 		if (userId) {
-			params.tracking = params.tracking || {};
 			params.tracking.userId = userId;
+		}
+		if (sessionId) {
+			params.tracking.sessionId = sessionId;
+		}
+		if (pageLoadId) {
+			params.tracking!.pageLoadId = pageLoadId;
 		}
 
 		if (!this.config.globals?.personalization?.disabled) {

--- a/packages/snap-controller/src/Finder/FinderController.ts
+++ b/packages/snap-controller/src/Finder/FinderController.ts
@@ -77,6 +77,22 @@ export class FinderController extends AbstractController {
 
 	get params(): Record<string, any> {
 		const urlState = this.urlManager.state;
+		const userId = this.tracker.getUserId();
+		const sessionId = this.tracker.getContext().sessionId;
+		const pageLoadId = this.tracker.getContext().pageLoadId;
+
+		let tracking: any = {};
+
+		if (userId) {
+			tracking.userId = userId;
+		}
+		if (sessionId) {
+			tracking.sessionId = sessionId;
+		}
+		if (pageLoadId) {
+			tracking!.pageLoadId = pageLoadId;
+		}
+		tracking.domain = window.location.href;
 
 		// get only the finder fields and disable auto drill down
 		const defaultParams = {
@@ -84,6 +100,7 @@ export class FinderController extends AbstractController {
 				include: this.config.fields.map((fieldConfig) => fieldConfig.field),
 				autoDrillDown: false,
 			},
+			tracking: tracking,
 		};
 
 		const params: Record<string, any> = deepmerge({ ...getSearchParams(urlState) }, deepmerge(defaultParams, this.config.globals));

--- a/packages/snap-controller/src/Recommendation/RecommendationController.ts
+++ b/packages/snap-controller/src/Recommendation/RecommendationController.ts
@@ -266,7 +266,8 @@ export class RecommendationController extends AbstractController {
 			order: this.context?.options?.order,
 			...this.config.globals,
 		};
-		const shopperId = this.tracker.context.shopperId;
+
+		const shopperId = this.tracker.getContext().shopperId;
 		const cart = this.tracker.cookies.cart.get();
 		const lastViewed = this.tracker.cookies.viewed.get();
 		if (shopperId) {

--- a/packages/snap-controller/src/Search/SearchController.test.ts
+++ b/packages/snap-controller/src/Search/SearchController.test.ts
@@ -630,10 +630,12 @@ describe('Search Controller', () => {
 
 		const scrollHeightSpy = jest.spyOn(document.documentElement, 'scrollHeight', 'get').mockImplementation(() => 1000);
 		const userId = controller.tracker.getUserId();
+		const sessionId = controller.tracker.getContext().sessionId;
 		const stringyParams = JSON.stringify({
 			filters: [],
 			tracking: {
 				userId: userId,
+				sessionId: sessionId,
 			},
 		});
 

--- a/packages/snap-controller/src/Search/SearchController.ts
+++ b/packages/snap-controller/src/Search/SearchController.ts
@@ -115,6 +115,10 @@ export class SearchController extends AbstractController {
 			if (requestParams?.search?.redirectResponse) {
 				delete requestParams.search.redirectResponse;
 			}
+			if (requestParams.tracking.pageLoadId) {
+				delete requestParams.tracking.pageLoadId;
+			}
+
 			const stringyParams = JSON.stringify(requestParams);
 
 			if (this.config.settings?.infinite?.restorePosition) {
@@ -201,6 +205,16 @@ export class SearchController extends AbstractController {
 		const userId = this.tracker.getUserId();
 		if (userId) {
 			params.tracking.userId = userId;
+		}
+
+		const sessionId = this.tracker.getContext().sessionId;
+		if (sessionId) {
+			params.tracking.sessionId = sessionId;
+		}
+
+		const pageId = this.tracker.getContext().pageLoadId;
+		if (pageId) {
+			params.tracking.pageLoadId = pageId;
 		}
 
 		if (!this.config.globals?.personalization?.disabled) {

--- a/packages/snap-preact-demo/tests/cypress/integration/tracking/track.spec.js
+++ b/packages/snap-preact-demo/tests/cypress/integration/tracking/track.spec.js
@@ -1,6 +1,13 @@
 import { BeaconType, BeaconCategory } from '@searchspring/snap-tracker';
 
 describe('Tracking', () => {
+	beforeEach(() => {
+		cy.on('window:before:load', (win) => {
+			win.mergeSnapConfig = {
+				mode: 'production',
+			};
+		});
+	});
 	it('tracked shopper login', () => {
 		cy.visit('https://localhost:2222');
 

--- a/packages/snap-preact/src/Snap.tsx
+++ b/packages/snap-preact/src/Snap.tsx
@@ -248,7 +248,7 @@ export class Snap {
 		error: (event: ErrorEvent): void => {
 			try {
 				const { filename } = event;
-				if (filename.includes('snapui.searchspring.io') && this.tracker.track.error) {
+				if (filename.includes('snapui.searchspring.io') && filename.endsWith('.js') && this.tracker.track.error) {
 					const {
 						colno,
 						lineno,
@@ -355,7 +355,7 @@ export class Snap {
 				this.config.client.config.mode = this.config.client.config.mode || this.mode;
 			}
 			this.client = services?.client || new Client(this.config.client!.globals, this.config.client!.config);
-			this.tracker = services?.tracker || new Tracker(this.config.client!.globals, { framework: 'preact' });
+			this.tracker = services?.tracker || new Tracker(this.config.client!.globals, { framework: 'preact', mode: this.mode });
 			this.logger = services?.logger || new Logger({ prefix: 'Snap Preact ', mode: this.mode });
 
 			// check for tracking attribution in URL ?ss_attribution=type:id

--- a/packages/snap-preact/src/create/createAutocompleteController.test.ts
+++ b/packages/snap-preact/src/create/createAutocompleteController.test.ts
@@ -219,6 +219,7 @@ describe('createAutocompleteController', () => {
 
 			expect(controller).toBeDefined();
 			expect(controller.tracker).toBe(customTracker);
+			// @ts-ignore - private property access
 			expect(controller.tracker.globals.siteId).toBe('custom');
 		});
 	});

--- a/packages/snap-preact/src/create/createFinderController.test.ts
+++ b/packages/snap-preact/src/create/createFinderController.test.ts
@@ -234,6 +234,7 @@ describe('createFinderController', () => {
 
 			expect(controller).toBeDefined();
 			expect(controller.tracker).toBe(customTracker);
+			// @ts-ignore - private property access
 			expect(controller.tracker.globals.siteId).toBe('custom');
 		});
 	});

--- a/packages/snap-preact/src/create/createRecommendationController.test.ts
+++ b/packages/snap-preact/src/create/createRecommendationController.test.ts
@@ -219,6 +219,7 @@ describe('createRecommendationController', () => {
 
 			expect(controller).toBeDefined();
 			expect(controller.tracker).toBe(customTracker);
+			// @ts-ignore - private property access
 			expect(controller.tracker.globals.siteId).toBe('custom');
 		});
 	});

--- a/packages/snap-preact/src/create/createSearchController.test.ts
+++ b/packages/snap-preact/src/create/createSearchController.test.ts
@@ -218,6 +218,7 @@ describe('createSearchController', () => {
 
 			expect(controller).toBeDefined();
 			expect(controller.tracker).toBe(customTracker);
+			// @ts-ignore - private property access
 			expect(controller.tracker.globals.siteId).toBe('custom');
 		});
 	});

--- a/packages/snap-store-mobx/src/Autocomplete/AutocompleteStore.ts
+++ b/packages/snap-store-mobx/src/Autocomplete/AutocompleteStore.ts
@@ -132,7 +132,8 @@ export class AutocompleteStore extends AbstractStore {
 				data.facets || [],
 				data.pagination || {},
 				this.meta,
-				this.state
+				this.state,
+				data.merchandising || {}
 			);
 		}
 

--- a/packages/snap-store-mobx/src/Autocomplete/Stores/AutocompleteFacetStore.test.ts
+++ b/packages/snap-store-mobx/src/Autocomplete/Stores/AutocompleteFacetStore.test.ts
@@ -37,7 +37,8 @@ describe('Facet store', () => {
 			searchData.facets!,
 			searchData.pagination!,
 			searchData.meta,
-			rootState
+			rootState,
+			searchData.merchandising || {}
 		);
 
 		expect(facetStore).toHaveLength(searchData.facets?.length!);
@@ -55,7 +56,8 @@ describe('Facet store', () => {
 			searchData.facets!,
 			searchData.pagination!,
 			searchData.meta,
-			rootState
+			rootState,
+			searchData.merchandising || {}
 		);
 
 		expect(rootState.locks.terms.locked).toBe(false);

--- a/packages/snap-store-mobx/src/Autocomplete/Stores/AutocompleteFacetStore.ts
+++ b/packages/snap-store-mobx/src/Autocomplete/Stores/AutocompleteFacetStore.ts
@@ -2,7 +2,12 @@ import { SearchFacetStore, FacetValue } from '../../Search/Stores';
 import type { StorageStore } from '../../Storage/StorageStore';
 import type { AutocompleteStateStore } from './AutocompleteStateStore';
 import type { AutocompleteStoreConfig, SearchStoreConfig, StoreServices } from '../../types';
-import type { SearchResponseModelFacet, SearchResponseModelPagination, MetaResponseModel } from '@searchspring/snapi-types';
+import type {
+	SearchResponseModelFacet,
+	SearchResponseModelPagination,
+	MetaResponseModel,
+	SearchResponseModelMerchandising,
+} from '@searchspring/snapi-types';
 
 export class AutocompleteFacetStore extends Array {
 	static get [Symbol.species](): ArrayConstructor {
@@ -16,11 +21,12 @@ export class AutocompleteFacetStore extends Array {
 		facetsData: SearchResponseModelFacet[],
 		paginationData: SearchResponseModelPagination,
 		meta: MetaResponseModel,
-		rootState: AutocompleteStateStore
+		rootState: AutocompleteStateStore,
+		merchandising: SearchResponseModelMerchandising
 	) {
 		// allow for only a singular facet option selection at a time
 		const alteredServices = { ...services, urlManager: services.urlManager.remove('filter') };
-		const facets = new SearchFacetStore(config, alteredServices, storage, facetsData, paginationData, meta);
+		const facets = new SearchFacetStore(config, alteredServices, storage, facetsData, paginationData, meta, merchandising);
 
 		// mutate facet values to add 'preview' function
 		facets.forEach((facet) => {

--- a/packages/snap-store-mobx/src/Search/SearchStore.ts
+++ b/packages/snap-store-mobx/src/Search/SearchStore.ts
@@ -73,7 +73,15 @@ export class SearchStore extends AbstractStore {
 		this.meta = data.meta || {};
 		this.merchandising = new SearchMerchandisingStore(this.services, data?.merchandising || {});
 		this.search = new SearchQueryStore(this.services, data?.search || {});
-		this.facets = new SearchFacetStore(this.config, this.services, this.storage, data.facets, data?.pagination || {}, this.meta);
+		this.facets = new SearchFacetStore(
+			this.config,
+			this.services,
+			this.storage,
+			data.facets,
+			data?.pagination || {},
+			this.meta,
+			data?.merchandising || {}
+		);
 		this.filters = new SearchFilterStore(this.services, data.filters, this.meta);
 		this.results = new SearchResultStore(this.config, this.services, data?.results || [], data.pagination, data.merchandising);
 		this.pagination = new SearchPaginationStore(this.config, this.services, data.pagination);

--- a/packages/snap-store-mobx/src/Search/Stores/SearchFacetStore.test.ts
+++ b/packages/snap-store-mobx/src/Search/Stores/SearchFacetStore.test.ts
@@ -80,13 +80,29 @@ describe('Facet Store', () => {
 	});
 
 	it('returns an array the same length as the facets passed in', () => {
-		const facets = new SearchFacetStore(searchConfig, services, storageStore, searchData.facets, searchData.pagination, searchData.meta);
+		const facets = new SearchFacetStore(
+			searchConfig,
+			services,
+			storageStore,
+			searchData.facets,
+			searchData.pagination,
+			searchData.meta,
+			searchData.merchandising || {}
+		);
 
 		expect(facets.length).toBe(searchData.facets?.length);
 	});
 
 	it('adds a reference to services to each facet', () => {
-		const facets = new SearchFacetStore(searchConfig, services, storageStore, searchData.facets, searchData.pagination, searchData.meta);
+		const facets = new SearchFacetStore(
+			searchConfig,
+			services,
+			storageStore,
+			searchData.facets,
+			searchData.pagination,
+			searchData.meta,
+			searchData.merchandising || {}
+		);
 
 		for (const facet of facets) {
 			expect(facet.services).toStrictEqual(services);
@@ -94,7 +110,15 @@ describe('Facet Store', () => {
 	});
 
 	it('it merges the proper facet meta', () => {
-		const facets = new SearchFacetStore(searchConfig, services, storageStore, searchData.facets, searchData.pagination, searchData.meta);
+		const facets = new SearchFacetStore(
+			searchConfig,
+			services,
+			storageStore,
+			searchData.facets,
+			searchData.pagination,
+			searchData.meta,
+			searchData.merchandising || {}
+		);
 
 		facets.forEach((facet) => {
 			const searchDataFacet =
@@ -106,7 +130,15 @@ describe('Facet Store', () => {
 	});
 
 	it('will have facet data that matches what was passed in', () => {
-		const facets = new SearchFacetStore(searchConfig, services, storageStore, searchData.facets, searchData.pagination, searchData.meta);
+		const facets = new SearchFacetStore(
+			searchConfig,
+			services,
+			storageStore,
+			searchData.facets,
+			searchData.pagination,
+			searchData.meta,
+			searchData.merchandising || {}
+		);
 
 		facets.forEach((facet, index) => {
 			const searchDataFacet = searchData.facets && searchData.facets[index];
@@ -117,7 +149,15 @@ describe('Facet Store', () => {
 	});
 
 	it('it toggles the collapsed state', () => {
-		const facets = new SearchFacetStore(searchConfig, services, storageStore, searchData.facets, searchData.pagination, searchData.meta);
+		const facets = new SearchFacetStore(
+			searchConfig,
+			services,
+			storageStore,
+			searchData.facets,
+			searchData.pagination,
+			searchData.meta,
+			searchData.merchandising || {}
+		);
 
 		const collapsed = facets[0].collapsed;
 		expect(collapsed).toEqual(false);
@@ -128,14 +168,30 @@ describe('Facet Store', () => {
 	it('it clears the selected options', () => {
 		searchData = mockData.searchMeta('filtered');
 
-		const facets = new SearchFacetStore(searchConfig, services, storageStore, searchData.facets, searchData.pagination, searchData.meta);
+		const facets = new SearchFacetStore(
+			searchConfig,
+			services,
+			storageStore,
+			searchData.facets,
+			searchData.pagination,
+			searchData.meta,
+			searchData.merchandising || {}
+		);
 
 		expect(facets[0].clear.url.constructor.name).toStrictEqual(services.urlManager.constructor.name);
 		expect(facets[0].clear.url.href).not.toMatch(facets[0].field);
 	});
 
 	it('has overflow has values we expect', () => {
-		const facets = new SearchFacetStore(searchConfig, services, storageStore, searchData.facets, searchData.pagination, searchData.meta);
+		const facets = new SearchFacetStore(
+			searchConfig,
+			services,
+			storageStore,
+			searchData.facets,
+			searchData.pagination,
+			searchData.meta,
+			searchData.merchandising || {}
+		);
 		const valueFacet = facets.filter((facet) => facet.values).pop();
 
 		expect(valueFacet.overflow.enabled).toBeDefined();
@@ -150,7 +206,15 @@ describe('Facet Store', () => {
 
 	it('has storage for overflow and restores the limit', () => {
 		storageStore = new StorageStore();
-		let facets = new SearchFacetStore(searchConfig, services, storageStore, searchData.facets, searchData.pagination, searchData.meta);
+		let facets = new SearchFacetStore(
+			searchConfig,
+			services,
+			storageStore,
+			searchData.facets,
+			searchData.pagination,
+			searchData.meta,
+			searchData.merchandising || {}
+		);
 		let facet = facets.filter((facet) => facet.values && facet.values.length > 2).pop();
 
 		const limit = 2;
@@ -167,7 +231,15 @@ describe('Facet Store', () => {
 		// new store to ensure storage does not bleed
 
 		const newStorageStore = new StorageStore();
-		facets = new SearchFacetStore(searchConfig, services, storageStore, searchData.facets, searchData.pagination, searchData.meta);
+		facets = new SearchFacetStore(
+			searchConfig,
+			services,
+			storageStore,
+			searchData.facets,
+			searchData.pagination,
+			searchData.meta,
+			searchData.merchandising || {}
+		);
 		expect(facet.overflow.limited).toBe(false);
 
 		facet = facets.filter((facet) => facet.values && facet.values.length > 2).pop();
@@ -178,7 +250,15 @@ describe('Facet Store', () => {
 	});
 
 	it('has overflow and the toggle function works as expected', () => {
-		const facets = new SearchFacetStore(searchConfig, services, storageStore, searchData.facets, searchData.pagination, searchData.meta);
+		const facets = new SearchFacetStore(
+			searchConfig,
+			services,
+			storageStore,
+			searchData.facets,
+			searchData.pagination,
+			searchData.meta,
+			searchData.merchandising || {}
+		);
 		const valueFacets = facets.filter((facet) => facet.values && facet.values.length > 3);
 
 		valueFacets.forEach((facet) => {
@@ -194,7 +274,15 @@ describe('Facet Store', () => {
 	});
 
 	it('has overflow and the toggle function can take a toggle value as parameter', () => {
-		const facets = new SearchFacetStore(searchConfig, services, storageStore, searchData.facets, searchData.pagination, searchData.meta);
+		const facets = new SearchFacetStore(
+			searchConfig,
+			services,
+			storageStore,
+			searchData.facets,
+			searchData.pagination,
+			searchData.meta,
+			searchData.merchandising || {}
+		);
 		const valueFacets = facets.filter((facet) => facet.values && facet.values.length > 3);
 
 		valueFacets.forEach((facet) => {
@@ -214,7 +302,15 @@ describe('Facet Store', () => {
 	});
 
 	it('has overflow and works with the search input', () => {
-		const facets = new SearchFacetStore(searchConfig, services, storageStore, searchData.facets, searchData.pagination, searchData.meta);
+		const facets = new SearchFacetStore(
+			searchConfig,
+			services,
+			storageStore,
+			searchData.facets,
+			searchData.pagination,
+			searchData.meta,
+			searchData.merchandising || {}
+		);
 		const colorFacet = facets.filter((facet) => facet.field == 'color_family').pop();
 
 		const limit = 5;
@@ -238,7 +334,15 @@ describe('Facet Store', () => {
 	it('uses range facet when needed', () => {
 		searchData = mockData.searchMeta('range');
 
-		const facets = new SearchFacetStore(searchConfig, services, storageStore, searchData.facets, searchData.pagination, searchData.meta);
+		const facets = new SearchFacetStore(
+			searchConfig,
+			services,
+			storageStore,
+			searchData.facets,
+			searchData.pagination,
+			searchData.meta,
+			searchData.merchandising || {}
+		);
 		const rangeFacet = facets.filter((facet) => facet.type == 'range').pop();
 
 		expect(rangeFacet.type).toBe('range');
@@ -246,7 +350,15 @@ describe('Facet Store', () => {
 
 	it('uses range values (range-buckets) when needed', () => {
 		searchData = mockData.updateConfig({ meta: 'priceBuckets' }).searchMeta('priceBuckets');
-		const facets = new SearchFacetStore(searchConfig, services, storageStore, searchData.facets, searchData.pagination, searchData.meta);
+		const facets = new SearchFacetStore(
+			searchConfig,
+			services,
+			storageStore,
+			searchData.facets,
+			searchData.pagination,
+			searchData.meta,
+			searchData.merchandising || {}
+		);
 		const rangeFacet: ValueFacet = facets.filter((facet) => facet.type == 'range-buckets').pop();
 
 		(rangeFacet?.values as Array<FacetRangeValue>).forEach((value) => {
@@ -269,7 +381,15 @@ describe('Facet Store', () => {
 
 				const searchData = mockData.searchMeta('settings.trim');
 
-				const facets = new SearchFacetStore(settingsConfig, services, storageStore, searchData.facets, searchData.pagination, searchData.meta);
+				const facets = new SearchFacetStore(
+					settingsConfig,
+					services,
+					storageStore,
+					searchData.facets,
+					searchData.pagination,
+					searchData.meta,
+					searchData.merchandising || {}
+				);
 				expect(facets.length).toBe(4);
 			});
 
@@ -285,7 +405,15 @@ describe('Facet Store', () => {
 
 				const searchData = mockData.searchMeta('settings.trim');
 
-				const facets = new SearchFacetStore(settingsConfig, services, storageStore, searchData.facets, searchData.pagination, searchData.meta);
+				const facets = new SearchFacetStore(
+					settingsConfig,
+					services,
+					storageStore,
+					searchData.facets,
+					searchData.pagination,
+					searchData.meta,
+					searchData.merchandising || {}
+				);
 				expect(facets.length).not.toBe(searchData.facets?.length);
 				expect(facets.length).toBe(1);
 			});
@@ -307,7 +435,15 @@ describe('Facet Store', () => {
 
 				const searchData = mockData.searchMeta('settings.trim');
 
-				const facets = new SearchFacetStore(settingsConfig, services, storageStore, searchData.facets, searchData.pagination, searchData.meta);
+				const facets = new SearchFacetStore(
+					settingsConfig,
+					services,
+					storageStore,
+					searchData.facets,
+					searchData.pagination,
+					searchData.meta,
+					searchData.merchandising || {}
+				);
 				expect(facets.length).toBe(2);
 			});
 
@@ -328,7 +464,15 @@ describe('Facet Store', () => {
 
 				const searchData = mockData.searchMeta('settings.trim');
 
-				const facets = new SearchFacetStore(settingsConfig, services, storageStore, searchData.facets, searchData.pagination, searchData.meta);
+				const facets = new SearchFacetStore(
+					settingsConfig,
+					services,
+					storageStore,
+					searchData.facets,
+					searchData.pagination,
+					searchData.meta,
+					searchData.merchandising || {}
+				);
 				expect(facets.length).toBe(3);
 			});
 		});
@@ -346,7 +490,15 @@ describe('Facet Store', () => {
 
 				const searchData = mockData.searchMeta('settings.pinFiltered');
 
-				const facets = new SearchFacetStore(settingsConfig, services, storageStore, searchData.facets, searchData.pagination, searchData.meta);
+				const facets = new SearchFacetStore(
+					settingsConfig,
+					services,
+					storageStore,
+					searchData.facets,
+					searchData.pagination,
+					searchData.meta,
+					searchData.merchandising || {}
+				);
 				expect(facets.length).toBe(2);
 				facets.forEach((facet) => {
 					facet.values.forEach((value: FacetValue, index: number) => {
@@ -369,7 +521,15 @@ describe('Facet Store', () => {
 
 				const searchData = mockData.searchMeta('settings.pinFiltered');
 
-				const facets = new SearchFacetStore(settingsConfig, services, storageStore, searchData.facets, searchData.pagination, searchData.meta);
+				const facets = new SearchFacetStore(
+					settingsConfig,
+					services,
+					storageStore,
+					searchData.facets,
+					searchData.pagination,
+					searchData.meta,
+					searchData.merchandising || {}
+				);
 				expect(facets.length).toBe(2);
 				facets.forEach((facet) => {
 					expect(facet.values[2]).toHaveProperty('filtered', true);
@@ -393,7 +553,15 @@ describe('Facet Store', () => {
 
 				const searchData = mockData.searchMeta('settings.pinFiltered');
 
-				const facets = new SearchFacetStore(settingsConfig, services, storageStore, searchData.facets, searchData.pagination, searchData.meta);
+				const facets = new SearchFacetStore(
+					settingsConfig,
+					services,
+					storageStore,
+					searchData.facets,
+					searchData.pagination,
+					searchData.meta,
+					searchData.merchandising || {}
+				);
 				expect(facets.length).toBe(2);
 				facets.forEach((facet) => {
 					if (facet.field == 'size') {
@@ -421,7 +589,15 @@ describe('Facet Store', () => {
 
 				const searchData = mockData.searchMeta('settings.pinFiltered');
 
-				const facets = new SearchFacetStore(settingsConfig, services, storageStore, searchData.facets, searchData.pagination, searchData.meta);
+				const facets = new SearchFacetStore(
+					settingsConfig,
+					services,
+					storageStore,
+					searchData.facets,
+					searchData.pagination,
+					searchData.meta,
+					searchData.merchandising || {}
+				);
 				expect(facets.length).toBe(2);
 				facets.forEach((facet) => {
 					if (facet.field == 'size') {
@@ -446,7 +622,15 @@ describe('Facet Store', () => {
 
 				const searchData = mockData.searchMeta('settings.storeRange');
 
-				const facets = new SearchFacetStore(settingsConfig, services, storageStore, searchData.facets, searchData.pagination, searchData.meta);
+				const facets = new SearchFacetStore(
+					settingsConfig,
+					services,
+					storageStore,
+					searchData.facets,
+					searchData.pagination,
+					searchData.meta,
+					searchData.merchandising || {}
+				);
 				expect(facets.length).toBe(1);
 
 				const searchDataFacet = searchData.facets && (searchData.facets[0] as SearchResponseModelFacetRange);
@@ -465,7 +649,8 @@ describe('Facet Store', () => {
 					storageStore,
 					filteredSearchData.facets,
 					filteredSearchData.pagination,
-					filteredSearchData.meta
+					filteredSearchData.meta,
+					filteredSearchData.merchandising || {}
 				);
 
 				const updatedSearchDataFacet = filteredSearchData.facets && (filteredSearchData.facets[0] as SearchResponseModelFacetRange);
@@ -488,7 +673,15 @@ describe('Facet Store', () => {
 
 				const searchData = mockData.searchMeta('settings.storeRange');
 
-				const facets = new SearchFacetStore(settingsConfig, services, storageStore, searchData.facets, searchData.pagination, searchData.meta);
+				const facets = new SearchFacetStore(
+					settingsConfig,
+					services,
+					storageStore,
+					searchData.facets,
+					searchData.pagination,
+					searchData.meta,
+					searchData.merchandising || {}
+				);
 
 				const searchDataFacet = searchData.facets && (searchData.facets[0] as SearchResponseModelFacetRange);
 				expect(facets.length).toBe(1);
@@ -507,7 +700,8 @@ describe('Facet Store', () => {
 					storageStore,
 					filteredSearchData.facets,
 					filteredSearchData.pagination,
-					filteredSearchData.meta
+					filteredSearchData.meta,
+					filteredSearchData.merchandising || {}
 				);
 
 				const filteredSearchDataFacet = filteredSearchData.facets && (filteredSearchData.facets[0] as SearchResponseModelFacetRange);
@@ -535,7 +729,15 @@ describe('Facet Store', () => {
 
 				const searchData = mockData.searchMeta('settings.storeRange');
 
-				const facets = new SearchFacetStore(settingsConfig, services, storageStore, searchData.facets, searchData.pagination, searchData.meta);
+				const facets = new SearchFacetStore(
+					settingsConfig,
+					services,
+					storageStore,
+					searchData.facets,
+					searchData.pagination,
+					searchData.meta,
+					searchData.merchandising || {}
+				);
 
 				const searchDataFacet = searchData.facets && (searchData.facets[0] as SearchResponseModelFacetRange);
 				expect(facets.length).toBe(1);
@@ -554,7 +756,8 @@ describe('Facet Store', () => {
 					storageStore,
 					filteredSearchData.facets,
 					filteredSearchData.pagination,
-					filteredSearchData.meta
+					filteredSearchData.meta,
+					filteredSearchData.merchandising || {}
 				);
 
 				const filteredSearchDataFacet = filteredSearchData.facets && (filteredSearchData.facets[0] as SearchResponseModelFacetRange);
@@ -582,7 +785,15 @@ describe('Facet Store', () => {
 
 				const searchData = mockData.searchMeta('settings.storeRange');
 
-				const facets = new SearchFacetStore(settingsConfig, services, storageStore, searchData.facets, searchData.pagination, searchData.meta);
+				const facets = new SearchFacetStore(
+					settingsConfig,
+					services,
+					storageStore,
+					searchData.facets,
+					searchData.pagination,
+					searchData.meta,
+					searchData.merchandising || {}
+				);
 
 				const searchDataFacet = searchData.facets && (searchData.facets[0] as SearchResponseModelFacetRange);
 				expect(facets.length).toBe(1);
@@ -601,7 +812,8 @@ describe('Facet Store', () => {
 					storageStore,
 					filteredSearchData.facets,
 					filteredSearchData.pagination,
-					filteredSearchData.meta
+					filteredSearchData.meta,
+					filteredSearchData.merchandising || {}
 				);
 
 				const filteredSearchDataFacet = filteredSearchData.facets && (filteredSearchData.facets[0] as SearchResponseModelFacetRange);
@@ -616,7 +828,15 @@ describe('Facet Store', () => {
 
 	describe('ValueFacet', () => {
 		it('has the correct facet properties', () => {
-			const facets = new SearchFacetStore(searchConfig, services, storageStore, searchData.facets, searchData.pagination, searchData.meta);
+			const facets = new SearchFacetStore(
+				searchConfig,
+				services,
+				storageStore,
+				searchData.facets,
+				searchData.pagination,
+				searchData.meta,
+				searchData.merchandising || {}
+			);
 
 			facets.forEach((facet) => {
 				expect(facet.multiple).toBe((searchData?.meta?.facets && (searchData?.meta?.facets[facet.field] as ValueFacet))?.multiple);
@@ -625,7 +845,15 @@ describe('Facet Store', () => {
 
 		describe('value', () => {
 			it('stores the correct facet values', () => {
-				const facets = new SearchFacetStore(searchConfig, services, storageStore, searchData.facets, searchData.pagination, searchData.meta);
+				const facets = new SearchFacetStore(
+					searchConfig,
+					services,
+					storageStore,
+					searchData.facets,
+					searchData.pagination,
+					searchData.meta,
+					searchData.merchandising || {}
+				);
 
 				facets.forEach((facet, index) => {
 					if (facet.type == 'value') {
@@ -637,7 +865,15 @@ describe('Facet Store', () => {
 			it('has a removal URL for filter value when it is filtered/active', () => {
 				searchData = mockData.searchMeta('filtered');
 
-				const facets = new SearchFacetStore(searchConfig, services, storageStore, searchData.facets, searchData.pagination, searchData.meta);
+				const facets = new SearchFacetStore(
+					searchConfig,
+					services,
+					storageStore,
+					searchData.facets,
+					searchData.pagination,
+					searchData.meta,
+					searchData.merchandising || {}
+				);
 				const filteredValueFacet = facets.filter((facet) => facet.type == 'value' && facet.filtered).pop();
 
 				const filteredValues = filteredValueFacet.values.filter((value: FacetValue) => value.filtered);
@@ -650,7 +886,15 @@ describe('Facet Store', () => {
 			it('has a URL for filter value when it is not filtered/active', () => {
 				searchData = mockData.searchMeta();
 
-				const facets = new SearchFacetStore(searchConfig, services, storageStore, searchData.facets, searchData.pagination, searchData.meta);
+				const facets = new SearchFacetStore(
+					searchConfig,
+					services,
+					storageStore,
+					searchData.facets,
+					searchData.pagination,
+					searchData.meta,
+					searchData.merchandising || {}
+				);
 				const filteredValueFacet = facets.filter((facet) => facet.type == 'value').pop();
 
 				const filteredValues = filteredValueFacet.values.filter((value: FacetValue) => !value.filtered);
@@ -664,7 +908,15 @@ describe('Facet Store', () => {
 			it('uses FacetHierarchyValue when the hierarchy display type is used', () => {
 				searchData = mockData.searchMeta('filteredHierarchy');
 
-				const facets = new SearchFacetStore(searchConfig, services, storageStore, searchData.facets, searchData.pagination, searchData.meta);
+				const facets = new SearchFacetStore(
+					searchConfig,
+					services,
+					storageStore,
+					searchData.facets,
+					searchData.pagination,
+					searchData.meta,
+					searchData.merchandising || {}
+				);
 				const hierarchyFacet = facets.filter((facet) => facet.display == 'hierarchy').pop();
 
 				hierarchyFacet.values.forEach((value: FacetHierarchyValue) => {
@@ -676,7 +928,15 @@ describe('Facet Store', () => {
 			it.skip('supports multi select facets', () => {
 				searchData = mockData.searchMeta('filtered');
 
-				const facets = new SearchFacetStore(searchConfig, services, storageStore, searchData.facets, searchData.pagination, searchData.meta);
+				const facets = new SearchFacetStore(
+					searchConfig,
+					services,
+					storageStore,
+					searchData.facets,
+					searchData.pagination,
+					searchData.meta,
+					searchData.merchandising || {}
+				);
 				const multiSelectFacet = facets.filter((facet) => facet.filtered && facet.type == 'value' && facet.multiple != 'single')[0];
 
 				const selectedFacetValue = multiSelectFacet.values.filter((value: FacetValue) => value.filtered)[0];
@@ -691,7 +951,15 @@ describe('Facet Store', () => {
 			it('supports single select facets', () => {
 				searchData = mockData.searchMeta('filtered');
 
-				const facets = new SearchFacetStore(searchConfig, services, storageStore, searchData.facets, searchData.pagination, searchData.meta);
+				const facets = new SearchFacetStore(
+					searchConfig,
+					services,
+					storageStore,
+					searchData.facets,
+					searchData.pagination,
+					searchData.meta,
+					searchData.merchandising || {}
+				);
 				const singleSelectFacet = facets.filter((facet) => facet.multiple == 'single' && facet.filtered).pop();
 
 				const selectedFacetValue = singleSelectFacet.values.filter((value: FacetValue) => value.filtered).pop();
@@ -706,7 +974,15 @@ describe('Facet Store', () => {
 		describe('range-buckets', () => {
 			it('stores the correct facet values', () => {
 				searchData = mockData.updateConfig({ meta: 'priceBuckets' }).searchMeta('priceBuckets');
-				const facets = new SearchFacetStore(searchConfig, services, storageStore, searchData.facets, searchData.pagination, searchData.meta);
+				const facets = new SearchFacetStore(
+					searchConfig,
+					services,
+					storageStore,
+					searchData.facets,
+					searchData.pagination,
+					searchData.meta,
+					searchData.merchandising || {}
+				);
 
 				facets.forEach((facet, index) => {
 					if (facet.type == 'range-buckets') {
@@ -724,7 +1000,15 @@ describe('Facet Store', () => {
 			it('has a URL for filter value when it is filtered/active', () => {
 				searchData = mockData.updateConfig({ meta: 'priceBuckets' }).searchMeta('filteredRangeBucket');
 
-				const facets = new SearchFacetStore(searchConfig, services, storageStore, searchData.facets, searchData.pagination, searchData.meta);
+				const facets = new SearchFacetStore(
+					searchConfig,
+					services,
+					storageStore,
+					searchData.facets,
+					searchData.pagination,
+					searchData.meta,
+					searchData.merchandising || {}
+				);
 				const filteredRangeBucketFacet: ValueFacet = facets.filter((facet) => facet.type == 'range-buckets').pop();
 
 				const filteredValues = filteredRangeBucketFacet.values.filter((value) => value?.filtered);
@@ -738,7 +1022,15 @@ describe('Facet Store', () => {
 			it('has a removal URL for filter value when it is not filtered/active', () => {
 				searchData = mockData.updateConfig({ meta: 'priceBuckets' }).searchMeta('filteredRangeBucket');
 
-				const facets = new SearchFacetStore(searchConfig, services, storageStore, searchData.facets, searchData.pagination, searchData.meta);
+				const facets = new SearchFacetStore(
+					searchConfig,
+					services,
+					storageStore,
+					searchData.facets,
+					searchData.pagination,
+					searchData.meta,
+					searchData.merchandising || {}
+				);
 				const filteredRangeBucketFacet = facets.filter((facet) => facet.type == 'range-buckets' && facet.filtered).pop();
 				const filteredValues = filteredRangeBucketFacet.values.filter((value: FacetRangeValue) => !value?.filtered);
 				filteredValues.forEach((filteredValue: FacetRangeValue) => {
@@ -749,7 +1041,15 @@ describe('Facet Store', () => {
 			it('has a removal URL for filter value when it is filtered/active with single select', () => {
 				searchData = mockData.updateConfig({ meta: 'priceBucketsPriceSingle' }).searchMeta('filteredRangeBucket');
 
-				const facets = new SearchFacetStore(searchConfig, services, storageStore, searchData.facets, searchData.pagination, searchData.meta);
+				const facets = new SearchFacetStore(
+					searchConfig,
+					services,
+					storageStore,
+					searchData.facets,
+					searchData.pagination,
+					searchData.meta,
+					searchData.merchandising || {}
+				);
 				const filteredRangeBucketFacet: ValueFacet = facets
 					.filter((facet) => facet.type == 'range-buckets' && facet.multiple == 'single' && facet.filtered)
 					.pop();
@@ -772,7 +1072,15 @@ describe('Facet Store', () => {
 		it('it merges the proper facet meta', () => {
 			searchData = mockData.searchMeta('range');
 
-			const facets = new SearchFacetStore(searchConfig, services, storageStore, searchData.facets, searchData.pagination, searchData.meta);
+			const facets = new SearchFacetStore(
+				searchConfig,
+				services,
+				storageStore,
+				searchData.facets,
+				searchData.pagination,
+				searchData.meta,
+				searchData.merchandising || {}
+			);
 			const rangeFacets: RangeFacet[] = facets.filter((facet) => facet.type == 'range');
 
 			rangeFacets.forEach((facet) => {
@@ -785,7 +1093,15 @@ describe('Facet Store', () => {
 		it('it has the correct facet properties', () => {
 			searchData = mockData.searchMeta('range');
 
-			const facets = new SearchFacetStore(searchConfig, services, storageStore, searchData.facets, searchData.pagination, searchData.meta);
+			const facets = new SearchFacetStore(
+				searchConfig,
+				services,
+				storageStore,
+				searchData.facets,
+				searchData.pagination,
+				searchData.meta,
+				searchData.merchandising || {}
+			);
 
 			facets.forEach((facet: RangeFacet, index: number) => {
 				if (facet.type == 'range') {

--- a/packages/snap-store-mobx/src/Search/Stores/SearchFacetStore.ts
+++ b/packages/snap-store-mobx/src/Search/Stores/SearchFacetStore.ts
@@ -17,6 +17,7 @@ import type {
 	SearchResponseModelFacetValueAllOf,
 	SearchResponseModelFacetValueAllOfValues,
 	SearchRequestModelFilterRangeAllOfValue,
+	SearchResponseModelMerchandising,
 } from '@searchspring/snapi-types';
 
 export class SearchFacetStore extends Array {
@@ -29,7 +30,8 @@ export class SearchFacetStore extends Array {
 		storage: StorageStore,
 		facetsData: SearchResponseModelFacet[] = [],
 		pagination: SearchResponseModelPagination = {},
-		meta: MetaResponseModel
+		meta: MetaResponseModel,
+		merchandising: SearchResponseModelMerchandising
 	) {
 		const facets = facetsData
 			.filter((facet: SearchResponseModelFacet & SearchResponseModelFacetValueAllOf) => {
@@ -55,7 +57,11 @@ export class SearchFacetStore extends Array {
 					} else if (facet.values?.length == 0) {
 						return false;
 					} else if (!facet.filtered && facet.values?.length == 1) {
-						return facet.values[0].count != pagination.totalResults;
+						if (merchandising?.content?.inline) {
+							return facet.values[0].count! + merchandising.content?.inline.length != pagination.totalResults;
+						} else {
+							return facet.values[0].count != pagination.totalResults;
+						}
 					}
 				}
 

--- a/packages/snap-tracker/src/types.ts
+++ b/packages/snap-tracker/src/types.ts
@@ -1,3 +1,4 @@
+import { AppMode } from '@searchspring/snap-toolbox';
 import { BeaconEvent } from './BeaconEvent';
 
 export type TrackerGlobals = {
@@ -7,6 +8,7 @@ export type TrackerGlobals = {
 export type TrackerConfig = {
 	id?: string;
 	framework?: string;
+	mode?: keyof typeof AppMode | AppMode;
 };
 
 export type BeaconPayload = {


### PR DESCRIPTION
* prevent error beaconing in development mode and in mockup files
* adding `pageLoadId` and `sessionId` query params to search requests (closes #587)
* fixing bug with inline banners and facet trimming (closes #596)