### PR TITLE
Pass `banner` to InlineBanner `onClick`

### DIFF
--- a/packages/snap-preact-components/src/components/Atoms/Merchandising/InlineBanner.tsx
+++ b/packages/snap-preact-components/src/components/Atoms/Merchandising/InlineBanner.tsx
@@ -58,7 +58,7 @@ export function InlineBanner(properties: InlineBannerProps): JSX.Element {
 		<CacheProvider>
 			<div
 				onClick={(e: React.MouseEvent<Element, MouseEvent>) => {
-					onClick && onClick(e);
+					onClick && onClick(e, banner);
 				}}
 				className={classnames('ss__inline-banner', `ss__inline-banner--${layout}`, className)}
 				{...styling}
@@ -76,5 +76,5 @@ export interface InlineBannerProps extends ComponentProps {
 	banner: Banner;
 	width?: string;
 	layout?: LayoutType;
-	onClick?: (e: React.MouseEvent) => void;
+	onClick?: (e: React.MouseEvent, banner: Banner) => void;
 }

--- a/packages/snap-preact-components/src/components/Atoms/Merchandising/readme.md
+++ b/packages/snap-preact-components/src/components/Atoms/Merchandising/readme.md
@@ -61,10 +61,10 @@ The `layout` prop specifies if this banner will be rendered in a `grid` or `list
 
 
 ### onClick
-The `onClick` prop contains a custom onClick event handler. Function is passed the click event. 
+The `onClick` prop contains a custom onClick event handler. Function is passed the click event as first parameter, Banner object is passed as the second.
 
 ```typescript
-const CustomBannerClick = (e) => {
+const CustomBannerClick = (e, banner) => {
     console.log('You Clicked a banner!' , e)
 };
 ```


### PR DESCRIPTION
Several tickets needing to do GA tracking on inlineBanner click - however getting the banner specifics like the ID are difficult without data. Adding the data to `onClick` function to make this easier.