### PR TITLE
Trending Terms Empty

### DIFF
--- a/packages/snap-controller/src/Autocomplete/AutocompleteController.ts
+++ b/packages/snap-controller/src/Autocomplete/AutocompleteController.ts
@@ -70,7 +70,7 @@ export class AutocompleteController extends AbstractController {
 		this.storage = new StorageStore({
 			type: StorageType.SESSION,
 			//@ts-ignore
-			key: `ss-controller-${this.config.id}-${this.client.globals?.siteId}`,
+			key: `ss-controller-${this.config.id}`,
 		});
 
 		// add 'beforeSearch' middleware

--- a/packages/snap-controller/src/Autocomplete/AutocompleteController.ts
+++ b/packages/snap-controller/src/Autocomplete/AutocompleteController.ts
@@ -69,7 +69,8 @@ export class AutocompleteController extends AbstractController {
 		// persist trending terms in local storage
 		this.storage = new StorageStore({
 			type: StorageType.SESSION,
-			key: `ss-controller-${this.config.id}`,
+			//@ts-ignore
+			key: `ss-controller-${this.config.id}-${this.client.globals?.siteId}`,
 		});
 
 		// add 'beforeSearch' middleware
@@ -499,8 +500,9 @@ export class AutocompleteController extends AbstractController {
 
 			trendingProfile.stop();
 			this.log.profile(trendingProfile);
-
-			this.storage.set('terms', JSON.stringify(terms));
+			if (terms?.trending?.queries?.length) {
+				this.storage.set('terms', JSON.stringify(terms));
+			}
 		}
 
 		this.store.updateTrendingTerms(terms);

--- a/packages/snap-controller/src/Autocomplete/AutocompleteController.ts
+++ b/packages/snap-controller/src/Autocomplete/AutocompleteController.ts
@@ -69,7 +69,6 @@ export class AutocompleteController extends AbstractController {
 		// persist trending terms in local storage
 		this.storage = new StorageStore({
 			type: StorageType.SESSION,
-			//@ts-ignore
 			key: `ss-controller-${this.config.id}`,
 		});
 


### PR DESCRIPTION
dont save trending terms to storage if they are empty

also use the siteID in the storage key to allow switching of siteIds