### PR TITLE
Beacon Login `event` Payload

### DIFF
--- a/packages/snap-preact-demo/tests/cypress/integration/tracking/track.spec.js
+++ b/packages/snap-preact-demo/tests/cypress/integration/tracking/track.spec.js
@@ -28,7 +28,7 @@ describe('Tracking', () => {
 			const beacon = interception.request.body.filter((event) => event.type === BeaconType.LOGIN)[0];
 			expect(beacon.category).to.equal(BeaconCategory.PERSONALIZATION);
 			expect(beacon.type).to.equal(BeaconType.LOGIN);
-			expect(beacon.event).to.be.an('object');
+			expect(beacon.event).to.be.an('object').include.key('shopperId').include.key('userId');
 			expect(beacon.context).to.be.an('object').include.key('shopperId');
 
 			cy.window().then((window) => {
@@ -44,7 +44,7 @@ describe('Tracking', () => {
 			const beacon = interception.request.body.filter((event) => event.type === BeaconType.LOGIN)[0];
 			expect(beacon.category).to.equal(BeaconCategory.PERSONALIZATION);
 			expect(beacon.type).to.equal(BeaconType.LOGIN);
-			expect(beacon.event).to.be.an('object');
+			expect(beacon.event).to.be.an('object').include.key('shopperId').include.key('userId');
 			expect(beacon.context).to.be.an('object').include.key('shopperId');
 			expect(beacon.context.shopperId).to.equal(shopperId);
 		});

--- a/packages/snap-tracker/src/Tracker.test.ts
+++ b/packages/snap-tracker/src/Tracker.test.ts
@@ -692,18 +692,23 @@ describe('Tracker', () => {
 		const payload = { id: shopperId };
 		await tracker.track.shopper.login(payload, siteId);
 
+		const trackerContext = tracker.getContext();
+
 		expect(trackEvent).toHaveBeenCalledWith({
 			type: BeaconType.LOGIN,
 			category: BeaconCategory.PERSONALIZATION,
-			// @ts-ignore - private property access
-			context: deepmerge(tracker.context, {
+
+			context: deepmerge(trackerContext, {
 				context: {
 					website: {
 						trackingCode: siteId,
 					},
 				},
 			}),
-			event: {},
+			event: {
+				shopperId,
+				userId: trackerContext.userId,
+			},
 		});
 		expect(shopperLogin).toHaveBeenCalledWith(payload, siteId);
 

--- a/packages/snap-tracker/src/Tracker.ts
+++ b/packages/snap-tracker/src/Tracker.ts
@@ -305,7 +305,10 @@ export class Tracker {
 						type: BeaconType.LOGIN,
 						category: BeaconCategory.PERSONALIZATION,
 						context,
-						event: {},
+						event: {
+							userId: this.context.userId,
+							shopperId: data.id,
+						},
 					};
 					return this.track.event(payload);
 				}


### PR DESCRIPTION
* altering beacon login event to send `shopperId` and `userId` in event payload