### PR TITLE
DomTargeter Unhide Bug

### DIFF
--- a/packages/snap-toolbox/src/DomTargeter/DomTargeter.ts
+++ b/packages/snap-toolbox/src/DomTargeter/DomTargeter.ts
@@ -52,7 +52,7 @@ export class DomTargeter {
 					}
 				};
 				checker();
-			} else if (/complete|loaded/.test(this.document.readyState)) {
+			} else if (/complete|interactive|loaded/.test(this.document.readyState)) {
 				// DOMContent has loaded - unhide targets
 				target.hideTarget && this.unhideTarget(target.selector);
 			} else {

--- a/packages/snap-toolbox/src/DomTargeter/DomTargeter.ts
+++ b/packages/snap-toolbox/src/DomTargeter/DomTargeter.ts
@@ -33,21 +33,21 @@ export class DomTargeter {
 			if (target.autoRetarget) {
 				let timeoutTime = 100;
 				const checker = () => {
-					//lets not just keep trying forever - this waits roughly 12 seconds before giving up.
+					// lets not just keep trying forever - this waits roughly 12 seconds before giving up.
 					if (timeoutTime < 2000) {
-						//increase the time till next check
+						// increase the time till next check
 						timeoutTime = timeoutTime + 200;
 						const elems = this.domQuery(target.selector);
-						//did we find any targets?
+						// did we find any targets?
 						if (elems && elems.length) {
 							this.retarget();
 							target.hideTarget && this.unhideTarget(target.selector);
 						} else {
-							//try again soon
+							// try again soon
 							setTimeout(checker, timeoutTime);
 						}
 					} else {
-						//timed out, lets unhide the target
+						// timed out, lets unhide the target
 						target.hideTarget && this.unhideTarget(target.selector);
 					}
 				};
@@ -72,16 +72,14 @@ export class DomTargeter {
 	retarget(): void {
 		const targetElemPairs = this.targets.flatMap((target) => {
 			// hide targets before found
-			if (target.hideTarget) {
-				this.hideTarget(target.selector);
-			}
+			target.hideTarget && this.hideTarget(target.selector);
 
 			const elems = this.domQuery(target.selector).filter((elem) => {
 				if (!globallyTargetedElems.find((e) => e == elem) && !this.targetedElems.find((e) => e == elem)) {
 					return true;
 				} else {
 					// unhide retarget attempts
-					this.unhideTarget(target.selector);
+					target.hideTarget && this.unhideTarget(target.selector);
 				}
 			});
 
@@ -113,7 +111,7 @@ export class DomTargeter {
 			}
 
 			// unhide target
-			this.unhideTarget(target.selector);
+			target.hideTarget && this.unhideTarget(target.selector);
 		});
 
 		if (errors.length) {


### PR DESCRIPTION
Adding 'interactive' to document.readyState check because the event can have fired when the state is `interactive` - preventing the unhiding of previously hidden targets. This specifically was occurring when using the branch overrides.

Interestingly we used to have 'interactive' here before, I'm not sure why it was removed in the first place, perhaps we should test this on a few live sites.