### PR TITLE
Fix for `getBundleDetails()`

### DIFF
--- a/packages/snap-preact/src/getBundleDetails/getBundleDetails.ts
+++ b/packages/snap-preact/src/getBundleDetails/getBundleDetails.ts
@@ -16,7 +16,7 @@ export const getBundleDetails = async (url: string): Promise<BundleDetails> => {
 				if ((lastModified && status === 0) || (status >= 200 && status < 400)) {
 					resolve({
 						url,
-						lastModified: lastModified?.split(',')[1].trim() || '',
+						lastModified: lastModified?.split(',')[1]?.trim() || '',
 					});
 				} else {
 					reject({ message: 'Branch not found!', description: 'Incorrect branch name or branch no longer exists.' });

--- a/packages/snap-preact/src/getBundleDetails/getBundleDetails.ts
+++ b/packages/snap-preact/src/getBundleDetails/getBundleDetails.ts
@@ -16,7 +16,7 @@ export const getBundleDetails = async (url: string): Promise<BundleDetails> => {
 				if ((lastModified && status === 0) || (status >= 200 && status < 400)) {
 					resolve({
 						url,
-						lastModified: lastModified!.split(',')[1].trim(),
+						lastModified: lastModified?.split(',')[1].trim() || '',
 					});
 				} else {
 					reject({ message: 'Branch not found!', description: 'Incorrect branch name or branch no longer exists.' });


### PR DESCRIPTION
Adjusting getBundleDetails to allow for local testing of branch override function.

The `!` was causing error because the details did not exist when forcing a branch override using local development server and browser override extension (to force to load local bundle for initial and branch bundle).