### PR TITLE
Branch Override Halt

### DIFF
--- a/packages/snap-preact-demo/tests/cypress/integration/core/branchOverride.spec.js
+++ b/packages/snap-preact-demo/tests/cypress/integration/core/branchOverride.spec.js
@@ -2,6 +2,11 @@ describe('Branch Override Functionality', () => {
 	it('adds snap bundle to search page', () => {
 		cy.visit('https://localhost:2222/?branch=override');
 
+		cy.on('uncaught:exception', (err, runnable) => {
+			// expected error due to branch override throwing
+			return false;
+		});
+
 		// expect injected div from 'override' branch to be on the page
 		cy.get('#override').should('exist');
 
@@ -31,6 +36,11 @@ describe('Branch Override Functionality', () => {
 	});
 
 	it('breaks when using a non existant branch', () => {
+		cy.on('uncaught:exception', (err, runnable) => {
+			// expected error due to branch override throwing
+			return false;
+		});
+
 		// cy.on('uncaught:exception', (err, runnable) => false);
 		cy.visit('https://localhost:2222/?branch=nope');
 

--- a/packages/snap-preact/src/Snap.tsx
+++ b/packages/snap-preact/src/Snap.tsx
@@ -436,8 +436,9 @@ export class Snap {
 				style: `color: ${this.logger.colors.indigo}; font-weight: bold;`,
 			});
 
+			// handle branch override
 			if (branchOverride && !document.querySelector(`script[${BRANCH_COOKIE}]`)) {
-				this.logger.warn(`...loading build... '${branchOverride}'`);
+				this.logger.warn(`:: loading branch override ~ '${branchOverride}' ...`);
 
 				// set a cookie with branch
 				if (featureFlags.cookies) {
@@ -523,9 +524,13 @@ export class Snap {
 				);
 
 				// prevent further instantiation of config
-				return;
+				throw 'branch override';
 			}
 		} catch (e) {
+			if (e == 'branch override') {
+				throw `${this.logger.emoji.bang} Snap instantiation halted - using branch override.`;
+			}
+
 			this.logger.error(e);
 		}
 
@@ -550,6 +555,7 @@ export class Snap {
 			}
 		}
 
+		// create controllers
 		Object.keys(this.config?.controllers || {}).forEach((type) => {
 			switch (type) {
 				case 'search': {
@@ -899,6 +905,7 @@ export class Snap {
 			}
 		});
 
+		// create instantiators
 		if (this.config?.instantiators?.recommendation) {
 			try {
 				this._instantiatorPromises.recommendation = import('./Instantiators/RecommendationInstantiator').then(({ RecommendationInstantiator }) => {

--- a/packages/snap-preact/src/integration.test.tsx
+++ b/packages/snap-preact/src/integration.test.tsx
@@ -31,25 +31,16 @@ const xhrMock: Partial<XMLHttpRequest> = {
 	readyState: 4,
 };
 
-const modifiedDate = '07 Jan 2022 22:42:39 GMT';
-
 jest.spyOn(window, 'XMLHttpRequest').mockImplementation(() => xhrMock as XMLHttpRequest);
 
 describe('Snap Preact Integration', () => {
-	beforeAll(() => {
-		xhrMock.getResponseHeader = jest.fn(() => {
-			// return "Last-Modified" date
-			return `Fri, ${modifiedDate}`;
-		});
-	});
-
 	beforeEach(() => {
 		// @ts-ignore - modifying window
 		delete window.location;
 
 		// @ts-ignore - modifying window
 		window.location = {
-			href: 'https://www.merch.com?branch=branch',
+			href: 'https://www.merch.com',
 		};
 
 		const contextString = `config = ${JSON.stringify(context.config)}; shopper = ${JSON.stringify(context.shopper)};`;


### PR DESCRIPTION
Preventing instantiation of Snap by throwing an error when a branch override is underway. This removes the errors we were seeing regarding `getController` etc... and creates a singular error for that script to fail out on halting further execution.