### PR TITLE
Slideout Restoration

### DIFF
--- a/packages/snap-preact-components/src/components/Molecules/Slideout/Slideout.stories.tsx
+++ b/packages/snap-preact-components/src/components/Molecules/Slideout/Slideout.stories.tsx
@@ -96,6 +96,16 @@ export default {
 			},
 			control: { type: 'color' },
 		},
+		noButtonWrapper: {
+			description: 'Prevent the wrapper element from rendering (this element has the onClick handler to toggle the state)',
+			table: {
+				type: {
+					summary: 'boolean',
+				},
+				defaultValue: { summary: false },
+			},
+			control: { type: 'boolean' },
+		},
 		...componentArgs,
 	},
 };

--- a/packages/snap-preact-components/src/components/Molecules/Slideout/Slideout.tsx
+++ b/packages/snap-preact-components/src/components/Molecules/Slideout/Slideout.tsx
@@ -32,17 +32,16 @@ const CSS = {
 		}),
 };
 
-const buttonClass = 'ss__slideout__button';
-
 export function Slideout(properties: SlideoutProps): JSX.Element {
 	const globalTheme: Theme = useTheme();
+
 	const props: SlideoutProps = {
 		// default props
 		active: false,
 		displayAt: '',
 		slideDirection: 'left',
 		width: '300px',
-		buttonContent: <div className={buttonClass}>click me</div>,
+		buttonContent: 'click me',
 		overlayColor: 'rgba(0,0,0,0.8)',
 		transitionSpeed: '0.25s',
 		// global theme
@@ -52,7 +51,20 @@ export function Slideout(properties: SlideoutProps): JSX.Element {
 		...properties.theme?.components?.slideout,
 	};
 
-	const { children, active, width, displayAt, transitionSpeed, overlayColor, slideDirection, buttonContent, disableStyles, className, style } = props;
+	const {
+		children,
+		active,
+		buttonContent,
+		noButtonWrapper,
+		width,
+		displayAt,
+		transitionSpeed,
+		overlayColor,
+		slideDirection,
+		disableStyles,
+		className,
+		style,
+	} = props;
 
 	const subProps: SlideoutSubProps = {
 		overlay: {
@@ -93,7 +105,14 @@ export function Slideout(properties: SlideoutProps): JSX.Element {
 
 	return isVisible ? (
 		<CacheProvider>
-			<ButtonContent content={buttonContent} toggleActive={toggleActive} />
+			{buttonContent &&
+				(noButtonWrapper ? (
+					cloneWithProps(buttonContent, { toggleActive, active: isActive })
+				) : (
+					<div className="ss__slideout__button" onClick={() => toggleActive()}>
+						{cloneWithProps(buttonContent, { active: isActive })}
+					</div>
+				))}
 
 			<div className={classnames('ss__slideout', className, { 'ss__slideout--active': isActive })} {...styling}>
 				{cloneWithProps(children, { toggleActive, active: isActive })}
@@ -105,41 +124,11 @@ export function Slideout(properties: SlideoutProps): JSX.Element {
 	);
 }
 
-const ButtonContent = (props: { content: string | JSX.Element | undefined; toggleActive: () => void }): JSX.Element => {
-	const { content, toggleActive } = props;
-
-	if (content && typeof content == 'string') {
-		return (
-			<div className={buttonClass} onClick={() => toggleActive()}>
-				{content}
-			</div>
-		);
-	} else if (content && typeof content == 'object') {
-		let clone = cloneWithProps(content, {
-			onClick: () => toggleActive(),
-		});
-
-		if (clone.props.class || clone.props.className) {
-			// check if class
-			if (clone.props.class && clone.props.class.indexOf(buttonClass) < 0) {
-				clone.props.class = `${clone.props.class} ${buttonClass}`;
-			}
-			// check if classname
-			if (clone.props.className && clone.props.className.indexOf(buttonClass) < 0) {
-				clone.props.className = `${clone.props.className} ${buttonClass}`;
-			}
-		} else {
-			clone.props.className = clone.props.class = buttonClass;
-		}
-
-		return clone;
-	} else return <></>;
-};
-
 export interface SlideoutProps extends ComponentProps {
 	children?: ComponentChildren;
 	active?: boolean;
 	buttonContent?: string | JSX.Element;
+	noButtonWrapper?: boolean;
 	width?: string;
 	displayAt?: string;
 	transitionSpeed?: string;

--- a/packages/snap-preact-components/src/components/Molecules/Slideout/readme.md
+++ b/packages/snap-preact-components/src/components/Molecules/Slideout/readme.md
@@ -7,31 +7,38 @@ Renders a slideout with a background overlay. Typically used for a mobile menu s
 
 ## Usage
 
-### children
-The children provided to the component will be displayed within the slideout. 
-
-```jsx
-<Slideout>
-	<span>slideout content (children)</span>
-</Slideout>
-```
-### active
-The `active` prop specifies the initial state of the slideout when rendered.
-
-```jsx
-<Slideout active={true}>
-	<div>Hello World</div>
-</Slideout>
-```
-
 ### buttonContent
 The `buttonContent` prop accepts a string or JSX element to render a clickable button that toggles the slideout visibility. 
 
-When using the custom `buttonContent` prop, render the component where you want the button to render. The slideout menu's position is fixed, therefore the location of the component is only for the render location of the button. 
+When using the `buttonContent` prop, render the component where you want the button to render. The slideout content position is fixed, therefore, the location of the component is only for the render location of the button itself. 
 
 ```jsx
-<Slideout buttonContent={'Show Filters'}>
+<Slideout buttonContent={'click me'}>
 	<div>slideout content</div>
+</Slideout>
+```
+
+### children
+The children provided to the component will be displayed within the slideout - the slideout content. When using a component here, it will be passed additional props (`active` and `toggleActive`) from the slideout component which can be used for referencing and toggling of the `active` state.
+
+```jsx
+<Slideout buttonContent={'click me'}>
+	<span>slideout content (children)</span>
+</Slideout>
+```
+
+```jsx
+const SlideoutContent = (props) => {
+	return (
+		<div>
+			<button onClick={() => props.toggleActive()}>close slideout</button>
+			<div>the slideout is { props.active ? 'open' : 'closed' }</div>
+		</div>
+	)
+}
+
+<Slideout buttonContent={'click me'}>
+	<SlideoutContent />
 </Slideout>
 ```
 
@@ -82,3 +89,29 @@ The `slideDirection` prop sets the direction that the overlay slides in. Default
 </Slideout>
 ```
 
+### noButtonWrapper
+The `noButtonWrapper` prop prevents the button wrapper div with className of `ss__slideout__button` from rendering. This element normally wraps `buttonContent` and handles toggling the `active` state via an onClick handler. By utilizing this prop, toggling of the `active` state must instead happen within the component passed into `buttonContent`. The `buttonContent` component will be passed additional props (`active` and `toggleActive`) from the slideout component which can be used for referencing and toggling of the `active` state.
+
+```jsx
+
+const ButtonComponent = (props) => {
+	return (
+		<div onClick={() => props.toggleActive()}>
+			Button to Toggle the Slideout
+		</div>
+	)
+}
+
+<Slideout buttonContent={<ButtonComponent/>} noButtonWrapper>
+	<div>slideout content</div>
+</Slideout>
+```
+
+### active
+The `active` prop is an optional way to specify the initial state of the slideout when rendered. It is recommended to let the component manage its own state internally by not using this prop.
+
+```jsx
+<Slideout active={true}>
+	<div>Hello World</div>
+</Slideout>
+```

--- a/packages/snap-preact-demo/src/components/Toolbar/Toolbar.tsx
+++ b/packages/snap-preact-demo/src/components/Toolbar/Toolbar.tsx
@@ -19,7 +19,7 @@ export class Toolbar extends Component<ToolBarProps> {
 
 		return (
 			<div className="ss-toolbar ss-toolbar-top">
-				<Slideout displayAt={'(max-width: 991px)'} buttonContent={slideoutButton()}>
+				<Slideout displayAt={'(max-width: 991px)'} buttonContent={<SlideoutButton />}>
 					<Fragment>
 						<h3>Filters</h3>
 						<SidebarContents />
@@ -41,18 +41,20 @@ export class Toolbar extends Component<ToolBarProps> {
 	}
 }
 
-const slideoutButton = () => {
+const SlideoutButton = () => {
 	return (
-		<Button
-			style={{
-				margin: '0 10px',
-				display: 'block',
-				width: '100%',
-				boxSizing: 'border-box',
-				textAlign: 'center',
-			}}
-		>
-			Show Filters
-		</Button>
+		<>
+			<Button
+				style={{
+					margin: '10px 0',
+					display: 'block',
+					width: '100%',
+					boxSizing: 'border-box',
+					textAlign: 'center',
+				}}
+			>
+				Show Filters
+			</Button>
+		</>
 	);
 };


### PR DESCRIPTION
* rolling back the Slideout component to previous functionality
* adding a new prop `noButtonWrapper` to disable the button wrapper