### PR TITLE
De-reference Memory Cache

### DIFF
--- a/packages/snap-client/src/Client/NetworkCache/NetworkCache.ts
+++ b/packages/snap-client/src/Client/NetworkCache/NetworkCache.ts
@@ -31,7 +31,7 @@ export class NetworkCache {
 			try {
 				if (this.memoryCache[key]) {
 					if (Date.now() < this.memoryCache[key].expires) {
-						return this.memoryCache[key].value;
+						return deepmerge({}, this.memoryCache[key].value);
 					}
 				}
 


### PR DESCRIPTION
The memory cache was being modified and thus causing issues when attempting to re-observe parts of the store with Mobx. Returning a clone of the cache resolves the issue.