### PR TITLE
De-reference Memory Cache (hotfix)

### DIFF
--- a/packages/snap-client/src/Client/NetworkCache/NetworkCache.ts
+++ b/packages/snap-client/src/Client/NetworkCache/NetworkCache.ts
@@ -31,7 +31,7 @@ export class NetworkCache {
 			try {
 				if (this.memoryCache[key]) {
 					if (Date.now() < this.memoryCache[key].expires) {
-						return this.memoryCache[key].value;
+						return deepmerge({}, this.memoryCache[key].value);
 					}
 				}
 


### PR DESCRIPTION
* the client was returning a reference to the cached response causing an issue where the store, and thus Mobx would attempt to re-observe the properties.