### PR TITLE
Snap `integratedSpellCorrection` Config

### DIFF
--- a/packages/snap-preact-demo/src/index.ts
+++ b/packages/snap-preact-demo/src/index.ts
@@ -97,13 +97,6 @@ let config: SnapConfig = {
 							limit: 5,
 						},
 					},
-					globals: {
-						search: {
-							query: {
-								spellCorrection: true,
-							},
-						},
-					},
 				},
 				targeters: [
 					{

--- a/packages/snap-preact/src/Snap.test.tsx
+++ b/packages/snap-preact/src/Snap.test.tsx
@@ -783,6 +783,51 @@ describe('Snap Preact', () => {
 			// @ts-ignore - private class variable
 			expect(snap.config.client.config?.autocomplete?.requesters?.suggest?.globals?.integratedSpellCorrection).toBe(true);
 			expect((ac.config as AutocompleteControllerConfig).settings!.integratedSpellCorrection).toBe(true);
+			expect((ac.config as AutocompleteControllerConfig).globals!.search?.query?.spellCorrection).toBe(true);
+		});
+
+		it(`preserves controller integratedSpellCorrection setting when feature flag is set`, async () => {
+			const baseConfig = generateBaseConfig();
+
+			document.body.innerHTML = `<script id="searchspring-context"></script><input type="text" class="ss-ac-input"/>`;
+
+			const acConfig = {
+				...baseConfig,
+				features: {
+					integratedSpellCorrection: {
+						enabled: true,
+					},
+				},
+				controllers: {
+					autocomplete: [
+						{
+							config: {
+								selector: '.ss-ac-input',
+								id: 'ac',
+								settings: {
+									integratedSpellCorrection: false,
+								},
+							},
+							targeters: [
+								{
+									selector: '.ss-ac-input',
+									hideTarget: true,
+									component: async () => Component,
+								},
+							],
+						},
+					],
+				},
+			};
+			const client = new MockClient(acConfig.client!.globals as ClientGlobals);
+			const snap = new Snap(acConfig, { client });
+			const ac = await snap.getController('ac');
+			await wait();
+
+			// @ts-ignore - private class variable
+			expect(snap.config.client.config?.autocomplete?.requesters?.suggest?.globals?.integratedSpellCorrection).toBe(true);
+			expect((ac.config as AutocompleteControllerConfig).settings!.integratedSpellCorrection).toBe(false);
+			expect((ac.config as AutocompleteControllerConfig).globals!.search?.query?.spellCorrection).toBe(undefined);
 		});
 	});
 

--- a/packages/snap-preact/src/Snap.tsx
+++ b/packages/snap-preact/src/Snap.tsx
@@ -28,6 +28,7 @@ import type { Target, OnTarget } from '@searchspring/snap-toolbox';
 import type { UrlTranslatorConfig } from '@searchspring/snap-url-manager';
 
 import { default as createSearchController } from './create/createSearchController';
+import { configureSnapFeatures } from './configureSnapFeatures';
 import { RecommendationInstantiator, RecommendationInstantiatorConfig } from './Instantiators/RecommendationInstantiator';
 import type { SnapControllerServices, SnapControllerConfig } from './types';
 
@@ -378,35 +379,7 @@ export class Snap {
 			}
 
 			// feature check block
-			// TODO: move to function
-			if (this.config.client && this.config.features?.integratedSpellCorrection?.enabled) {
-				this.config.client.config = deepmerge(this.config.client.config || {}, {
-					autocomplete: {
-						requesters: {
-							suggest: {
-								globals: {
-									integratedSpellCorrection: true,
-								},
-							},
-						},
-					},
-				});
-
-				// loop through controllers config and toggle integratedSpellCorrection setting
-				Object.keys(this.config?.controllers || {}).forEach((type) => {
-					switch (type) {
-						case 'autocomplete': {
-							this.config.controllers![type]!.forEach((controller, index) => {
-								if (typeof controller.config?.settings?.integratedSpellCorrection == 'undefined') {
-									controller.config.settings = controller.config.settings || {};
-									controller.config.settings.integratedSpellCorrection = true;
-								}
-							});
-							break;
-						}
-					}
-				});
-			}
+			configureSnapFeatures(this.config);
 
 			this.client = services?.client || new Client(this.config.client!.globals as ClientGlobals, this.config.client!.config);
 			this.tracker = services?.tracker || new Tracker(this.config.client!.globals as ClientGlobals, { framework: 'preact', mode: this.mode });

--- a/packages/snap-preact/src/configureSnapFeatures.ts
+++ b/packages/snap-preact/src/configureSnapFeatures.ts
@@ -1,0 +1,58 @@
+import deepmerge from 'deepmerge';
+import type { SnapConfig } from './Snap';
+
+export function configureSnapFeatures(config: SnapConfig) {
+	/* configure snap features by mutating the config as needed */
+
+	configureIntegratedSpellCorrection(config);
+}
+
+function configureIntegratedSpellCorrection(config: SnapConfig) {
+	if (config.features?.integratedSpellCorrection?.enabled) {
+		if (config.client) {
+			config.client.config = deepmerge(
+				{
+					autocomplete: {
+						requesters: {
+							suggest: {
+								globals: {
+									integratedSpellCorrection: true,
+								},
+							},
+						},
+					},
+				},
+				config.client.config || {}
+			);
+		}
+
+		// loop through controllers config and toggle integratedSpellCorrection setting
+		Object.keys(config?.controllers || {}).forEach((type) => {
+			switch (type) {
+				case 'autocomplete': {
+					config.controllers![type]!.forEach((controller, index) => {
+						if (typeof controller.config?.settings?.integratedSpellCorrection == 'undefined') {
+							// enable integratedSpellCorrection controller setting
+							controller.config.settings = deepmerge({ integratedSpellCorrection: true }, controller.config.settings || {});
+						}
+
+						if (controller.config?.settings?.integratedSpellCorrection) {
+							// set spell correction globals for convenience
+							controller.config.globals = deepmerge(
+								{
+									search: {
+										query: {
+											spellCorrection: true,
+										},
+									},
+								},
+								controller.config.globals || {}
+							);
+						}
+					});
+					break;
+				}
+			}
+		});
+	}
+}


### PR DESCRIPTION
* eliminating the redundant need to specify a global `spellCorrection` for autocomplete controllers when the `integratedSpellCorrection` feature is set