### PR TITLE
ac hover backwards compatable

### DIFF
--- a/packages/snap-preact-components/src/components/Molecules/FacetGridOptions/FacetGridOptions.tsx
+++ b/packages/snap-preact-components/src/components/Molecules/FacetGridOptions/FacetGridOptions.tsx
@@ -87,7 +87,7 @@ export const FacetGridOptions = observer((properties: FacetGridOptionsProps): JS
 		...properties.theme?.components?.facetGridOptions,
 	};
 
-	const { values, columns, gapSize, onClick, previewOnFocus, valueProps, facet, disableStyles, className, style } = props;
+	const { values, columns, gapSize, onClick, previewOnFocus, someOtherProp, valueProps, facet, disableStyles, className, style } = props;
 
 	const styling: { css?: StylingCSS } = {};
 	if (!disableStyles) {
@@ -111,6 +111,11 @@ export const FacetGridOptions = observer((properties: FacetGridOptionsProps): JS
 								? `filter by ${facet?.label} - ${value.label}`
 								: `filter by ${value.label}`
 						}
+						onFocus={() => {
+							if (!someOtherProp && previewOnFocus && value.preview) {
+								value.preview();
+							}
+						}}
 						{...valueProps}
 						onMouseEnter={(e) => previewOnFocus && valueProps.onMouseEnter(e, value)}
 						href={value.url?.link?.href}
@@ -143,4 +148,5 @@ export interface FacetGridOptionsProps extends ComponentProps {
 	facet?: ValueFacet;
 	previewOnFocus?: boolean;
 	valueProps?: any;
+	someOtherProp?: boolean;
 }

--- a/packages/snap-preact-components/src/components/Molecules/FacetHierarchyOptions/FacetHierarchyOptions.tsx
+++ b/packages/snap-preact-components/src/components/Molecules/FacetHierarchyOptions/FacetHierarchyOptions.tsx
@@ -63,7 +63,7 @@ export const FacetHierarchyOptions = observer((properties: FacetHierarchyOptions
 		...properties.theme?.components?.facetHierarchyOptions,
 	};
 
-	const { values, hideCount, onClick, disableStyles, previewOnFocus, valueProps, facet, className, style } = props;
+	const { values, hideCount, onClick, disableStyles, previewOnFocus, someOtherProp, valueProps, facet, className, style } = props;
 
 	const styling: { css?: StylingCSS } = {};
 	if (!disableStyles) {
@@ -73,7 +73,6 @@ export const FacetHierarchyOptions = observer((properties: FacetHierarchyOptions
 	}
 
 	const facetValues = values || facet?.values;
-
 	return facetValues?.length ? (
 		<CacheProvider>
 			<div {...styling} className={classnames('ss__facet-hierarchy-options', className)}>
@@ -95,6 +94,11 @@ export const FacetHierarchyOptions = observer((properties: FacetHierarchyOptions
 						onClick={(e: React.MouseEvent<Element, MouseEvent>) => {
 							value.url?.link?.onClick(e);
 							onClick && onClick(e);
+						}}
+						onFocus={() => {
+							if (!someOtherProp && previewOnFocus && value.preview) {
+								value.preview();
+							}
 						}}
 						{...valueProps}
 						onMouseEnter={(e) => previewOnFocus && valueProps.onMouseEnter(e, value)}
@@ -120,4 +124,5 @@ export interface FacetHierarchyOptionsProps extends ComponentProps {
 	onClick?: (e: React.MouseEvent) => void;
 	previewOnFocus?: boolean;
 	valueProps?: any;
+	someOtherProp?: boolean;
 }

--- a/packages/snap-preact-components/src/components/Molecules/FacetListOptions/FacetListOptions.tsx
+++ b/packages/snap-preact-components/src/components/Molecules/FacetListOptions/FacetListOptions.tsx
@@ -51,7 +51,7 @@ export const FacetListOptions = observer((properties: FacetListOptionsProps): JS
 		...properties.theme?.components?.facetListOptions,
 	};
 
-	const { values, hideCheckbox, hideCount, onClick, previewOnFocus, valueProps, facet, disableStyles, className, style } = props;
+	const { values, hideCheckbox, hideCount, onClick, previewOnFocus, someOtherProp, valueProps, facet, disableStyles, className, style } = props;
 
 	const subProps: FacetListOptionsSubProps = {
 		checkbox: {
@@ -90,6 +90,11 @@ export const FacetListOptions = observer((properties: FacetListOptionsProps): JS
 								? `filter by ${facet?.label} - ${value.label}`
 								: `filter by ${value.label}`
 						}
+						onFocus={() => {
+							if (!someOtherProp && previewOnFocus && value.preview) {
+								value.preview();
+							}
+						}}
 						{...valueProps}
 						onMouseEnter={(e) => previewOnFocus && valueProps.onMouseEnter(e, value)}
 						href={value.url?.link?.href}
@@ -119,6 +124,9 @@ export interface FacetListOptionsProps extends ComponentProps {
 	facet?: ValueFacet;
 	onClick?: (e: React.MouseEvent) => void;
 	previewOnFocus?: boolean;
+
+	someOtherProp?: boolean;
+
 	valueProps?: any;
 }
 

--- a/packages/snap-preact-components/src/components/Molecules/FacetPaletteOptions/FacetPaletteOptions.tsx
+++ b/packages/snap-preact-components/src/components/Molecules/FacetPaletteOptions/FacetPaletteOptions.tsx
@@ -105,7 +105,21 @@ export const FacetPaletteOptions = observer((properties: FacetPaletteOptionsProp
 		...properties.theme?.components?.facetPaletteOptions,
 	};
 
-	const { values, hideLabel, columns, gapSize, hideIcon, onClick, previewOnFocus, valueProps, facet, disableStyles, className, style } = props;
+	const {
+		values,
+		hideLabel,
+		columns,
+		gapSize,
+		hideIcon,
+		onClick,
+		previewOnFocus,
+		someOtherProp,
+		valueProps,
+		facet,
+		disableStyles,
+		className,
+		style,
+	} = props;
 
 	const subProps: FacetPaletteOptionsSubProps = {
 		icon: {
@@ -147,6 +161,11 @@ export const FacetPaletteOptions = observer((properties: FacetPaletteOptionsProp
 								? `filter by ${facet?.label} - ${value.label}`
 								: `filter by ${value.label}`
 						}
+						onFocus={() => {
+							if (!someOtherProp && previewOnFocus && value.preview) {
+								value.preview();
+							}
+						}}
 						{...valueProps}
 						onMouseEnter={(e) => previewOnFocus && valueProps.onMouseEnter(e, value)}
 						href={value.url?.link?.href}
@@ -186,6 +205,7 @@ export interface FacetPaletteOptionsProps extends ComponentProps {
 	onClick?: (e: React.MouseEvent) => void;
 	previewOnFocus?: boolean;
 	valueProps?: any;
+	someOtherProp?: boolean;
 }
 
 interface FacetPaletteOptionsSubProps {

--- a/packages/snap-preact-components/src/components/Organisms/Autocomplete/Autocomplete.tsx
+++ b/packages/snap-preact-components/src/components/Organisms/Autocomplete/Autocomplete.tsx
@@ -250,20 +250,24 @@ export const Autocomplete = observer((properties: AutocompleteProps): JSX.Elemen
 			facetGridOptions: {
 				columns: 3,
 				onClick: facetClickEvent,
+				someOtherProp: true,
 			},
 			facetHierarchyOptions: {
 				hideCount: true,
 				onClick: facetClickEvent,
+				someOtherProp: true,
 			},
 			facetListOptions: {
 				hideCheckbox: true,
 				hideCount: true,
 				onClick: facetClickEvent,
+				someOtherProp: true,
 			},
 			facetPaletteOptions: {
 				hideLabel: true,
 				columns: 3,
 				onClick: facetClickEvent,
+				someOtherProp: true,
 			},
 			result: {
 				hideBadge: true,


### PR DESCRIPTION
added a prop to support prev versions of ac facet hover states