### PR TITLE
Results Theming

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -11,6 +11,18 @@ module.exports = {
 	rules: {
 		// add rules... or dont...
 		'no-debugger': 'error',
-		'@typescript-eslint/ban-ts-comment': 'off'
+		'@typescript-eslint/ban-ts-comment': 'off',
+		'@typescript-eslint/no-explicit-any': 'off',
+		'@typescript-eslint/no-non-null-assertion': 'off',
+		'@typescript-eslint/no-non-null-asserted-optional-chain': 'off',
+		'@typescript-eslint/no-empty-function': 'off'
 	},
+	settings: {
+		"preact": {
+			"pragma": "h"
+		}
+	}
+	
+
 };
+

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -15,7 +15,16 @@ module.exports = {
 		'@typescript-eslint/no-explicit-any': 'off',
 		'@typescript-eslint/no-non-null-assertion': 'off',
 		'@typescript-eslint/no-non-null-asserted-optional-chain': 'off',
-		'@typescript-eslint/no-empty-function': 'off'
+		'@typescript-eslint/no-empty-function': 'off',
+		"no-unused-vars": "off",
+		"@typescript-eslint/no-unused-vars": [
+		"warn", // or "error"
+		{ 
+			"argsIgnorePattern": "h|jsx",
+			"varsIgnorePattern": "h|jsx",
+			"caughtErrorsIgnorePattern": "h|jsx"
+		}
+		],
 	},
 	settings: {
 		"preact": {

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Eslint
+        run: npm run lint
+
       - name: Tests
         env:
           NODE_OPTIONS: "--max-old-space-size=4096"

--- a/packages/snap-client/src/Client/Client.test.ts
+++ b/packages/snap-client/src/Client/Client.test.ts
@@ -86,7 +86,7 @@ describe('Snap Client', () => {
 
 		expect(client.meta).toBeDefined();
 		// @ts-ignore
-		let clientConfig = client.config;
+		const clientConfig = client.config;
 
 		expect(clientConfig?.meta?.api?.origin).toBe(config?.meta?.api?.origin);
 

--- a/packages/snap-client/src/Client/Client.test.ts
+++ b/packages/snap-client/src/Client/Client.test.ts
@@ -46,6 +46,7 @@ describe('Snap Client', () => {
 		// checking requesters mode
 		// @ts-ignore - verifying private property
 		for (const [name, requester] of Object.entries(client.requesters)) {
+			expect(name).toBe(name);
 			// @ts-ignore - verifying private property
 			expect(requester.mode).toBe(AppMode.production);
 			// @ts-ignore - verifying private property
@@ -114,6 +115,8 @@ describe('Snap Client', () => {
 		// checking requesters mode
 		// @ts-ignore - verifying private property
 		for (const [name, requester] of Object.entries(client.requesters)) {
+			expect(name).toBe(name);
+
 			// @ts-ignore - verifying private property
 			expect(requester.mode).toBe(AppMode.development);
 			// @ts-ignore - verifying private property

--- a/packages/snap-client/src/Client/Client.ts
+++ b/packages/snap-client/src/Client/Client.ts
@@ -10,7 +10,6 @@ import type {
 	RecommendRequestModel,
 	RecommendCombinedRequestModel,
 	RecommendCombinedResponseModel,
-	GenericGlobals,
 } from '../types';
 
 import type {

--- a/packages/snap-client/src/Client/NetworkCache/NetworkCache.test.ts
+++ b/packages/snap-client/src/Client/NetworkCache/NetworkCache.test.ts
@@ -9,7 +9,7 @@ const CACHE_STORAGE_KEY = 'ss-networkcache';
 
 const typedResponse = mockData.meta() as Response;
 
-let searchConfig: SearchControllerConfig = {
+const searchConfig: SearchControllerConfig = {
 	id: 'search',
 	globals: {
 		filters: [],
@@ -55,7 +55,7 @@ describe('Network Cache', () => {
 		const cache = new NetworkCache();
 
 		// @ts-ignore
-		let memoryCache = cache.memoryCache;
+		const memoryCache = cache.memoryCache;
 
 		it('can use the set function', async () => {
 			expect(memoryCache).toBeDefined();
@@ -67,7 +67,7 @@ describe('Network Cache', () => {
 			cache.set('key', typedResponse);
 
 			// @ts-ignore
-			let UpdatedMemoryCache = cache.memoryCache;
+			const UpdatedMemoryCache = cache.memoryCache;
 
 			expect(UpdatedMemoryCache).not.toEqual({});
 
@@ -89,7 +89,7 @@ describe('Network Cache', () => {
 			expect(mockStorage[CACHE_STORAGE_KEY]).toEqual('');
 
 			// @ts-ignore
-			let NewmemoryCache = cache.memoryCache;
+			const NewmemoryCache = cache.memoryCache;
 			expect(NewmemoryCache).toEqual({});
 		});
 
@@ -112,7 +112,7 @@ describe('Network Cache', () => {
 	});
 
 	describe('can set custom config settings', () => {
-		let cacheConfig = {
+		const cacheConfig = {
 			ttl: 1000,
 			enabled: true,
 			maxSize: 2, // KB
@@ -166,14 +166,14 @@ describe('Network Cache', () => {
 		});
 
 		it('can disable purging max size for local storage', async () => {
-			let cacheConfig = {
+			const cacheConfig = {
 				ttl: 1000,
 				enabled: true,
 				maxSize: 2, // KB
 				purgeable: false,
 			};
 
-			let cacheConfig2 = {
+			const cacheConfig2 = {
 				...cacheConfig,
 				purgeable: true,
 			};
@@ -201,14 +201,14 @@ describe('Network Cache', () => {
 
 		it('can pass in cache to set', async () => {
 			const key = 'key';
-			let cacheConfig = {
+			const cacheConfig = {
 				entries: {
 					[key]: typedResponse,
 				},
 			};
 			const cache = new NetworkCache(cacheConfig);
 			// @ts-ignore
-			let memoryCache = cache.memoryCache;
+			const memoryCache = cache.memoryCache;
 			expect(memoryCache[key].value).toEqual(typedResponse);
 			expect(cache.get(key)).toEqual(typedResponse);
 		});

--- a/packages/snap-client/src/Client/apis/Abstract.test.ts
+++ b/packages/snap-client/src/Client/apis/Abstract.test.ts
@@ -1,5 +1,5 @@
 import 'whatwg-fetch';
-import { API, ApiConfiguration, ApiConfigurationParameters, HTTPQuery } from './Abstract';
+import { API, ApiConfiguration, ApiConfigurationParameters } from './Abstract';
 import { HTTPHeaders } from '../../types';
 
 describe('ApiConfiguration', () => {
@@ -21,7 +21,7 @@ describe('ApiConfiguration', () => {
 			purgeable: false,
 		};
 
-		const customQueryParamsStringify = (params: HTTPQuery) => {
+		const customQueryParamsStringify = () => {
 			return 'custom';
 		};
 
@@ -88,7 +88,7 @@ describe('Abstract Api', () => {
 		customheader: 'customkey',
 	};
 
-	let CustomCacheConfig = {
+	const CustomCacheConfig = {
 		ttl: 2222,
 		enabled: false,
 		maxSize: 4, // KB
@@ -101,7 +101,7 @@ describe('Abstract Api', () => {
 		.mockImplementation(() => Promise.resolve({ status: 200, json: () => Promise.resolve() } as Response));
 
 	it('can pass in all the props', async () => {
-		let config: ApiConfigurationParameters = {
+		const config: ApiConfigurationParameters = {
 			origin: 'https://searchspring.com',
 			fetchApi: global.window.fetch,
 			headers: customHeaders,
@@ -111,7 +111,7 @@ describe('Abstract Api', () => {
 
 		// end set up
 
-		let api = new API(new ApiConfiguration(config));
+		const api = new API(new ApiConfiguration(config));
 
 		//has correct values
 		expect(api?.cache).toEqual({
@@ -142,9 +142,9 @@ describe('Abstract Api', () => {
 	});
 
 	it('can pass pass in queryParamsStringify', async () => {
-		let queryParamMockfn = jest.fn(() => 'here');
+		const queryParamMockfn = jest.fn(() => 'here');
 
-		let config: ApiConfigurationParameters = {
+		const config: ApiConfigurationParameters = {
 			origin: 'https://searchspring.com',
 			fetchApi: global.window.fetch,
 			queryParamsStringify: queryParamMockfn,
@@ -152,7 +152,7 @@ describe('Abstract Api', () => {
 
 		// end set up
 
-		let api = new API(new ApiConfiguration(config));
+		const api = new API(new ApiConfiguration(config));
 
 		//can use query params stringify
 		// @ts-ignore
@@ -161,14 +161,14 @@ describe('Abstract Api', () => {
 	});
 
 	it('can use createFetchParams', async () => {
-		let config: ApiConfigurationParameters = {
+		const config: ApiConfigurationParameters = {
 			origin: 'https://searchspring.com',
 			fetchApi: global.window.fetch,
 			headers: customHeaders,
 		};
 
 		// end set up
-		let api = new API(new ApiConfiguration(config));
+		const api = new API(new ApiConfiguration(config));
 
 		const body = { siteId: '8uyt2m' };
 		const context = {
@@ -192,14 +192,14 @@ describe('Abstract Api', () => {
 		//@ts-ignore
 		expect(() => api.createFetchParams(badContext)).toThrowError(`Request failed. Missing "siteId" parameter.`);
 
-		let config2: ApiConfigurationParameters = {
+		const config2: ApiConfigurationParameters = {
 			origin: 'https://searchspring.com',
 			fetchApi: global.window.fetch,
 			headers: customHeaders,
 			maxRetry: 2,
 			cache: CustomCacheConfig,
 		};
-		let api2 = new API(new ApiConfiguration(config2));
+		const api2 = new API(new ApiConfiguration(config2));
 
 		const contextWithQuery = { ...context, query: { key: 'value' } };
 		// @ts-ignore
@@ -208,13 +208,13 @@ describe('Abstract Api', () => {
 	});
 
 	it('can use cacheKey', async () => {
-		let config: ApiConfigurationParameters = {
+		const config: ApiConfigurationParameters = {
 			origin: 'https://searchspring.com',
 			fetchApi: global.window.fetch,
 			headers: customHeaders,
 		};
 
-		let api = new API(new ApiConfiguration(config));
+		const api = new API(new ApiConfiguration(config));
 
 		const body = { siteId: '8uyt2m' };
 		const context = {
@@ -267,14 +267,14 @@ describe('Abstract Api', () => {
 	});
 
 	it('can handle 429s', async () => {
-		let config: ApiConfigurationParameters = {
+		const config: ApiConfigurationParameters = {
 			origin: 'https://searchspring.com',
 			fetchApi: global.window.fetch,
 			headers: customHeaders,
 			maxRetry: 2,
 		};
 
-		let api = new API(new ApiConfiguration(config));
+		const api = new API(new ApiConfiguration(config));
 
 		const body = { siteId: '8uyt2m' };
 		const context = {

--- a/packages/snap-client/src/Client/apis/Hybrid.test.ts
+++ b/packages/snap-client/src/Client/apis/Hybrid.test.ts
@@ -7,7 +7,7 @@ const mockData = new MockData();
 
 describe('Hybrid Api', () => {
 	it('has expected default functions', () => {
-		let api = new HybridAPI(new ApiConfiguration({}));
+		const api = new HybridAPI(new ApiConfiguration({}));
 
 		//@ts-ignore
 		expect(api?.requesters).toBeDefined();
@@ -26,7 +26,7 @@ describe('Hybrid Api', () => {
 	});
 
 	it('can call getMeta', async () => {
-		let api = new HybridAPI(new ApiConfiguration({}));
+		const api = new HybridAPI(new ApiConfiguration({}));
 		const requestMock = jest
 			.spyOn(global.window, 'fetch')
 			.mockImplementation(() => Promise.resolve({ status: 200, json: () => Promise.resolve({}) } as Response));
@@ -43,7 +43,7 @@ describe('Hybrid Api', () => {
 	});
 
 	it('can call getSearch', async () => {
-		let api = new HybridAPI(new ApiConfiguration({}));
+		const api = new HybridAPI(new ApiConfiguration({}));
 		const requestMock = jest
 			.spyOn(global.window, 'fetch')
 			.mockImplementation(() => Promise.resolve({ status: 200, json: () => Promise.resolve(mockData.search()) } as Response));
@@ -65,7 +65,7 @@ describe('Hybrid Api', () => {
 	});
 
 	it('can call getAutcomplete', async () => {
-		let api = new HybridAPI(new ApiConfiguration({}));
+		const api = new HybridAPI(new ApiConfiguration({}));
 
 		const requestMock = jest
 			.spyOn(global.window, 'fetch')

--- a/packages/snap-client/src/Client/apis/Legacy.test.ts
+++ b/packages/snap-client/src/Client/apis/Legacy.test.ts
@@ -4,7 +4,7 @@ import { LegacyAPI } from './Legacy';
 
 describe('Legacy Api', () => {
 	it('has expected default functions', () => {
-		let api = new LegacyAPI(new ApiConfiguration({}));
+		const api = new LegacyAPI(new ApiConfiguration({}));
 
 		// @ts-ignore
 		expect(api?.getEndpoint).toBeDefined();
@@ -19,7 +19,7 @@ describe('Legacy Api', () => {
 	});
 
 	it('can call getMeta', async () => {
-		let api = new LegacyAPI(new ApiConfiguration({}));
+		const api = new LegacyAPI(new ApiConfiguration({}));
 		const requestMock = jest
 			.spyOn(global.window, 'fetch')
 			.mockImplementation(() => Promise.resolve({ status: 200, json: () => Promise.resolve({}) } as Response));
@@ -38,7 +38,7 @@ describe('Legacy Api', () => {
 	});
 
 	it('can call getSearch', async () => {
-		let api = new LegacyAPI(new ApiConfiguration({}));
+		const api = new LegacyAPI(new ApiConfiguration({}));
 		const requestMock = jest
 			.spyOn(global.window, 'fetch')
 			.mockImplementation(() => Promise.resolve({ status: 200, json: () => Promise.resolve({}) } as Response));
@@ -58,7 +58,7 @@ describe('Legacy Api', () => {
 	});
 
 	it('can call postMeta', async () => {
-		let api = new LegacyAPI(new ApiConfiguration({}));
+		const api = new LegacyAPI(new ApiConfiguration({}));
 		const requestMock = jest
 			.spyOn(global.window, 'fetch')
 			.mockImplementation(() => Promise.resolve({ status: 200, json: () => Promise.resolve({}) } as Response));
@@ -80,7 +80,7 @@ describe('Legacy Api', () => {
 	});
 
 	it('can call getAutocomplete', async () => {
-		let api = new LegacyAPI(new ApiConfiguration({}));
+		const api = new LegacyAPI(new ApiConfiguration({}));
 		const requestMock = jest
 			.spyOn(global.window, 'fetch')
 			.mockImplementation(() => Promise.resolve({ status: 200, json: () => Promise.resolve({}) } as Response));
@@ -100,7 +100,7 @@ describe('Legacy Api', () => {
 	});
 
 	it('can call getFinder', async () => {
-		let api = new LegacyAPI(new ApiConfiguration({}));
+		const api = new LegacyAPI(new ApiConfiguration({}));
 		const requestMock = jest
 			.spyOn(global.window, 'fetch')
 			.mockImplementation(() => Promise.resolve({ status: 200, json: () => Promise.resolve({}) } as Response));
@@ -120,7 +120,7 @@ describe('Legacy Api', () => {
 	});
 
 	it('can call getEndpoint', async () => {
-		let api = new LegacyAPI(new ApiConfiguration({}));
+		const api = new LegacyAPI(new ApiConfiguration({}));
 
 		let requestMock = jest
 			.spyOn(global.window, 'fetch')

--- a/packages/snap-client/src/Client/apis/Legacy.ts
+++ b/packages/snap-client/src/Client/apis/Legacy.ts
@@ -9,7 +9,7 @@ export class LegacyAPI extends API {
 		const headerParameters: HTTPHeaders = {};
 
 		//remove pageLoadId from cache key query params
-		let cacheParameters = { ...queryParameters };
+		const cacheParameters = { ...queryParameters };
 		delete cacheParameters.pageLoadId;
 
 		const legacyResponse = await this.request(

--- a/packages/snap-client/src/Client/apis/Recommend.test.ts
+++ b/packages/snap-client/src/Client/apis/Recommend.test.ts
@@ -13,7 +13,7 @@ const wait = (time?: number) => {
 
 describe('Recommend Api', () => {
 	it('has expected default functions', () => {
-		let api = new RecommendAPI(new ApiConfiguration({}));
+		const api = new RecommendAPI(new ApiConfiguration({}));
 
 		// @ts-ignore - accessing private property
 		expect(api?.batches).toBeDefined();
@@ -28,7 +28,7 @@ describe('Recommend Api', () => {
 	});
 
 	it('can call getProfile', async () => {
-		let api = new RecommendAPI(new ApiConfiguration({}));
+		const api = new RecommendAPI(new ApiConfiguration({}));
 
 		const params = {
 			body: undefined,
@@ -38,7 +38,7 @@ describe('Recommend Api', () => {
 
 		const requestUrl = 'https://8uyt2m.a.searchspring.io/api/personalized-recommendations/profile.json?siteId=8uyt2m&tag=dress';
 
-		let requestMock = jest
+		const requestMock = jest
 			.spyOn(global.window, 'fetch')
 			.mockImplementation(() => Promise.resolve({ status: 200, json: () => Promise.resolve({}) } as Response));
 
@@ -53,7 +53,7 @@ describe('Recommend Api', () => {
 	});
 
 	it('can call getRecommendations', async () => {
-		let api = new RecommendAPI(new ApiConfiguration({}));
+		const api = new RecommendAPI(new ApiConfiguration({}));
 
 		const params = {
 			method: 'GET',
@@ -62,7 +62,7 @@ describe('Recommend Api', () => {
 
 		const requestUrl = 'https://8uyt2m.a.searchspring.io/boost/8uyt2m/recommend?siteId=8uyt2m&tags=dress';
 
-		let requestMock = jest
+		const requestMock = jest
 			.spyOn(global.window, 'fetch')
 			.mockImplementation(() => Promise.resolve({ status: 200, json: () => Promise.resolve({}) } as Response));
 
@@ -77,7 +77,7 @@ describe('Recommend Api', () => {
 	});
 
 	it('can call postRecommendations', async () => {
-		let api = new RecommendAPI(new ApiConfiguration({}));
+		const api = new RecommendAPI(new ApiConfiguration({}));
 
 		const params = {
 			method: 'POST',
@@ -89,7 +89,7 @@ describe('Recommend Api', () => {
 
 		const requestUrl = 'https://88uyt2m.a.searchspring.io/boost/88uyt2m/recommend';
 
-		let requestMock = jest
+		const requestMock = jest
 			.spyOn(global.window, 'fetch')
 			.mockImplementation(() => Promise.resolve({ status: 200, json: () => Promise.resolve({}) } as Response));
 
@@ -104,7 +104,7 @@ describe('Recommend Api', () => {
 	});
 
 	it('can call batchRecommendations', async () => {
-		let api = new RecommendAPI(new ApiConfiguration({}));
+		const api = new RecommendAPI(new ApiConfiguration({}));
 
 		const params = {
 			method: 'GET',
@@ -113,7 +113,7 @@ describe('Recommend Api', () => {
 
 		const requestUrl = 'https://8uyt2m.a.searchspring.io/boost/8uyt2m/recommend?tags=similar&limits=20&siteId=8uyt2m';
 
-		let requestMock = jest
+		const requestMock = jest
 			.spyOn(global.window, 'fetch')
 			.mockImplementation(() => Promise.resolve({ status: 200, json: () => Promise.resolve(mockData.recommend()) } as Response));
 
@@ -157,9 +157,9 @@ describe('Recommend Api', () => {
 	};
 
 	it('batchRecommendations batches as expected', async () => {
-		let api = new RecommendAPI(new ApiConfiguration({}));
+		const api = new RecommendAPI(new ApiConfiguration({}));
 
-		let requestMock = jest
+		const requestMock = jest
 			.spyOn(global.window, 'fetch')
 			.mockImplementation(() => Promise.resolve({ status: 200, json: () => Promise.resolve(mockData.recommend()) } as Response));
 
@@ -190,9 +190,9 @@ describe('Recommend Api', () => {
 	});
 
 	it('batchRecommendations handles multiple categories as expected', async () => {
-		let api = new RecommendAPI(new ApiConfiguration({}));
+		const api = new RecommendAPI(new ApiConfiguration({}));
 
-		let requestMock = jest
+		const requestMock = jest
 			.spyOn(global.window, 'fetch')
 			.mockImplementation(() => Promise.resolve({ status: 200, json: () => Promise.resolve(mockData.recommend()) } as Response));
 
@@ -234,9 +234,9 @@ describe('Recommend Api', () => {
 	});
 
 	it('batchRecommendations handles order prop as expected', async () => {
-		let api = new RecommendAPI(new ApiConfiguration({}));
+		const api = new RecommendAPI(new ApiConfiguration({}));
 
-		let requestMock = jest
+		const requestMock = jest
 			.spyOn(global.window, 'fetch')
 			.mockImplementation(() => Promise.resolve({ status: 200, json: () => Promise.resolve(mockData.recommend()) } as Response));
 
@@ -280,17 +280,17 @@ describe('Recommend Api', () => {
 
 		//add delay for paramBatch.timeout
 		await wait(250);
-		let reorderedGetURL =
+		const reorderedGetURL =
 			'https://8uyt2m.a.searchspring.io/boost/8uyt2m/recommend?tags=crossSell&tags=crossSell&tags=similar&tags=crossSell&limits=10&limits=10&limits=14&limits=10&categories=pants&categories=shirts&siteId=8uyt2m&lastViewed=marnie-runner-2-7x10&lastViewed=ruby-runner-2-7x10&lastViewed=abbie-runner-2-7x10&lastViewed=riley-4x6&lastViewed=joely-5x8&lastViewed=helena-4x6&lastViewed=kwame-4x6&lastViewed=sadie-4x6&lastViewed=candice-runner-2-7x10&lastViewed=esmeray-4x6&lastViewed=camilla-230x160&lastViewed=candice-4x6&lastViewed=sahara-4x6&lastViewed=dayna-4x6&lastViewed=moema-4x6&product=marnie-runner-2-7x10';
 		expect(requestMock).toHaveBeenCalledWith(reorderedGetURL, GETParams);
 		requestMock.mockReset();
 	});
 
 	it('batchRecommendations resolves in right order with order prop', async () => {
-		let api = new RecommendAPI(new ApiConfiguration({}));
+		const api = new RecommendAPI(new ApiConfiguration({}));
 		const response = mockData.file('recommend/results/8uyt2m/ordered.json');
 
-		let requestMock = jest
+		const requestMock = jest
 			.spyOn(global.window, 'fetch')
 			.mockImplementation(() => Promise.resolve({ status: 200, json: () => Promise.resolve(response) } as Response));
 
@@ -316,7 +316,7 @@ describe('Recommend Api', () => {
 
 		//add delay for paramBatch.timeout
 		await wait(250);
-		let reorderedGetURL =
+		const reorderedGetURL =
 			'https://8uyt2m.a.searchspring.io/boost/8uyt2m/recommend?tags=crosssell&tags=similar&limits=20&limits=10&categories=dress&categories=shirts&siteId=8uyt2m&lastViewed=marnie-runner-2-7x10&lastViewed=ruby-runner-2-7x10&lastViewed=abbie-runner-2-7x10&lastViewed=riley-4x6&lastViewed=joely-5x8&lastViewed=helena-4x6&lastViewed=kwame-4x6&lastViewed=sadie-4x6&lastViewed=candice-runner-2-7x10&lastViewed=esmeray-4x6&lastViewed=camilla-230x160&lastViewed=candice-4x6&lastViewed=sahara-4x6&lastViewed=dayna-4x6&lastViewed=moema-4x6&product=marnie-runner-2-7x10';
 
 		expect(requestMock).toHaveBeenCalledWith(reorderedGetURL, GETParams);
@@ -330,16 +330,16 @@ describe('Recommend Api', () => {
 	});
 
 	it('batchRecommendations handles undefined limits', async () => {
-		let api = new RecommendAPI(new ApiConfiguration({}));
+		const api = new RecommendAPI(new ApiConfiguration({}));
 
-		let requestMock = jest
+		const requestMock = jest
 			.spyOn(global.window, 'fetch')
 			.mockImplementation(() => Promise.resolve({ status: 200, json: () => Promise.resolve(mockData.recommend()) } as Response));
 
 		const requestURL =
 			'https://8uyt2m.a.searchspring.io/boost/8uyt2m/recommend?tags=crossSell&limits=20&siteId=8uyt2m&lastViewed=marnie-runner-2-7x10&lastViewed=ruby-runner-2-7x10&lastViewed=abbie-runner-2-7x10&lastViewed=riley-4x6&lastViewed=joely-5x8&lastViewed=helena-4x6&lastViewed=kwame-4x6&lastViewed=sadie-4x6&lastViewed=candice-runner-2-7x10&lastViewed=esmeray-4x6&lastViewed=camilla-230x160&lastViewed=candice-4x6&lastViewed=sahara-4x6&lastViewed=dayna-4x6&lastViewed=moema-4x6&product=marnie-runner-2-7x10';
 
-		//now lets try with no limits
+		//now consts try with no limits
 		// @ts-ignore
 		api.batchRecommendations({
 			tags: ['crossSell'],
@@ -355,9 +355,9 @@ describe('Recommend Api', () => {
 	});
 
 	it('batchRecommendations handles POST requests', async () => {
-		let api = new RecommendAPI(new ApiConfiguration({}));
+		const api = new RecommendAPI(new ApiConfiguration({}));
 
-		//now lets try a post
+		//now consts try a post
 		const POSTParams = {
 			method: 'POST',
 			headers: {
@@ -389,7 +389,7 @@ describe('Recommend Api', () => {
 		};
 		const POSTRequestUrl = 'https://8uyt2m.a.searchspring.io/boost/8uyt2m/recommend';
 
-		let POSTRequestMock = jest
+		const POSTRequestMock = jest
 			.spyOn(global.window, 'fetch')
 			.mockImplementation(() => Promise.resolve({ status: 200, json: () => Promise.resolve({}) } as Response));
 

--- a/packages/snap-client/src/Client/apis/Recommend.ts
+++ b/packages/snap-client/src/Client/apis/Recommend.ts
@@ -54,8 +54,7 @@ export class RecommendAPI extends API {
 	}
 
 	async batchRecommendations(parameters: RecommendRequestModel): Promise<RecommendResponseModel> {
-		let { tags, limits, categories, ...otherParams } = parameters;
-
+		let { tags, limits, categories, ...otherParams } = parameters; // eslint-disable-line
 		// set up batch key and deferred promises
 		const key = parameters.batched ? parameters.siteId : `${Math.random()}`;
 		const batch = (this.batches[key] = this.batches[key] || { timeout: null, request: { tags: [], limits: [] }, entries: [] });
@@ -76,7 +75,7 @@ export class RecommendAPI extends API {
 			// now that the requests are in proper order, map through them
 			// and build out the batches
 			batch.entries.map((entry) => {
-				let { tags, limits, categories, ...otherParams } = entry.request;
+				let { tags, limits, categories, ...otherParams } = entry.request; // eslint-disable-line
 
 				if (!limits) limits = 20;
 				const [tag] = tags || [];

--- a/packages/snap-client/src/Client/apis/Snap.test.ts
+++ b/packages/snap-client/src/Client/apis/Snap.test.ts
@@ -4,7 +4,7 @@ import { SnapAPI } from './Snap';
 
 describe('Snap Api', () => {
 	it('has expected default functions', () => {
-		let api = new SnapAPI(new ApiConfiguration({}));
+		const api = new SnapAPI(new ApiConfiguration({}));
 
 		expect(api?.postMeta).toBeDefined();
 
@@ -14,8 +14,8 @@ describe('Snap Api', () => {
 	});
 
 	it('can call postMeta', async () => {
-		let api = new SnapAPI(new ApiConfiguration({}));
-		let requestMock = jest
+		const api = new SnapAPI(new ApiConfiguration({}));
+		const requestMock = jest
 			.spyOn(global.window, 'fetch')
 			.mockImplementation(() => Promise.resolve({ status: 200, json: () => Promise.resolve({}) } as Response));
 
@@ -39,8 +39,8 @@ describe('Snap Api', () => {
 	});
 
 	it('can call postSearch', async () => {
-		let api = new SnapAPI(new ApiConfiguration({}));
-		let requestMock = jest
+		const api = new SnapAPI(new ApiConfiguration({}));
+		const requestMock = jest
 			.spyOn(global.window, 'fetch')
 			.mockImplementation(() => Promise.resolve({ status: 200, json: () => Promise.resolve({}) } as Response));
 
@@ -61,8 +61,8 @@ describe('Snap Api', () => {
 	});
 
 	it('can call postAutocomplete', async () => {
-		let api = new SnapAPI(new ApiConfiguration({}));
-		let requestMock = jest
+		const api = new SnapAPI(new ApiConfiguration({}));
+		const requestMock = jest
 			.spyOn(global.window, 'fetch')
 			.mockImplementation(() => Promise.resolve({ status: 200, json: () => Promise.resolve({}) } as Response));
 

--- a/packages/snap-client/src/Client/apis/Suggest.test.ts
+++ b/packages/snap-client/src/Client/apis/Suggest.test.ts
@@ -4,7 +4,7 @@ import { SuggestAPI } from './Suggest';
 
 describe('Suggest Api', () => {
 	it('has expected default functions', () => {
-		let api = new SuggestAPI(new ApiConfiguration({}));
+		const api = new SuggestAPI(new ApiConfiguration({}));
 
 		expect(api?.getSuggest).toBeDefined();
 
@@ -16,9 +16,9 @@ describe('Suggest Api', () => {
 	});
 
 	it('can call getSuggest', async () => {
-		let api = new SuggestAPI(new ApiConfiguration({}));
+		const api = new SuggestAPI(new ApiConfiguration({}));
 
-		let requestMock = jest
+		const requestMock = jest
 			.spyOn(global.window, 'fetch')
 			.mockImplementation(() => Promise.resolve({ status: 200, json: () => Promise.resolve({}) } as Response));
 
@@ -40,7 +40,7 @@ describe('Suggest Api', () => {
 	});
 
 	it('can call postSuggest', async () => {
-		let api = new SuggestAPI(new ApiConfiguration({}));
+		const api = new SuggestAPI(new ApiConfiguration({}));
 
 		const params = {
 			body: '{"siteId":"88uyt2m","query":"dress"}',
@@ -51,7 +51,7 @@ describe('Suggest Api', () => {
 		};
 		const requestUrl = 'https://88uyt2m.a.searchspring.io/api/suggest/query';
 
-		let requestMock = jest
+		const requestMock = jest
 			.spyOn(global.window, 'fetch')
 			.mockImplementation(() => Promise.resolve({ status: 200, json: () => Promise.resolve({}) } as Response));
 
@@ -66,8 +66,8 @@ describe('Suggest Api', () => {
 	});
 
 	it('can call getTrending', async () => {
-		let api = new SuggestAPI(new ApiConfiguration({}));
-		let requestMock = jest
+		const api = new SuggestAPI(new ApiConfiguration({}));
+		const requestMock = jest
 			.spyOn(global.window, 'fetch')
 			.mockImplementation(() => Promise.resolve({ status: 200, json: () => Promise.resolve({}) } as Response));
 
@@ -90,8 +90,8 @@ describe('Suggest Api', () => {
 	});
 
 	it('can call postTrending', async () => {
-		let api = new SuggestAPI(new ApiConfiguration({}));
-		let requestMock = jest
+		const api = new SuggestAPI(new ApiConfiguration({}));
+		const requestMock = jest
 			.spyOn(global.window, 'fetch')
 			.mockImplementation(() => Promise.resolve({ status: 200, json: () => Promise.resolve({}) } as Response));
 

--- a/packages/snap-client/src/Client/apis/Suggest.ts
+++ b/packages/snap-client/src/Client/apis/Suggest.ts
@@ -1,12 +1,5 @@
 import { API } from './Abstract';
-import {
-	HTTPHeaders,
-	SuggestRequestModel,
-	SuggestResponseModelSuggestion,
-	SuggestResponseModel,
-	TrendingRequestModel,
-	TrendingResponseModel,
-} from '../../types';
+import { HTTPHeaders, SuggestRequestModel, SuggestResponseModel, TrendingRequestModel, TrendingResponseModel } from '../../types';
 
 export class SuggestAPI extends API {
 	async getSuggest(queryParameters: SuggestRequestModel): Promise<SuggestResponseModel> {

--- a/packages/snap-client/src/Client/integration.test.ts
+++ b/packages/snap-client/src/Client/integration.test.ts
@@ -14,7 +14,7 @@ describe('Snap Client Integration Tests', () => {
 		const globals = { siteId: '8uyt2m' };
 		const CACHE_STORAGE_KEY = 'ss-networkcache';
 
-		let searchConfig: SearchControllerConfig = {
+		const searchConfig: SearchControllerConfig = {
 			id: 'search',
 			globals: {
 				filters: [],

--- a/packages/snap-client/src/Client/transforms/searchResponse.test.ts
+++ b/packages/snap-client/src/Client/transforms/searchResponse.test.ts
@@ -305,7 +305,7 @@ describe('search response transformer', () => {
 		const merchandising = jest.spyOn(transformSearchResponse, 'merchandising');
 		const search = jest.spyOn(transformSearchResponse, 'search');
 
-		const searchResponse = transformSearchResponse(mockResponse, mockRequest);
+		transformSearchResponse(mockResponse, mockRequest);
 
 		expect(results).toHaveBeenCalled();
 		expect(filters).toHaveBeenCalled();

--- a/packages/snap-client/src/Client/transforms/searchResponse.ts
+++ b/packages/snap-client/src/Client/transforms/searchResponse.ts
@@ -136,7 +136,7 @@ export type searchResponseType = {
 		is_elevated: string[];
 		elevated: any[];
 		removed: string[];
-		content: {};
+		content: object;
 		facets: any[];
 		facetsHide: any[];
 		experiments?: [];
@@ -406,7 +406,7 @@ transformSearchResponse.merchandising = (response: searchResponseType) => {
 };
 
 transformSearchResponse.search = (response: searchResponseType, request: SearchRequestModel) => {
-	let searchObj: {
+	const searchObj: {
 		search: {
 			query?: string;
 			didYouMean?: string;

--- a/packages/snap-client/src/Client/transforms/suggestResponse.test.ts
+++ b/packages/snap-client/src/Client/transforms/suggestResponse.test.ts
@@ -45,7 +45,7 @@ describe('suggest response transformer', () => {
 		const suggested = jest.spyOn(transformSuggestResponse, 'suggested');
 		const alternatives = jest.spyOn(transformSuggestResponse, 'alternatives');
 
-		const suggestResponse = transformSuggestResponse(mockResponse);
+		transformSuggestResponse(mockResponse);
 
 		expect(query).toHaveBeenCalled();
 		expect(correctedQuery).toHaveBeenCalled();

--- a/packages/snap-client/src/Client/utils/htmlUnescape.test.ts
+++ b/packages/snap-client/src/Client/utils/htmlUnescape.test.ts
@@ -9,7 +9,7 @@ describe('htmlUnescape function', () => {
 
 		expect(htmlUnescape('test me')).toEqual('test me');
 
-		let unicodeString = 'Hugo &amp; Caddy &gt; WordPress &amp; Apache';
+		const unicodeString = 'Hugo &amp; Caddy &gt; WordPress &amp; Apache';
 		expect(htmlUnescape(unicodeString)).toEqual('Hugo & Caddy > WordPress & Apache');
 	});
 });

--- a/packages/snap-controller/src/Abstract/AbstractController.test.ts
+++ b/packages/snap-controller/src/Abstract/AbstractController.test.ts
@@ -16,7 +16,7 @@ import type { ControllerConfig } from '../types';
 describe('Search Controller', () => {
 	const globals = { siteId: 'ga9kq2' };
 
-	let controllerConfigDefault: ControllerConfig = {
+	const controllerConfigDefault: ControllerConfig = {
 		id: 'abstract',
 	};
 
@@ -38,7 +38,7 @@ describe('Search Controller', () => {
 	it('throws if invalid config', async () => {
 		expect(() => {
 			// @ts-ignore
-			const controller = new TestController(
+			new TestController(
 				// @ts-ignore
 				{ id: 123 },
 				{
@@ -56,7 +56,7 @@ describe('Search Controller', () => {
 
 	it('throws if invalid services', async () => {
 		expect(() => {
-			const controller = new TestController(searchConfig, {
+			new TestController(searchConfig, {
 				// @ts-ignore
 				client: 'invalid',
 				store: new SearchStore(searchConfig, services),
@@ -69,7 +69,7 @@ describe('Search Controller', () => {
 		}).toThrow();
 
 		expect(() => {
-			const controller = new TestController(searchConfig, {
+			new TestController(searchConfig, {
 				client: new MockClient(globals, {}),
 				// @ts-ignore
 				store: 'invalid',
@@ -82,7 +82,7 @@ describe('Search Controller', () => {
 		}).toThrow();
 
 		expect(() => {
-			const controller = new TestController(searchConfig, {
+			new TestController(searchConfig, {
 				client: new MockClient(globals, {}),
 				store: new SearchStore(searchConfig, services),
 				// @ts-ignore
@@ -95,7 +95,7 @@ describe('Search Controller', () => {
 		}).toThrow();
 
 		expect(() => {
-			const controller = new TestController(searchConfig, {
+			new TestController(searchConfig, {
 				client: new MockClient(globals, {}),
 				store: new SearchStore(searchConfig, services),
 				urlManager,
@@ -108,7 +108,7 @@ describe('Search Controller', () => {
 		}).toThrow();
 
 		expect(() => {
-			const controller = new TestController(searchConfig, {
+			new TestController(searchConfig, {
 				client: new MockClient(globals, {}),
 				store: new SearchStore(searchConfig, services),
 				urlManager,
@@ -121,7 +121,7 @@ describe('Search Controller', () => {
 		}).toThrow();
 
 		expect(() => {
-			const controller = new TestController(searchConfig, {
+			new TestController(searchConfig, {
 				client: new MockClient(globals, {}),
 				store: new SearchStore(searchConfig, services),
 				urlManager,
@@ -134,7 +134,7 @@ describe('Search Controller', () => {
 		}).toThrow();
 
 		expect(() => {
-			const controller = new TestController(searchConfig, {
+			new TestController(searchConfig, {
 				client: new MockClient(globals, {}),
 				store: new SearchStore(searchConfig, services),
 				urlManager,
@@ -191,7 +191,7 @@ describe('Search Controller', () => {
 		});
 		const initfn = jest.fn();
 		const paramPlugin = (controller: AbstractController) => {
-			controller.on('init', async ({ controller }: { controller: AbstractController }, next: Next) => {
+			controller.on('init', async ({}: { controller: AbstractController }, next: Next) => {
 				initfn();
 				await next();
 			});
@@ -219,20 +219,20 @@ describe('Search Controller', () => {
 		});
 		const initfn = jest.fn();
 
-		const initMiddleware: Middleware<{ controller: AbstractController }> = async ({ controller }: { controller: AbstractController }, next: Next) => {
+		const initMiddleware: Middleware<{ controller: AbstractController }> = async ({}: { controller: AbstractController }, next: Next) => {
 			initfn();
 			await next();
 		};
 
 		const plugin = (controller: AbstractController) => {
-			controller.on('init', async ({ controller }: { controller: AbstractController }, next: Next) => {
+			controller.on('init', async ({}: { controller: AbstractController }, next: Next) => {
 				initfn();
 				await next();
 			});
 		};
 
-		const paramPlugin = (controller: AbstractController, ...params: any[]) => {
-			controller.on('init', async ({ controller }: { controller: AbstractController }, next: Next) => {
+		const paramPlugin = (controller: AbstractController) => {
+			controller.on('init', async ({}: { controller: AbstractController }, next: Next) => {
 				initfn();
 				await next();
 			});
@@ -271,7 +271,7 @@ describe('Search Controller', () => {
 		const spy = jest.spyOn(controller.log, 'warn');
 
 		const plugin = (controller: AbstractController) => {
-			controller.on('init', async ({ controller }: { controller: AbstractController }, next: Next) => {
+			controller.on('init', async ({}: { controller: AbstractController }, next: Next) => {
 				initfn();
 				await next();
 			});
@@ -296,7 +296,7 @@ describe('Search Controller', () => {
 		spy.mockClear();
 
 		// test if middleware is not an array (should be converted to an array internally)
-		const initMiddleware: Middleware<{ controller: AbstractController }> = async ({ controller }: { controller: AbstractController }, next: Next) => {
+		const initMiddleware: Middleware<{ controller: AbstractController }> = async ({}: { controller: AbstractController }, next: Next) => {
 			initfn();
 			await next();
 		};

--- a/packages/snap-controller/src/Autocomplete/AutocompleteController.test.ts
+++ b/packages/snap-controller/src/Autocomplete/AutocompleteController.test.ts
@@ -16,7 +16,7 @@ const KEY_ENTER = 13;
 const KEY_ESCAPE = 27;
 const INPUT_DELAY = _INPUT_DELAY + 10;
 
-let acConfigBase = {
+const acConfigBase = {
 	id: 'ac',
 	selector: '#search_query',
 	action: '',
@@ -629,8 +629,7 @@ describe('Autocomplete Controller', () => {
 
 		await controller.bind();
 
-		let form: HTMLFormElement | null;
-		let query = 'dresss';
+		const query = 'dresss';
 		let inputEl: HTMLInputElement | null;
 
 		await waitFor(() => {
@@ -638,7 +637,7 @@ describe('Autocomplete Controller', () => {
 			expect(inputEl).toBeDefined();
 		});
 
-		form = inputEl!.form;
+		const form = inputEl!.form;
 
 		inputEl!.value = query;
 		inputEl!.focus();
@@ -646,11 +645,11 @@ describe('Autocomplete Controller', () => {
 
 		await controller.search();
 
-		let beforeSubmitfn = jest.spyOn(controller.eventManager, 'fire');
+		const beforeSubmitfn = jest.spyOn(controller.eventManager, 'fire');
 		form?.dispatchEvent(new Event('submit', { bubbles: true }));
 
 		await waitFor(() => {
-			let oqInputEl: HTMLInputElement | null = form!.querySelector('input[name="oq"]');
+			const oqInputEl: HTMLInputElement | null = form!.querySelector('input[name="oq"]');
 			expect(oqInputEl!).toBeDefined();
 			expect(oqInputEl!.value).toBe(query);
 		});
@@ -730,7 +729,7 @@ describe('Autocomplete Controller', () => {
 		controller.urlManager = controller.urlManager.set('query', query);
 
 		await controller.bind();
-		let inputEl: HTMLInputElement = document.querySelector(controller.config.selector)!;
+		const inputEl: HTMLInputElement = document.querySelector(controller.config.selector)!;
 		expect(inputEl).toBeDefined();
 
 		inputEl.value = query;
@@ -782,7 +781,7 @@ describe('Autocomplete Controller', () => {
 		controller.urlManager = controller.urlManager.set('query', query);
 
 		await controller.bind();
-		let inputEl: HTMLInputElement = document.querySelector(controller.config.selector)!;
+		const inputEl: HTMLInputElement = document.querySelector(controller.config.selector)!;
 		expect(inputEl).toBeDefined();
 
 		inputEl.value = query;
@@ -1106,7 +1105,7 @@ describe('Autocomplete Controller', () => {
 		});
 
 		await controller.bind();
-		let inputEl: HTMLInputElement | null;
+		// let inputEl: HTMLInputElement | null;
 		const query = 'bumpers';
 		const middleware = jest.fn(() => {
 			throw new Error('middleware error');
@@ -1117,7 +1116,7 @@ describe('Autocomplete Controller', () => {
 
 		expect(middleware).not.toHaveBeenCalled();
 
-		inputEl = document.querySelector(controller.config.selector);
+		const inputEl = document.querySelector(controller.config.selector) as HTMLInputElement | null;
 		inputEl!.value = query;
 		inputEl!.focus();
 		inputEl!.dispatchEvent(new Event('keyup'));
@@ -1150,14 +1149,13 @@ describe('Autocomplete Controller', () => {
 		const middleware = jest.fn(() => {
 			return false; // return false to stop middleware
 		});
-		let inputEl: HTMLInputElement | null;
 		const event = 'beforeSubmit';
 		(controller.client as MockClient).mockData.updateConfig({ autocomplete: 'autocomplete.query.bumpers' });
 		controller.on(event, middleware);
 
 		expect(middleware).not.toHaveBeenCalled();
 
-		inputEl = document.querySelector(controller.config.selector);
+		const inputEl = document.querySelector(controller.config.selector) as HTMLInputElement | null;
 		const query = 'bumpers';
 		inputEl!.value = query;
 		inputEl!.focus();

--- a/packages/snap-controller/src/Autocomplete/AutocompleteController.ts
+++ b/packages/snap-controller/src/Autocomplete/AutocompleteController.ts
@@ -1,6 +1,6 @@
 import deepmerge from 'deepmerge';
 
-import { StorageStore, StorageType, ErrorType, SearchHistoryStore } from '@searchspring/snap-store-mobx';
+import { StorageStore, StorageType, ErrorType } from '@searchspring/snap-store-mobx';
 import { AbstractController } from '../Abstract/AbstractController';
 import { getSearchParams } from '../utils/getParams';
 import { ControllerTypes } from '../types';
@@ -116,7 +116,7 @@ export class AutocompleteController extends AbstractController {
 	track: AutocompleteTrackMethods = {
 		// TODO: add in future when autocomplete supports result click tracking
 		product: {
-			click: (e: MouseEvent, result): void => {
+			click: (): void => {
 				this.log.warn('product.click tracking is not currently supported in this controller type');
 			},
 		},

--- a/packages/snap-controller/src/Finder/FinderController.ts
+++ b/packages/snap-controller/src/Finder/FinderController.ts
@@ -81,7 +81,7 @@ export class FinderController extends AbstractController {
 		const sessionId = this.tracker.getContext().sessionId;
 		const pageLoadId = this.tracker.getContext().pageLoadId;
 
-		let tracking: any = {};
+		const tracking: any = {};
 
 		if (userId) {
 			tracking.userId = userId;

--- a/packages/snap-controller/src/Recommendation/RecommendationController.test.ts
+++ b/packages/snap-controller/src/Recommendation/RecommendationController.test.ts
@@ -52,7 +52,7 @@ describe('Recommendation Controller', () => {
 			};
 
 			// @ts-ignore
-			const controller = new RecommendationController(configWithoutTag, {
+			new RecommendationController(configWithoutTag, {
 				client: new MockClient(globals, {}),
 				store: new RecommendationStore(configWithoutTag, services),
 				urlManager,

--- a/packages/snap-controller/src/Search/SearchController.test.ts
+++ b/packages/snap-controller/src/Search/SearchController.test.ts
@@ -17,7 +17,7 @@ import type { SearchRequestModel } from '@searchspring/snapi-types';
 
 const globals = { siteId: 'ga9kq2' };
 
-let searchConfigDefault: SearchControllerConfig = {
+const searchConfigDefault: SearchControllerConfig = {
 	id: 'search',
 	globals: {
 		filters: [],
@@ -680,7 +680,9 @@ describe('Search Controller', () => {
 			await next();
 		});
 
-		const restorePositionFunc = jest.fn((element?: ElementPositionObj) => {});
+		const restorePositionFunc = jest.fn((element?: ElementPositionObj) => {
+			console.log(element);
+		});
 
 		controller.on('restorePosition', async (search: RestorePositionObj, next: Next) => {
 			restorePositionFunc(search.element);

--- a/packages/snap-controller/src/Search/SearchController.ts
+++ b/packages/snap-controller/src/Search/SearchController.ts
@@ -20,7 +20,6 @@ import type {
 import type { Next } from '@searchspring/snap-event-manager';
 import type { SearchRequestModel, SearchResponseModelResult, SearchRequestModelSearchRedirectResponseEnum } from '@searchspring/snapi-types';
 
-const HEIGHT_CHECK_INTERVAL = 50;
 const API_LIMIT = 500;
 
 const defaultConfig: SearchControllerConfig = {
@@ -361,7 +360,7 @@ export class SearchController extends AbstractController {
 				// infinite backfill results
 				if (backfills && backfills.length) {
 					// array to hold all results from backfill responses
-					let backfillResults: SearchResponseModelResult[] = [];
+					const backfillResults: SearchResponseModelResult[] = [];
 
 					const backfillResponses = await Promise.all(backfills);
 					backfillResponses.map(([metaBackfill, responseBackfill]) => {

--- a/packages/snap-event-manager/src/EventManager.test.ts
+++ b/packages/snap-event-manager/src/EventManager.test.ts
@@ -113,7 +113,7 @@ describe('Event Manager', () => {
 		const testFunc1 = jest.fn();
 		const testFunc2 = jest.fn();
 
-		eventManager.on('testEvent', (context, next) => {
+		eventManager.on('testEvent', () => {
 			testFunc1();
 			expect(testFunc2).not.toHaveBeenCalled();
 

--- a/packages/snap-event-manager/src/MiddlewareManager.test.ts
+++ b/packages/snap-event-manager/src/MiddlewareManager.test.ts
@@ -114,7 +114,7 @@ describe('Middleware Manager', () => {
 		const middlewareManager = new MiddlewareManager();
 		const testFunc = jest.fn();
 
-		const fn1 = (_context: any, next: any) => {
+		const fn1 = () => {
 			testFunc();
 			// next();
 			testFunc();

--- a/packages/snap-preact-components/src/components/Atoms/Breadcrumbs/Breadcrumbs.test.tsx
+++ b/packages/snap-preact-components/src/components/Atoms/Breadcrumbs/Breadcrumbs.test.tsx
@@ -91,7 +91,7 @@ describe('Breadcrumbs Component', () => {
 
 		const rendered = render(<Breadcrumbs {...args} style={style} />);
 		const breadcrumbElement = rendered.container.querySelector('.ss__breadcrumbs')!;
-		let styles = getComputedStyle(breadcrumbElement);
+		const styles = getComputedStyle(breadcrumbElement);
 
 		expect(styles.padding).toBe(style.padding);
 	});

--- a/packages/snap-preact-components/src/components/Atoms/Button/Button.test.tsx
+++ b/packages/snap-preact-components/src/components/Atoms/Button/Button.test.tsx
@@ -117,7 +117,7 @@ describe('Button Component', () => {
 
 			const rendered = render(<Button style={style} content={content} />);
 			const buttonElement = rendered.container.querySelector('.ss__button')!;
-			let styles = getComputedStyle(buttonElement);
+			const styles = getComputedStyle(buttonElement);
 
 			expect(styles.padding).toBe(style.padding);
 		});
@@ -150,7 +150,7 @@ describe('Button Component', () => {
 
 			const buttonElement = rendered.container.querySelector('.ss__button')!;
 
-			let styles = getComputedStyle(buttonElement);
+			const styles = getComputedStyle(buttonElement);
 
 			expect(styles.color).toBe(globalTheme.components.button.color);
 			expect(buttonElement).toBeInTheDocument();
@@ -170,7 +170,7 @@ describe('Button Component', () => {
 
 			const buttonElement = rendered.container.querySelector('.ss__button')!;
 
-			let styles = getComputedStyle(buttonElement);
+			const styles = getComputedStyle(buttonElement);
 
 			expect(styles.color).toBe(propTheme.components.button.color);
 			expect(buttonElement).toBeInTheDocument();
@@ -202,7 +202,7 @@ describe('Button Component', () => {
 
 			const buttonElement = rendered.container.querySelector('.ss__button')!;
 
-			let styles = getComputedStyle(buttonElement);
+			const styles = getComputedStyle(buttonElement);
 
 			expect(styles.color).toBe(propTheme.components.button.color);
 			expect(buttonElement).toBeInTheDocument();

--- a/packages/snap-preact-components/src/components/Atoms/Button/Button.tsx
+++ b/packages/snap-preact-components/src/components/Atoms/Button/Button.tsx
@@ -1,11 +1,13 @@
 /** @jsx jsx */
+/** @jsx h */
+
 import { h, Fragment, ComponentChildren } from 'preact';
 
 import { jsx, css } from '@emotion/react';
 import classnames from 'classnames';
 import { observer } from 'mobx-react-lite';
 
-import { ComponentProps, StylingCSS } from '../../../types';
+import { ComponentProps } from '../../../types';
 import { Theme, useTheme, CacheProvider } from '../../../providers';
 import { useA11y } from '../../../hooks/useA11y';
 
@@ -70,7 +72,7 @@ export const Button = observer((properties: ButtonProps): JSX.Element => {
 		onClick: (e: React.MouseEvent<HTMLElement, MouseEvent>) => !disabled && onClick && onClick(e),
 	};
 
-	let a11yProps = {
+	const a11yProps = {
 		ref: (e: any) => useA11y(e),
 	};
 

--- a/packages/snap-preact-components/src/components/Atoms/Dropdown/Dropdown.tsx
+++ b/packages/snap-preact-components/src/components/Atoms/Dropdown/Dropdown.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
-import { ComponentChildren, h, RefObject } from 'preact';
-import { useState, StateUpdater, MutableRef, useRef } from 'preact/hooks';
+import { ComponentChildren, h } from 'preact';
+import { useState, StateUpdater, MutableRef } from 'preact/hooks';
 
 import { jsx, css } from '@emotion/react';
 import classnames from 'classnames';

--- a/packages/snap-preact-components/src/components/Atoms/FormattedNumber/FormattedNumber.tsx
+++ b/packages/snap-preact-components/src/components/Atoms/FormattedNumber/FormattedNumber.tsx
@@ -50,7 +50,7 @@ export function FormattedNumber(properties: FormattedNumberProps): JSX.Element {
 	}
 
 	return raw ? (
-		<>{formattedNumber}</>
+		<Fragment>{formattedNumber}</Fragment>
 	) : (
 		<CacheProvider>
 			<span className={classnames('ss__formatted-number', className)} {...styling}>

--- a/packages/snap-preact-components/src/components/Atoms/Image/Image.test.tsx
+++ b/packages/snap-preact-components/src/components/Atoms/Image/Image.test.tsx
@@ -10,11 +10,11 @@ import { MockData } from '@searchspring/snap-shared';
 import { SearchResponseModel } from '@searchspring/snapi-types';
 
 const mockData = new MockData();
-let searchResponse: SearchResponseModel = mockData.search();
+const searchResponse: SearchResponseModel = mockData.search();
 
 describe('image Component', () => {
 	const result = searchResponse.results![1].mappings?.core;
-	let badResult = searchResponse.results![0].mappings?.core;
+	const badResult = searchResponse.results![0].mappings?.core;
 	badResult!.imageUrl = '';
 	badResult!.thumbnailImageUrl = '';
 	const rolloverImage = searchResponse.results![2].mappings?.core?.thumbnailImageUrl;

--- a/packages/snap-preact-components/src/components/Atoms/Image/Image.tsx
+++ b/packages/snap-preact-components/src/components/Atoms/Image/Image.tsx
@@ -7,7 +7,6 @@ import classnames from 'classnames';
 
 import { Theme, useTheme, CacheProvider } from '../../../providers';
 import { ComponentProps, StylingCSS } from '../../../types';
-import { CSSProperties } from 'react';
 
 export const FALLBACK_IMAGE_URL = '//cdn.searchspring.net/ajax_search/img/default_image.png';
 

--- a/packages/snap-preact-components/src/components/Atoms/Merchandising/Banner/Banner.test.tsx
+++ b/packages/snap-preact-components/src/components/Atoms/Merchandising/Banner/Banner.test.tsx
@@ -11,7 +11,7 @@ import { SearchResponseModel } from '@searchspring/snapi-types';
 
 const mockData = new MockData();
 mockData.updateConfig({ search: 'merchandising' });
-let searchResponse: SearchResponseModel = mockData.search();
+const searchResponse: SearchResponseModel = mockData.search();
 
 describe('Merchandising Banner Component', () => {
 	const theme = {

--- a/packages/snap-preact-components/src/components/Atoms/Merchandising/InlineBanner/InlineBanner.test.tsx
+++ b/packages/snap-preact-components/src/components/Atoms/Merchandising/InlineBanner/InlineBanner.test.tsx
@@ -12,7 +12,7 @@ import { SearchResponseModel } from '@searchspring/snapi-types';
 
 const mockData = new MockData();
 mockData.updateConfig({ search: 'inlineBanners' });
-let searchResponse: SearchResponseModel = mockData.search();
+const searchResponse: SearchResponseModel = mockData.search();
 
 describe('Merchandising Inline Banner Component', () => {
 	it('renders type:inline banner', () => {

--- a/packages/snap-preact-components/src/components/Atoms/Price/Price.tsx
+++ b/packages/snap-preact-components/src/components/Atoms/Price/Price.tsx
@@ -72,7 +72,7 @@ export function Price(properties: PriceProps): JSX.Element {
 	}
 
 	return raw ? (
-		<>{formattedPrice}</>
+		<Fragment>{formattedPrice}</Fragment>
 	) : (
 		<CacheProvider>
 			<span {...styling} className={classnames('ss__price', { 'ss__price--strike': lineThrough }, className)}>

--- a/packages/snap-preact-components/src/components/Molecules/Carousel/Carousel.stories.tsx
+++ b/packages/snap-preact-components/src/components/Molecules/Carousel/Carousel.stories.tsx
@@ -1,4 +1,4 @@
-import { Fragment, h } from 'preact';
+import { h } from 'preact';
 
 import { ArgsTable, PRIMARY_STORY } from '@storybook/addon-docs/blocks';
 

--- a/packages/snap-preact-components/src/components/Molecules/Carousel/Carousel.test.tsx
+++ b/packages/snap-preact-components/src/components/Molecules/Carousel/Carousel.test.tsx
@@ -12,7 +12,7 @@ import { MockData } from '@searchspring/snap-shared';
 import { SearchResponseModel } from '@searchspring/snapi-types';
 
 const mockData = new MockData();
-let searchResponse: SearchResponseModel = mockData.search();
+const searchResponse: SearchResponseModel = mockData.search();
 
 describe('Carousel Component', () => {
 	const theme = {
@@ -188,7 +188,7 @@ describe('Carousel Component', () => {
 	it('can add additional modules', () => {
 		const rendered = render(
 			<Carousel modules={[Scrollbar]} scrollbar>
-				{searchResponse.results!.map((result, idx) => (
+				{searchResponse.results!.map((result) => (
 					<Result result={result as Product} />
 				))}
 			</Carousel>
@@ -205,10 +205,6 @@ describe('Carousel Component', () => {
 			700: {
 				hideButtons: false,
 			},
-		};
-
-		const args = {
-			breakpoints: customBreakpoints,
 		};
 
 		const rendered = render(

--- a/packages/snap-preact-components/src/components/Molecules/Carousel/Carousel.tsx
+++ b/packages/snap-preact-components/src/components/Molecules/Carousel/Carousel.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { h, Fragment } from 'preact';
-import { useState, useRef } from 'preact/hooks';
+import { useRef } from 'preact/hooks';
 
 import { jsx, css } from '@emotion/react';
 import classnames from 'classnames';
@@ -216,13 +216,11 @@ export const Carousel = observer((properties: CarouselProps): JSX.Element => {
 
 	const {
 		children,
-		breakpoints,
 		loop,
 		nextButton,
 		prevButton,
 		hideButtons,
 		vertical,
-		autoAdjustSlides,
 		onInit,
 		onNextButtonClick,
 		onPrevButtonClick,

--- a/packages/snap-preact-components/src/components/Molecules/Checkbox/Checkbox.test.tsx
+++ b/packages/snap-preact-components/src/components/Molecules/Checkbox/Checkbox.test.tsx
@@ -79,7 +79,7 @@ describe('Checkbox Component', () => {
 
 			const rendered = render(<Checkbox style={style} />);
 			const checkboxElement = rendered.container.querySelector('.ss__checkbox')!;
-			let styles = getComputedStyle(checkboxElement);
+			const styles = getComputedStyle(checkboxElement);
 
 			expect(styles.padding).toBe(style.padding);
 		});
@@ -119,7 +119,7 @@ describe('Checkbox Component', () => {
 			const svg = checkboxElement?.querySelector('svg')!;
 			const path = svg.querySelector('path');
 
-			let styles = getComputedStyle(svg);
+			const styles = getComputedStyle(svg);
 
 			expect(styles.width).toBe(`calc(${size} - 30%)`);
 			expect(styles.height).toBe(`calc(${size} - 30%)`);
@@ -135,7 +135,7 @@ describe('Checkbox Component', () => {
 			const rendered = render(<Checkbox checked size={size} icon={icon} iconColor={iconColor} />);
 			const checkboxElement = rendered.container.querySelector('.ss__checkbox');
 			const svg = checkboxElement?.querySelector('svg')!;
-			let styles = getComputedStyle(svg);
+			const styles = getComputedStyle(svg);
 			expect(styles.fill).toBe(iconColor);
 		});
 
@@ -157,7 +157,7 @@ describe('Checkbox Component', () => {
 
 			const checkboxElement = rendered.container.querySelector('.ss__checkbox');
 			const iconElement = checkboxElement?.querySelector('.ss__icon')!;
-			let iconStyles = getComputedStyle(iconElement);
+			const iconStyles = getComputedStyle(iconElement);
 
 			expect(checkboxElement).toHaveClass(globalTheme.components.checkbox.className);
 			expect(iconStyles.fill).toBe(globalTheme.components.icon.color);
@@ -168,7 +168,7 @@ describe('Checkbox Component', () => {
 
 			const checkboxElement = rendered.container.querySelector('.ss__checkbox');
 			const iconElement = checkboxElement?.querySelector('.ss__icon')!;
-			let iconStyles = getComputedStyle(iconElement);
+			const iconStyles = getComputedStyle(iconElement);
 
 			expect(checkboxElement).toHaveClass(propTheme.components.checkbox.className);
 			expect(iconStyles.fill).toBe(propTheme.components.icon.color);
@@ -183,7 +183,7 @@ describe('Checkbox Component', () => {
 
 			const checkboxElement = rendered.container.querySelector('.ss__checkbox');
 			const iconElement = checkboxElement?.querySelector('.ss__icon')!;
-			let iconStyles = getComputedStyle(iconElement);
+			const iconStyles = getComputedStyle(iconElement);
 
 			expect(checkboxElement).toHaveClass(propTheme.components.checkbox.className);
 			expect(checkboxElement).not.toHaveClass(globalTheme.components.checkbox.className);
@@ -259,7 +259,7 @@ describe('Checkbox Component', () => {
 
 			const rendered = render(<Checkbox native style={style} />);
 			const checkboxElement = rendered.container.querySelector('.ss__checkbox')!;
-			let styles = getComputedStyle(checkboxElement);
+			const styles = getComputedStyle(checkboxElement);
 
 			expect(styles.padding).toBe(style.padding);
 		});

--- a/packages/snap-preact-components/src/components/Molecules/ErrorHandler/ErrorHandler.stories.tsx
+++ b/packages/snap-preact-components/src/components/Molecules/ErrorHandler/ErrorHandler.stories.tsx
@@ -1,4 +1,4 @@
-import { Fragment, h } from 'preact';
+import { h } from 'preact';
 
 import { ArgsTable, PRIMARY_STORY } from '@storybook/addon-docs/blocks';
 import { ErrorType } from '@searchspring/snap-store-mobx';

--- a/packages/snap-preact-components/src/components/Molecules/FacetGridOptions/FacetGridOptions.test.tsx
+++ b/packages/snap-preact-components/src/components/Molecules/FacetGridOptions/FacetGridOptions.test.tsx
@@ -9,7 +9,7 @@ import { MockData } from '@searchspring/snap-shared';
 import { SearchResponseModelFacet, SearchResponseModelFacetValueAllOf } from '@searchspring/snapi-types';
 
 const mockData = new MockData();
-let gridFacetMock: SearchResponseModelFacet & SearchResponseModelFacetValueAllOf = mockData
+const gridFacetMock: SearchResponseModelFacet & SearchResponseModelFacetValueAllOf = mockData
 	.search()
 	.facets!.filter((facet) => facet.field == 'size_dress')!
 	.pop()!;

--- a/packages/snap-preact-components/src/components/Molecules/FacetHierarchyOptions/FacetHierarchyOptions.test.tsx
+++ b/packages/snap-preact-components/src/components/Molecules/FacetHierarchyOptions/FacetHierarchyOptions.test.tsx
@@ -10,12 +10,12 @@ import { MockData } from '@searchspring/snap-shared';
 import { SearchResponseModelFacet, SearchResponseModelFacetValueAllOf } from '@searchspring/snapi-types';
 
 const mockData = new MockData();
-let hierarchyFacetMock: SearchResponseModelFacet & SearchResponseModelFacetValueAllOf = mockData
+const hierarchyFacetMock: SearchResponseModelFacet & SearchResponseModelFacetValueAllOf = mockData
 	.search()
 	.facets!.filter((facet) => facet.field == 'ss_category_hierarchy')!
 	.pop()!;
 mockData.updateConfig({ search: 'filteredHierarchy' });
-let hierarchyFacetFilteredMock: SearchResponseModelFacet & SearchResponseModelFacetValueAllOf = mockData
+const hierarchyFacetFilteredMock: SearchResponseModelFacet & SearchResponseModelFacetValueAllOf = mockData
 	.search()
 	.facets!.filter((facet) => facet.field == 'ss_category_hierarchy')!
 	.pop()!;

--- a/packages/snap-preact-components/src/components/Molecules/FacetListOptions/FacetListOptions.test.tsx
+++ b/packages/snap-preact-components/src/components/Molecules/FacetListOptions/FacetListOptions.test.tsx
@@ -10,7 +10,7 @@ import { MockData } from '@searchspring/snap-shared';
 import { SearchResponseModelFacet, SearchResponseModelFacetValueAllOf } from '@searchspring/snapi-types';
 
 const mockData = new MockData();
-let listFacetMock: SearchResponseModelFacet & SearchResponseModelFacetValueAllOf = mockData
+const listFacetMock: SearchResponseModelFacet & SearchResponseModelFacetValueAllOf = mockData
 	.search()
 	.facets!.filter((facet) => facet.type == 'value')!
 	.pop()!;

--- a/packages/snap-preact-components/src/components/Molecules/FacetPaletteOptions/FacetPaletteOptions.test.tsx
+++ b/packages/snap-preact-components/src/components/Molecules/FacetPaletteOptions/FacetPaletteOptions.test.tsx
@@ -10,7 +10,7 @@ import { MockData } from '@searchspring/snap-shared';
 import { SearchResponseModelFacet, SearchResponseModelFacetValueAllOf } from '@searchspring/snapi-types';
 
 const mockData = new MockData();
-let paletteFacetMock: SearchResponseModelFacet & SearchResponseModelFacetValueAllOf = mockData
+const paletteFacetMock: SearchResponseModelFacet & SearchResponseModelFacetValueAllOf = mockData
 	.search()
 	.facets!.filter((facet) => facet.field == 'pattern')!
 	.pop()!;

--- a/packages/snap-preact-components/src/components/Molecules/FacetSlider/FacetSlider.test.tsx
+++ b/packages/snap-preact-components/src/components/Molecules/FacetSlider/FacetSlider.test.tsx
@@ -12,7 +12,7 @@ import { MockData } from '@searchspring/snap-shared';
 import { SearchResponseModelFacet, SearchResponseModelFacetRangeAllOf } from '@searchspring/snapi-types';
 
 const mockData = new MockData();
-let sliderFacetMock: SearchResponseModelFacet & SearchResponseModelFacetRangeAllOf = mockData
+const sliderFacetMock: SearchResponseModelFacet & SearchResponseModelFacetRangeAllOf = mockData
 	.search()
 	.facets!.filter((facet) => facet.type == 'range')!
 	.pop()!;

--- a/packages/snap-preact-components/src/components/Molecules/Pagination/Pagination.test.tsx
+++ b/packages/snap-preact-components/src/components/Molecules/Pagination/Pagination.test.tsx
@@ -21,7 +21,7 @@ describe('Pagination Component', () => {
 
 	const data = new MockData().searchMeta();
 
-	let paginationStore = new SearchPaginationStore(searchConfig, services, data.pagination, data.meta);
+	const paginationStore = new SearchPaginationStore(searchConfig, services, data.pagination, data.meta);
 
 	beforeEach(() => {
 		rendered = render(<Pagination pagination={paginationStore} />);
@@ -76,7 +76,7 @@ describe('Lets test the Pagination Component optional props', () => {
 
 	const data = new MockData().searchMeta('page10');
 
-	let paginationStore = new SearchPaginationStore(searchConfig, services, data.pagination, data.meta);
+	const paginationStore = new SearchPaginationStore(searchConfig, services, data.pagination, data.meta);
 
 	it('shows all the optional buttons', () => {
 		const rendered = render(<Pagination pagination={paginationStore} />);
@@ -183,7 +183,7 @@ describe('Pagination theming works', () => {
 
 	const data = new MockData().searchMeta();
 
-	let paginationStore = new SearchPaginationStore(searchConfig, services, data.pagination, data.meta);
+	const paginationStore = new SearchPaginationStore(searchConfig, services, data.pagination, data.meta);
 
 	it('is themeable with ThemeProvider', () => {
 		const globalTheme = {

--- a/packages/snap-preact-components/src/components/Molecules/Result/Result.test.tsx
+++ b/packages/snap-preact-components/src/components/Molecules/Result/Result.test.tsx
@@ -11,7 +11,7 @@ import { MockData } from '@searchspring/snap-shared';
 import { SearchResponseModel } from '@searchspring/snapi-types';
 
 const mockData = new MockData();
-let searchResponse: SearchResponseModel = mockData.search();
+const searchResponse: SearchResponseModel = mockData.search();
 
 // TODO: refactor to use mock store data
 const mockResults = searchResponse.results as SearchResultStore;

--- a/packages/snap-preact-components/src/components/Molecules/SearchInput/SearchInput.tsx
+++ b/packages/snap-preact-components/src/components/Molecules/SearchInput/SearchInput.tsx
@@ -35,7 +35,7 @@ export const SearchInput = observer((properties: SearchInputProps): JSX.Element 
 	const globalTheme: Theme = useTheme();
 	const theme = { ...globalTheme, ...properties.theme };
 
-	let props: SearchInputProps = {
+	const props: SearchInputProps = {
 		// default props
 		placeholder: 'Search',
 		hideIcon: false,

--- a/packages/snap-preact-components/src/components/Molecules/Select/Select.tsx
+++ b/packages/snap-preact-components/src/components/Molecules/Select/Select.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { h, Fragment } from 'preact';
-import { StateUpdater, useState } from 'preact/hooks';
+import { useState } from 'preact/hooks';
 
 import { observer } from 'mobx-react-lite';
 import { jsx, css } from '@emotion/react';
@@ -222,7 +222,7 @@ export const Select = observer((properties: SelectProps): JSX.Element => {
 						disableClickOutside={disableClickOutside}
 						open={open}
 						onToggle={(e, state) => setOpen((prev) => state ?? !prev)}
-						onClick={(e) => setOpen((prev) => !prev)}
+						onClick={() => setOpen((prev) => !prev)}
 						disableA11y
 						button={
 							<Button {...subProps.button} disableA11y={true}>

--- a/packages/snap-preact-components/src/components/Molecules/Slideout/Slideout.tsx
+++ b/packages/snap-preact-components/src/components/Molecules/Slideout/Slideout.tsx
@@ -10,7 +10,6 @@ import { Theme, useTheme, CacheProvider } from '../../../providers';
 import { ComponentProps, StylingCSS } from '../../../types';
 import { useMediaQuery } from '../../../hooks';
 import { Overlay, OverlayProps } from '../../Atoms/Overlay';
-import { useA11y } from '../../../hooks/useA11y';
 
 const CSS = {
 	slideout: ({ isActive, width, transitionSpeed, slideDirection }: Partial<SlideoutProps> & { isActive: boolean }) =>
@@ -101,7 +100,7 @@ export function Slideout(properties: SlideoutProps): JSX.Element {
 		document.body.style.overflow = isActive ? 'hidden' : '';
 	};
 
-	let isVisible = useMediaQuery(displayAt!, () => {
+	const isVisible = useMediaQuery(displayAt!, () => {
 		document.body.style.overflow = '';
 	});
 

--- a/packages/snap-preact-components/src/components/Organisms/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/snap-preact-components/src/components/Organisms/Autocomplete/Autocomplete.stories.tsx
@@ -1,4 +1,4 @@
-import { h, Fragment } from 'preact';
+import { h } from 'preact';
 
 import { ArgsTable, PRIMARY_STORY } from '@storybook/addon-docs/blocks';
 

--- a/packages/snap-preact-components/src/components/Organisms/Autocomplete/Autocomplete.test.tsx
+++ b/packages/snap-preact-components/src/components/Organisms/Autocomplete/Autocomplete.test.tsx
@@ -108,10 +108,10 @@ describe('Autocomplete Component', () => {
 		input.focus();
 		input.value = 'dress';
 
-		let rendered = render(<Autocomplete {...args} />, { container });
+		const rendered = render(<Autocomplete {...args} />, { container });
 
 		await waitFor(() => {
-			let results = rendered.container.querySelectorAll('.ss__autocomplete__content__results .ss__result');
+			const results = rendered.container.querySelectorAll('.ss__autocomplete__content__results .ss__result');
 			expect(results[0]).toBeInTheDocument();
 			expect(results.length).toEqual(9);
 		});
@@ -130,7 +130,7 @@ describe('Autocomplete Component', () => {
 		input.focus();
 		input.value = 'dress';
 
-		let rendered = render(<Autocomplete {...args} />, { container });
+		const rendered = render(<Autocomplete {...args} />, { container });
 		let termLinks: any;
 		let firstResult: any;
 		let terms: any;
@@ -160,7 +160,7 @@ describe('Autocomplete Component', () => {
 
 		await waitFor(() => {
 			//now lets check for the new results
-			let newResults = rendered.container.querySelectorAll('.ss__autocomplete__content__results .ss__result');
+			const newResults = rendered.container.querySelectorAll('.ss__autocomplete__content__results .ss__result');
 			//there should be new results available
 			expect(newResults[0]).toBeInTheDocument();
 			// we will need to save this for later
@@ -188,7 +188,7 @@ describe('Autocomplete Component', () => {
 
 		await waitFor(() => {
 			//check for the new results
-			let newNewResults = rendered.container.querySelectorAll('.ss__autocomplete__content__results .ss__result');
+			const newNewResults = rendered.container.querySelectorAll('.ss__autocomplete__content__results .ss__result');
 			expect(newNewResults[0]).toBeInTheDocument();
 			//new results should again be different from previous results
 			expect(newNewResults[0].innerHTML).not.toEqual(newFirstResult);
@@ -199,7 +199,7 @@ describe('Autocomplete Component', () => {
 	});
 
 	it('can use hide props to hide/show hideTerms, hideFacets, hideContent, hideLink & hideHistory', async () => {
-		let mockStorage: {
+		const mockStorage: {
 			[key: string]: string;
 		} = {};
 		global.Storage.prototype.setItem = jest.fn((key, value) => {
@@ -242,47 +242,47 @@ describe('Autocomplete Component', () => {
 		input.focus();
 		input.value = 'dress';
 
-		let renderedWithout = render(<Autocomplete {...args} />, { container });
+		const renderedWithout = render(<Autocomplete {...args} />, { container });
 
 		await waitFor(() => {
-			let terms = renderedWithout.container.querySelector('.ss__autocomplete__terms');
+			const terms = renderedWithout.container.querySelector('.ss__autocomplete__terms');
 			expect(terms).not.toBeInTheDocument();
 
-			let facets = renderedWithout.container.querySelector('.ss__autocomplete__facets');
+			const facets = renderedWithout.container.querySelector('.ss__autocomplete__facets');
 			expect(facets).not.toBeInTheDocument();
 
-			let content = renderedWithout.container.querySelector('.ss__autocomplete__content');
+			const content = renderedWithout.container.querySelector('.ss__autocomplete__content');
 			expect(content).not.toBeInTheDocument();
 
-			let link = renderedWithout.container.querySelector('.ss__autocomplete__content__info');
+			const link = renderedWithout.container.querySelector('.ss__autocomplete__content__info');
 			expect(link).not.toBeInTheDocument();
 
-			let history = renderedWithout.container.querySelector('.ss__autocomplete__terms__history .ss__autocomplete__terms__options');
+			const history = renderedWithout.container.querySelector('.ss__autocomplete__terms__history .ss__autocomplete__terms__options');
 			expect(history).not.toBeInTheDocument();
 
-			let trending = renderedWithout.container.querySelector('.ss__autocomplete__terms__trending .ss__autocomplete__terms__options');
+			const trending = renderedWithout.container.querySelector('.ss__autocomplete__terms__trending .ss__autocomplete__terms__options');
 			expect(trending).not.toBeInTheDocument();
 		});
 
-		let renderedWith = render(<Autocomplete {...otherArgs} />, { container });
+		const renderedWith = render(<Autocomplete {...otherArgs} />, { container });
 
 		await waitFor(() => {
-			let terms2 = renderedWith.container.querySelector('.ss__autocomplete__terms');
+			const terms2 = renderedWith.container.querySelector('.ss__autocomplete__terms');
 			expect(terms2).toBeInTheDocument();
 
-			let facets2 = renderedWith.container.querySelector('.ss__autocomplete__facets');
+			const facets2 = renderedWith.container.querySelector('.ss__autocomplete__facets');
 			expect(facets2).toBeInTheDocument();
 
-			let content2 = renderedWith.container.querySelector('.ss__autocomplete__content');
+			const content2 = renderedWith.container.querySelector('.ss__autocomplete__content');
 			expect(content2).toBeInTheDocument();
 
-			let link2 = renderedWith.container.querySelector('.ss__autocomplete__content__info');
+			const link2 = renderedWith.container.querySelector('.ss__autocomplete__content__info');
 			expect(link2).toBeInTheDocument();
 
-			let history2 = renderedWith.container.querySelector('.ss__autocomplete__terms__history .ss__autocomplete__terms__options');
+			const history2 = renderedWith.container.querySelector('.ss__autocomplete__terms__history .ss__autocomplete__terms__options');
 			expect(history2).toBeInTheDocument();
 
-			let trending2 = renderedWithout.container.querySelector('.ss__autocomplete__terms__trending .ss__autocomplete__terms__options');
+			const trending2 = renderedWithout.container.querySelector('.ss__autocomplete__terms__trending .ss__autocomplete__terms__options');
 			expect(trending2).toBeInTheDocument();
 		});
 	});
@@ -310,22 +310,22 @@ describe('Autocomplete Component', () => {
 		input.value = 'dress';
 		(controller.client as MockClient).mockData.updateConfig({ autocomplete: 'ac.banners' });
 
-		let renderedWithoutBanners = render(<Autocomplete {...args} />, { container });
+		const renderedWithoutBanners = render(<Autocomplete {...args} />, { container });
 		await waitFor(() => {
-			let banners = renderedWithoutBanners.container.querySelector('.ss__banner');
+			const banners = renderedWithoutBanners.container.querySelector('.ss__banner');
 			expect(banners).not.toBeInTheDocument();
 		});
 
-		let renderedWithBanners = render(<Autocomplete {...otherArgs} />, { container });
+		const renderedWithBanners = render(<Autocomplete {...otherArgs} />, { container });
 
 		await waitFor(() => {
-			let banners2 = renderedWithBanners.container.querySelector('.ss__banner');
+			const banners2 = renderedWithBanners.container.querySelector('.ss__banner');
 			expect(banners2).toBeInTheDocument();
 		});
 	});
 
 	it('can set custom titles, such as termsTitle, facetsTitle, contentTitle, & historyTitle', async () => {
-		let mockStorage: {
+		const mockStorage: {
 			[key: string]: string;
 		} = {};
 		global.Storage.prototype.setItem = jest.fn((key, value) => {
@@ -354,28 +354,28 @@ describe('Autocomplete Component', () => {
 		input.focus();
 		input.value = 'dress';
 
-		let rendered = render(<Autocomplete {...args} />, { container });
+		const rendered = render(<Autocomplete {...args} />, { container });
 
 		await waitFor(() => {
-			let termTitle = rendered.container.querySelector('.ss__autocomplete__title');
+			const termTitle = rendered.container.querySelector('.ss__autocomplete__title');
 			expect(termTitle).toHaveTextContent(args.termsTitle);
 
-			let facetsTitle = rendered.container.querySelector('.ss__autocomplete__title--facets');
+			const facetsTitle = rendered.container.querySelector('.ss__autocomplete__title--facets');
 			expect(facetsTitle).toHaveTextContent(args.facetsTitle);
 
-			let contentTitle = rendered.container.querySelector('.ss__autocomplete__title--content');
+			const contentTitle = rendered.container.querySelector('.ss__autocomplete__title--content');
 			expect(contentTitle).toHaveTextContent(args.contentTitle);
 
-			let historyTitle = rendered.container.querySelector('.ss__autocomplete__title--history');
+			const historyTitle = rendered.container.querySelector('.ss__autocomplete__title--history');
 			expect(historyTitle).toHaveTextContent(args.historyTitle);
 
-			let trendingTitle = rendered.container.querySelector('.ss__autocomplete__title--trending');
+			const trendingTitle = rendered.container.querySelector('.ss__autocomplete__title--trending');
 			expect(trendingTitle).toHaveTextContent(args.trendingTitle);
 		});
 	});
 
 	it('can use retainhistory && retaintrending false', async () => {
-		let mockStorage: {
+		const mockStorage: {
 			[key: string]: string;
 		} = {};
 		global.Storage.prototype.setItem = jest.fn((key, value) => {
@@ -400,13 +400,13 @@ describe('Autocomplete Component', () => {
 
 		input.focus();
 
-		let rendered = render(<Autocomplete input={input} {...args} />, { container });
+		const rendered = render(<Autocomplete input={input} {...args} />, { container });
 
 		await waitFor(() => {
-			let historyTitle = rendered.container.querySelector('.ss__autocomplete__title--history');
+			const historyTitle = rendered.container.querySelector('.ss__autocomplete__title--history');
 			expect(historyTitle).toHaveTextContent(args.historyTitle);
 
-			let trendingTitle = rendered.container.querySelector('.ss__autocomplete__title--trending');
+			const trendingTitle = rendered.container.querySelector('.ss__autocomplete__title--trending');
 			expect(trendingTitle).toHaveTextContent(args.trendingTitle);
 		});
 
@@ -414,10 +414,10 @@ describe('Autocomplete Component', () => {
 		userEvent.keyboard('dress');
 
 		await waitFor(() => {
-			let historyTitle = rendered.container.querySelector('.ss__autocomplete__title--history');
+			const historyTitle = rendered.container.querySelector('.ss__autocomplete__title--history');
 			expect(historyTitle).not.toBeInTheDocument();
 
-			let trendingTitle = rendered.container.querySelector('.ss__autocomplete__title--trending');
+			const trendingTitle = rendered.container.querySelector('.ss__autocomplete__title--trending');
 			expect(trendingTitle).not.toBeInTheDocument();
 		});
 
@@ -435,10 +435,10 @@ describe('Autocomplete Component', () => {
 		let rendered2 = render(<Autocomplete {...args2} />, { container });
 
 		await waitFor(() => {
-			let historyTitle = rendered2.container.querySelector('.ss__autocomplete__title--history');
+			const historyTitle = rendered2.container.querySelector('.ss__autocomplete__title--history');
 			expect(historyTitle).toHaveTextContent(args.historyTitle);
 
-			let trendingTitle = rendered2.container.querySelector('.ss__autocomplete__title--trending');
+			const trendingTitle = rendered2.container.querySelector('.ss__autocomplete__title--trending');
 			expect(trendingTitle).toHaveTextContent(args.trendingTitle);
 		});
 
@@ -447,10 +447,10 @@ describe('Autocomplete Component', () => {
 
 		rendered2 = render(<Autocomplete {...args2} />, { container });
 		await waitFor(() => {
-			let historyTitle = rendered2.container.querySelector('.ss__autocomplete__title--history');
+			const historyTitle = rendered2.container.querySelector('.ss__autocomplete__title--history');
 			expect(historyTitle).toHaveTextContent(args.historyTitle);
 
-			let trendingTitle = rendered2.container.querySelector('.ss__autocomplete__title--trending');
+			const trendingTitle = rendered2.container.querySelector('.ss__autocomplete__title--trending');
 			expect(trendingTitle).toHaveTextContent(args.trendingTitle);
 		});
 	});
@@ -470,10 +470,10 @@ describe('Autocomplete Component', () => {
 		const input = document.querySelector('.searchspring-ac') as HTMLInputElement;
 		input.focus();
 
-		let rendered = render(<Autocomplete {...args} />, { container });
+		const rendered = render(<Autocomplete {...args} />, { container });
 
 		await waitFor(() => {
-			let trendingTitle = rendered.container.querySelector('.ss__autocomplete__title--trending');
+			const trendingTitle = rendered.container.querySelector('.ss__autocomplete__title--trending');
 			expect(trendingTitle).toHaveTextContent(args.trendingTitle);
 		});
 	});
@@ -495,22 +495,22 @@ describe('Autocomplete Component', () => {
 		input.focus();
 		input.value = 'dress';
 
-		let rendered = render(<Autocomplete {...args} />, { container });
+		const rendered = render(<Autocomplete {...args} />, { container });
 
 		await waitFor(() => {
-			let termsSlot = rendered.container.querySelector('.ss__autocomplete__terms');
+			const termsSlot = rendered.container.querySelector('.ss__autocomplete__terms');
 			expect(termsSlot).toHaveTextContent('custom termsSlot');
 
-			let facetSlot = rendered.container.querySelector('.ss__autocomplete__facets');
+			const facetSlot = rendered.container.querySelector('.ss__autocomplete__facets');
 			expect(facetSlot).toHaveTextContent('custom facetsSlot');
 
-			let resultsSlot = rendered.container.querySelector('.ss__autocomplete__content__results');
-			let defaultTitle = rendered.container.querySelector('.ss__autocomplete__title--content');
+			const resultsSlot = rendered.container.querySelector('.ss__autocomplete__content__results');
+			const defaultTitle = rendered.container.querySelector('.ss__autocomplete__title--content');
 			expect(defaultTitle).not.toBeInTheDocument();
 			expect(resultsSlot).toHaveTextContent('custom resultsSlot');
 
-			let defaultLink = rendered.container.querySelector('.ss__autocomplete__content__info');
-			let linkSlot = rendered.container.querySelector('.ss__autocomplete__content #findMe');
+			const defaultLink = rendered.container.querySelector('.ss__autocomplete__content__info');
+			const linkSlot = rendered.container.querySelector('.ss__autocomplete__content #findMe');
 
 			expect(defaultLink).not.toBeInTheDocument();
 			expect(linkSlot).toHaveTextContent('custom linkSlot');
@@ -532,10 +532,10 @@ describe('Autocomplete Component', () => {
 		input.focus();
 		input.value = 'dress';
 
-		let rendered = render(<Autocomplete {...args} />, { container });
+		const rendered = render(<Autocomplete {...args} />, { container });
 
 		await waitFor(() => {
-			let contentSlot = rendered.container.querySelector('.ss__autocomplete__content');
+			const contentSlot = rendered.container.querySelector('.ss__autocomplete__content');
 			expect(contentSlot).toHaveTextContent('Lorem Ipsum');
 		});
 	});
@@ -558,10 +558,10 @@ describe('Autocomplete Component', () => {
 
 		input.focus();
 
-		let rendered = render(<Autocomplete {...args} />, { container });
+		const rendered = render(<Autocomplete {...args} />, { container });
 
 		await waitFor(() => {
-			let noResultsSlot = rendered.container.querySelector('.ss__autocomplete__content__no-results');
+			const noResultsSlot = rendered.container.querySelector('.ss__autocomplete__content__no-results');
 			expect(noResultsSlot).toHaveTextContent('Lorem Ipsum');
 		});
 	});
@@ -601,7 +601,7 @@ describe('Autocomplete Component', () => {
 
 			expect(controller.store.trending[0].active).toBeTruthy();
 
-			let results = rendered.container.querySelectorAll('.ss__result');
+			const results = rendered.container.querySelectorAll('.ss__result');
 			expect(results[0]).toBeInTheDocument();
 		});
 	});
@@ -626,17 +626,17 @@ describe('Autocomplete Component', () => {
 		input.focus();
 		input.value = 'dress';
 
-		let rendered = render(<Autocomplete {...args} />, { container });
+		const rendered = render(<Autocomplete {...args} />, { container });
 
 		await waitFor(() => {
-			let ac = rendered.container.querySelector('.ss__autocomplete')!;
+			const ac = rendered.container.querySelector('.ss__autocomplete')!;
 			const styles = getComputedStyle(ac);
 			expect(styles['width']).toBe(args.width);
 		});
 
-		let rendered2 = render(<Autocomplete {...args2} />, { container });
+		const rendered2 = render(<Autocomplete {...args2} />, { container });
 		await waitFor(() => {
-			let ac2 = rendered2.container.querySelector('.ss__autocomplete')!;
+			const ac2 = rendered2.container.querySelector('.ss__autocomplete')!;
 			const styles2 = getComputedStyle(ac2);
 			expect(styles2['width']).toBe(args2.width);
 		});
@@ -665,7 +665,7 @@ describe('Autocomplete Component', () => {
 		input.focus();
 		input.value = 'dress';
 
-		let rendered = render(<Autocomplete {...args} />, { container });
+		const rendered = render(<Autocomplete {...args} />, { container });
 		let acFacets: any;
 		await waitFor(() => {
 			acFacets = rendered.container.querySelector('.ss__autocomplete .ss__autocomplete__facets');
@@ -831,7 +831,7 @@ describe('Autocomplete Component', () => {
 			input.focus();
 			input.value = 'dress';
 
-			let rendered = render(<Autocomplete {...args} />, { container });
+			const rendered = render(<Autocomplete {...args} />, { container });
 			let acFacet: any;
 			let options: any;
 

--- a/packages/snap-preact-components/src/components/Organisms/Autocomplete/Autocomplete.tsx
+++ b/packages/snap-preact-components/src/components/Organisms/Autocomplete/Autocomplete.tsx
@@ -278,7 +278,7 @@ export const Autocomplete = observer((properties: AutocompleteProps): JSX.Elemen
 		...displaySettings,
 		theme,
 	};
-	let input: String | Element | null = props.input;
+	let input: string | Element | null = props.input;
 	let inputViewportOffsetBottom = 0;
 	if (input) {
 		if (typeof input === 'string') {

--- a/packages/snap-preact-components/src/components/Organisms/BranchOverride/BranchOverride.stories.tsx
+++ b/packages/snap-preact-components/src/components/Organisms/BranchOverride/BranchOverride.stories.tsx
@@ -1,4 +1,4 @@
-import { h, Fragment } from 'preact';
+import { h } from 'preact';
 
 import { ArgsTable, PRIMARY_STORY } from '@storybook/addon-docs/blocks';
 

--- a/packages/snap-preact-components/src/components/Organisms/BranchOverride/BranchOverride.tsx
+++ b/packages/snap-preact-components/src/components/Organisms/BranchOverride/BranchOverride.tsx
@@ -3,7 +3,7 @@ import { h, Fragment } from 'preact';
 
 import { jsx, css } from '@emotion/react';
 import classnames from 'classnames';
-import { useState, useEffect } from 'preact/hooks';
+import { useState } from 'preact/hooks';
 import { Icon, IconProps } from '../../Atoms/Icon/Icon';
 
 import { ComponentProps, StylingCSS } from '../../../types';
@@ -246,9 +246,8 @@ const componentThemes = {
 
 export const BranchOverride = (properties: BranchOverrideProps): JSX.Element => {
 	const globalTheme: Theme = useTheme();
-	const theme = { ...globalTheme, ...properties.theme };
 
-	let props: BranchOverrideProps = {
+	const props: BranchOverrideProps = {
 		// global theme
 		...globalTheme?.components?.branchOverride,
 		// props

--- a/packages/snap-preact-components/src/components/Organisms/Facet/Facet.test.tsx
+++ b/packages/snap-preact-components/src/components/Organisms/Facet/Facet.test.tsx
@@ -3,31 +3,30 @@ import { render, waitFor } from '@testing-library/preact';
 import { Facet } from './Facet';
 import { ThemeProvider } from '../../../providers';
 
-import { FacetDisplay } from '../../../types';
 import userEvent from '@testing-library/user-event';
 import { ValueFacet, RangeFacet } from '@searchspring/snap-store-mobx';
-import { SearchResponseModel, SearchResponseModelFacet, SearchResponseModelFacetValueAllOf } from '@searchspring/snapi-types';
+import { SearchResponseModelFacet, SearchResponseModelFacetValueAllOf } from '@searchspring/snapi-types';
 import { MockData } from '@searchspring/snap-shared';
 
 const mockData = new MockData();
-let searchResponseFacets = mockData.search().facets!;
+const searchResponseFacets = mockData.search().facets!;
 
-let hierarchyFacetMock: SearchResponseModelFacet & SearchResponseModelFacetValueAllOf = searchResponseFacets
+const hierarchyFacetMock: SearchResponseModelFacet & SearchResponseModelFacetValueAllOf = searchResponseFacets
 	.filter((facet) => facet.field == 'ss_category_hierarchy')!
 	.pop()!;
-let gridFacetMock: SearchResponseModelFacet & SearchResponseModelFacetValueAllOf = searchResponseFacets
+const gridFacetMock: SearchResponseModelFacet & SearchResponseModelFacetValueAllOf = searchResponseFacets
 	.filter((facet) => facet.field == 'size_dress')!
 	.pop()!;
-let paletteFacetMock: SearchResponseModelFacet & SearchResponseModelFacetValueAllOf = searchResponseFacets
+const paletteFacetMock: SearchResponseModelFacet & SearchResponseModelFacetValueAllOf = searchResponseFacets
 	.filter((facet) => facet.field == 'color_family')!
 	.pop()!;
-let listFacetMock: SearchResponseModelFacet & SearchResponseModelFacetValueAllOf = searchResponseFacets
+const listFacetMock: SearchResponseModelFacet & SearchResponseModelFacetValueAllOf = searchResponseFacets
 	.filter((facet) => facet.field == 'season')!
 	.pop()!;
-let facetOverflowMock: SearchResponseModelFacet & SearchResponseModelFacetValueAllOf = searchResponseFacets
+const facetOverflowMock: SearchResponseModelFacet & SearchResponseModelFacetValueAllOf = searchResponseFacets
 	.filter((facet) => facet.field == 'brand')!
 	.pop()!;
-let sliderFacetMock: SearchResponseModelFacet & SearchResponseModelFacetValueAllOf = searchResponseFacets
+const sliderFacetMock: SearchResponseModelFacet & SearchResponseModelFacetValueAllOf = searchResponseFacets
 	.filter((facet) => facet.field == 'price')
 	.pop()!;
 

--- a/packages/snap-preact-components/src/components/Organisms/Facet/Facet.tsx
+++ b/packages/snap-preact-components/src/components/Organisms/Facet/Facet.tsx
@@ -265,7 +265,7 @@ export const Facet = observer((properties: FacetProps): JSX.Element => {
 					<Dropdown
 						{...subProps.dropdown}
 						open={disableCollapse || !facet?.collapsed}
-						onClick={(e) => !disableCollapse && facet.toggleCollapse && facet?.toggleCollapse()}
+						onClick={() => !disableCollapse && facet.toggleCollapse && facet?.toggleCollapse()}
 						disableA11y={true}
 						button={
 							<div
@@ -320,13 +320,13 @@ export const Facet = observer((properties: FacetProps): JSX.Element => {
 								{overflowSlot ? (
 									cloneWithProps(overflowSlot, { facet })
 								) : (
-									<>
+									<Fragment>
 										<Icon
 											{...subProps.showMoreLessIcon}
 											icon={((facet as ValueFacet).overflow?.remaining || 0) > 0 ? iconOverflowMore : iconOverflowLess}
 										/>
 										<span>{((facet as ValueFacet)?.overflow?.remaining || 0) > 0 ? showMoreText : showLessText}</span>
-									</>
+									</Fragment>
 								)}
 							</div>
 						)}

--- a/packages/snap-preact-components/src/components/Organisms/Facets/Facets.test.tsx
+++ b/packages/snap-preact-components/src/components/Organisms/Facets/Facets.test.tsx
@@ -8,7 +8,7 @@ import { MockData } from '@searchspring/snap-shared';
 import { SearchResponseModel } from '@searchspring/snapi-types';
 
 const mockData = new MockData();
-let searchResponse: SearchResponseModel = mockData.search();
+const searchResponse: SearchResponseModel = mockData.search();
 
 describe('Facets Component', () => {
 	it('renders', () => {

--- a/packages/snap-preact-components/src/components/Organisms/Recommendation/Recommendation.test.tsx
+++ b/packages/snap-preact-components/src/components/Organisms/Recommendation/Recommendation.test.tsx
@@ -192,7 +192,7 @@ describe('Recommendation Component', () => {
 
 		for (let i = 0; i < 21; i++) {
 			// @ts-ignore
-			let [callback] = window.IntersectionObserver.mock.calls[i];
+			const [callback] = window.IntersectionObserver.mock.calls[i];
 
 			callback([
 				{

--- a/packages/snap-preact-components/src/components/Organisms/Results/Results.test.tsx
+++ b/packages/snap-preact-components/src/components/Organisms/Results/Results.test.tsx
@@ -10,7 +10,7 @@ import { MockData } from '@searchspring/snap-shared';
 import { SearchResponseModel } from '@searchspring/snapi-types';
 
 const mockData = new MockData();
-let searchResponse: SearchResponseModel = mockData.search();
+const searchResponse: SearchResponseModel = mockData.search();
 
 const mockResults = searchResponse.results as SearchResultStore;
 

--- a/packages/snap-preact-components/src/components/Organisms/Results/Results.tsx
+++ b/packages/snap-preact-components/src/components/Organisms/Results/Results.tsx
@@ -4,6 +4,7 @@ import { Fragment, h } from 'preact';
 import { observer } from 'mobx-react-lite';
 import { jsx, css } from '@emotion/react';
 import classnames from 'classnames';
+import deepmerge from 'deepmerge';
 
 import type { SearchController, AutocompleteController, RecommendationController } from '@searchspring/snap-controller';
 import type { SearchResultStore, Product, Banner } from '@searchspring/snap-store-mobx';
@@ -81,13 +82,14 @@ export const Results = observer((properties: ResultsProp): JSX.Element => {
 		...properties.theme?.components?.results,
 	};
 
-	const displaySettings = useDisplaySettings(props.breakpoints!);
-	if (displaySettings && Object.keys(displaySettings).length) {
-		props = {
-			...props,
-			...displaySettings,
-		};
-	}
+	const displaySettings = useDisplaySettings(props?.breakpoints || {});
+	const theme = deepmerge(props?.theme || {}, displaySettings?.theme || {});
+
+	props = {
+		...props,
+		...displaySettings,
+		theme,
+	};
 
 	const { disableStyles, className, layout, style, controller } = props;
 

--- a/packages/snap-preact-components/src/components/Trackers/Recommendation/ProfileTracker/RecommendationProfileTracker.test.tsx
+++ b/packages/snap-preact-components/src/components/Trackers/Recommendation/ProfileTracker/RecommendationProfileTracker.test.tsx
@@ -131,7 +131,7 @@ describe('RecommendationProfileTracker Component', () => {
 		trackfn.mockClear();
 
 		// @ts-ignore
-		let [callback] = window.IntersectionObserver.mock.calls[0];
+		const [callback] = window.IntersectionObserver.mock.calls[0];
 		callback([
 			{
 				isIntersecting: true,

--- a/packages/snap-preact-components/src/components/Trackers/Recommendation/ResultTracker/RecommendationResultTracker.test.tsx
+++ b/packages/snap-preact-components/src/components/Trackers/Recommendation/ResultTracker/RecommendationResultTracker.test.tsx
@@ -110,7 +110,7 @@ describe('RecommendationResultTracker Component', () => {
 
 		for (let i = 0; i < 21; i++) {
 			// @ts-ignore
-			let [callback] = window.IntersectionObserver.mock.calls[i];
+			const [callback] = window.IntersectionObserver.mock.calls[i];
 
 			callback([
 				{

--- a/packages/snap-preact-demo/src/components/Content/Content.tsx
+++ b/packages/snap-preact-demo/src/components/Content/Content.tsx
@@ -1,4 +1,4 @@
-import { h, Fragment, Component } from 'preact';
+import { h, Component } from 'preact';
 import { observer } from 'mobx-react';
 
 import { ThemeProvider, LoadingBar, defaultTheme, StoreProvider, ControllerProvider } from '@searchspring/snap-preact-components';

--- a/packages/snap-preact-demo/src/components/Content/Skel.tsx
+++ b/packages/snap-preact-demo/src/components/Content/Skel.tsx
@@ -1,4 +1,4 @@
-import { h, Fragment, Component } from 'preact';
+import { h, Component } from 'preact';
 import { Skeleton } from '@searchspring/snap-preact-components';
 
 export class ContentSkel extends Component {

--- a/packages/snap-preact-demo/src/components/FilterSummary/FilterSummary.tsx
+++ b/packages/snap-preact-demo/src/components/FilterSummary/FilterSummary.tsx
@@ -1,4 +1,4 @@
-import { h, Fragment, Component } from 'preact';
+import { h, Component } from 'preact';
 import { observer } from 'mobx-react';
 
 import { withStore, withController, useA11y } from '@searchspring/snap-preact-components';
@@ -14,7 +14,7 @@ type FilterSummaryProps = {
 @observer
 export class FilterSummary extends Component<FilterSummaryProps> {
 	render() {
-		const { facets, filters } = this.props.store;
+		const { filters } = this.props.store;
 		const controller = this.props.controller;
 		const removeAll = controller?.urlManager.remove('filter');
 

--- a/packages/snap-preact-demo/src/components/Header/Header.tsx
+++ b/packages/snap-preact-demo/src/components/Header/Header.tsx
@@ -11,7 +11,7 @@ type HeaderProps = {
 @observer
 export class Header extends Component<HeaderProps> {
 	render() {
-		const { pagination, search, custom } = this.props.controller.store;
+		const { pagination, search } = this.props.controller.store;
 
 		const landingPage = this.props.controller.store.merchandising.landingPage;
 		return (
@@ -19,7 +19,7 @@ export class Header extends Component<HeaderProps> {
 				{landingPage ? (
 					<h3 className="ss__search-header--landingPageTitle">{landingPage.title}</h3>
 				) : (
-					<>
+					<Fragment>
 						{pagination.totalResults ? (
 							<h3
 								class="ss-title ss-results-title"
@@ -56,7 +56,7 @@ export class Header extends Component<HeaderProps> {
 								</h3>
 							)
 						)}
-					</>
+					</Fragment>
 				)}
 			</header>
 		);

--- a/packages/snap-preact-demo/src/components/Recommendations/Email/Email.tsx
+++ b/packages/snap-preact-demo/src/components/Recommendations/Email/Email.tsx
@@ -1,4 +1,4 @@
-import { h, Fragment, Component } from 'preact';
+import { h, Component } from 'preact';
 import { observer } from 'mobx-react';
 
 import { Result } from '@searchspring/snap-preact-components';

--- a/packages/snap-preact-demo/src/components/Recommendations/Recs/Recs.tsx
+++ b/packages/snap-preact-demo/src/components/Recommendations/Recs/Recs.tsx
@@ -1,4 +1,4 @@
-import { h, Fragment, Component } from 'preact';
+import { h, Component } from 'preact';
 import { observer } from 'mobx-react';
 
 import { Carousel, Recommendation, Result } from '@searchspring/snap-preact-components';

--- a/packages/snap-preact-demo/src/components/Results/Results.tsx
+++ b/packages/snap-preact-demo/src/components/Results/Results.tsx
@@ -1,4 +1,4 @@
-import { h, Fragment, Component } from 'preact';
+import { h, Component } from 'preact';
 import { observer } from 'mobx-react';
 
 import { Pagination, Results as ResultsComponent, withStore, withController } from '@searchspring/snap-preact-components';

--- a/packages/snap-preact-demo/src/components/Sidebar/Sidebar.tsx
+++ b/packages/snap-preact-demo/src/components/Sidebar/Sidebar.tsx
@@ -1,11 +1,10 @@
-import { h, Fragment, Component } from 'preact';
+import { h, Component } from 'preact';
 import { observer } from 'mobx-react';
 
 import {
 	ThemeProvider,
 	defaultTheme,
 	FilterSummary,
-	Select,
 	Facets,
 	StoreProvider,
 	withStore,

--- a/packages/snap-preact-demo/src/components/Sidebar/Skel.tsx
+++ b/packages/snap-preact-demo/src/components/Sidebar/Skel.tsx
@@ -1,4 +1,4 @@
-import { h, Fragment, Component } from 'preact';
+import { h, Component } from 'preact';
 import { Skeleton } from '@searchspring/snap-preact-components';
 
 export class SidebarSkel extends Component {

--- a/packages/snap-preact-demo/src/components/Toolbar/PerPage.tsx
+++ b/packages/snap-preact-demo/src/components/Toolbar/PerPage.tsx
@@ -1,4 +1,4 @@
-import { h, Fragment, Component } from 'preact';
+import { h, Component } from 'preact';
 import { observer } from 'mobx-react';
 
 import { Select, withStore } from '@searchspring/snap-preact-components';

--- a/packages/snap-preact-demo/src/components/Toolbar/SortBy.tsx
+++ b/packages/snap-preact-demo/src/components/Toolbar/SortBy.tsx
@@ -1,4 +1,4 @@
-import { h, Fragment, Component } from 'preact';
+import { h, Component } from 'preact';
 import { observer } from 'mobx-react';
 
 import { Select, withStore } from '@searchspring/snap-preact-components';

--- a/packages/snap-preact-demo/src/index.ts
+++ b/packages/snap-preact-demo/src/index.ts
@@ -176,4 +176,4 @@ if (window.mergeSnapConfig) {
 	config = deepmerge(config, window.mergeSnapConfig, { arrayMerge: combineMerge });
 }
 
-const snap = new Snap(config);
+new Snap(config);

--- a/packages/snap-preact-demo/src/middleware/functions.ts
+++ b/packages/snap-preact-demo/src/middleware/functions.ts
@@ -3,7 +3,7 @@ import deepmerge from 'deepmerge';
 export async function timeout(microSeconds: number) {
 	console.log(`...waiting ${microSeconds} μsecs...`);
 
-	return new Promise((resolve, reject) => {
+	return new Promise((resolve) => {
 		setTimeout(resolve, microSeconds);
 	});
 }

--- a/packages/snap-preact-demo/src/middleware/plugins/afterStore.ts
+++ b/packages/snap-preact-demo/src/middleware/plugins/afterStore.ts
@@ -1,5 +1,5 @@
 export function afterStore(controller: AbstractController) {
-	controller.on('init', async ({ controller: AbstractController }, next) => {
+	controller.on('init', async ({}, next) => {
 		controller.log.debug('initialization...');
 		await next();
 	});
@@ -19,7 +19,7 @@ export function afterStore(controller: AbstractController) {
 }
 
 function mutateFacets(facets: SearchFacetsStore) {
-	for (let facet of facets) {
+	for (const facet of facets) {
 		let limit = 12;
 		if (facet.display == 'palette' || facet.display == 'grid') {
 			limit = 16;
@@ -29,7 +29,7 @@ function mutateFacets(facets: SearchFacetsStore) {
 	}
 }
 
-async function restorePosition({ controller, element }, next: Next) {
+async function restorePosition({ element }, next: Next) {
 	// scroll to top only if we are not going to be scrolling to stored element
 	if (!element) {
 		setTimeout(() => {

--- a/packages/snap-preact-demo/src/types.ts
+++ b/packages/snap-preact-demo/src/types.ts
@@ -1,7 +1,6 @@
 import type * as SnapPreactTypes from '@searchspring/snap-preact';
 import type * as ControllerTypes from '@searchspring/snap-controller';
 import type * as StoreTypes from '@searchspring/snap-store-mobx';
-import type * as UrlManagerTypes from '@searchspring/snap-url-manager';
 import type * as EventManagerTypes from '@searchspring/snap-event-manager';
 
 declare global {

--- a/packages/snap-preact/src/Instantiators/RecommendationInstantiator.test.tsx
+++ b/packages/snap-preact/src/Instantiators/RecommendationInstantiator.test.tsx
@@ -40,7 +40,7 @@ describe('RecommendationInstantiator', () => {
 	it('throws if configuration is not provided', () => {
 		expect(() => {
 			// @ts-ignore - testing bad instantiation
-			const recommendationInstantiator = new RecommendationInstantiator();
+			new RecommendationInstantiator();
 		}).toThrow();
 	});
 
@@ -59,7 +59,7 @@ describe('RecommendationInstantiator', () => {
 
 		expect(() => {
 			// @ts-ignore - testing bad instantiation
-			const recommendationInstantiator = new RecommendationInstantiator(invalidConfig);
+			new RecommendationInstantiator(invalidConfig);
 		}).toThrow();
 	});
 
@@ -75,7 +75,7 @@ describe('RecommendationInstantiator', () => {
 
 		expect(() => {
 			// @ts-ignore - testing bad instantiation
-			const recommendationInstantiator = new RecommendationInstantiator(invalidConfig);
+			new RecommendationInstantiator(invalidConfig);
 		}).toThrow();
 	});
 
@@ -94,7 +94,7 @@ describe('RecommendationInstantiator', () => {
 
 		expect(() => {
 			// @ts-ignore - testing bad instantiation
-			const recommendationInstantiator = new RecommendationInstantiator(invalidConfig);
+			new RecommendationInstantiator(invalidConfig);
 		}).toThrow();
 	});
 
@@ -245,7 +245,7 @@ describe('RecommendationInstantiator', () => {
 		const recommendationInstantiator = new RecommendationInstantiator(baseConfig, { client });
 		await wait();
 		expect(Object.keys(recommendationInstantiator.controller).length).toBe(4);
-		Object.keys(recommendationInstantiator.controller).forEach((controllerId, index) => {
+		Object.keys(recommendationInstantiator.controller).forEach((controllerId) => {
 			const controller = recommendationInstantiator.controller[controllerId];
 			profileCount[controller.context.profile] = profileCount[controller.context.profile] + 1 || 0;
 			expect(controllerId).toBe(`recommend_${controller.context.profile}_${profileCount[controller.context.profile]}`);
@@ -271,7 +271,7 @@ describe('RecommendationInstantiator', () => {
 		const recommendationInstantiator = new RecommendationInstantiator(baseConfig, { client });
 		await wait();
 		expect(Object.keys(recommendationInstantiator.controller).length).toBe(1);
-		Object.keys(recommendationInstantiator.controller).forEach((controllerId, index) => {
+		Object.keys(recommendationInstantiator.controller).forEach((controllerId) => {
 			const controller = recommendationInstantiator.controller[controllerId];
 			expect(controller.context).toStrictEqual({
 				profile: 'trending',
@@ -333,7 +333,7 @@ describe('RecommendationInstantiator', () => {
 		});
 		await wait();
 
-		Object.keys(recommendationInstantiator.controller).forEach((controllerId, index) => {
+		Object.keys(recommendationInstantiator.controller).forEach((controllerId) => {
 			const controller = recommendationInstantiator.controller[controllerId];
 			expect(clientSpy).toHaveBeenCalledTimes(1);
 			expect(middlewareFn).toHaveBeenCalledTimes(6);
@@ -378,7 +378,7 @@ describe('RecommendationInstantiator', () => {
 		const recommendationInstantiator = new RecommendationInstantiator(attachmentConfig as RecommendationInstantiatorConfig, { client });
 		await wait();
 
-		Object.keys(recommendationInstantiator.controller).forEach((controllerId, index) => {
+		Object.keys(recommendationInstantiator.controller).forEach((controllerId) => {
 			const controller = recommendationInstantiator.controller[controllerId];
 			expect(clientSpy).toHaveBeenCalledTimes(1);
 			expect(middlewareFn).toHaveBeenCalledTimes(3);

--- a/packages/snap-preact/src/Instantiators/RecommendationInstantiator.tsx
+++ b/packages/snap-preact/src/Instantiators/RecommendationInstantiator.tsx
@@ -6,7 +6,6 @@ import { Client } from '@searchspring/snap-client';
 import { Logger } from '@searchspring/snap-logger';
 import { Tracker } from '@searchspring/snap-tracker';
 
-import type { FunctionComponent } from 'preact';
 import type { ClientConfig, ClientGlobals } from '@searchspring/snap-client';
 import type { UrlTranslatorConfig } from '@searchspring/snap-url-manager';
 import type { AbstractController, RecommendationController, Attachments, ContextVariables } from '@searchspring/snap-controller';
@@ -299,7 +298,7 @@ export class RecommendationInstantiator {
 		this.plugins.push({ func, args });
 	}
 
-	public on<T>(event: string, ...func: Middleware<unknown>[]): void {
+	public on(event: string, ...func: Middleware<unknown>[]): void {
 		this.middleware.push({ event, func });
 	}
 

--- a/packages/snap-preact/src/Snap.test.tsx
+++ b/packages/snap-preact/src/Snap.test.tsx
@@ -7,14 +7,9 @@ import { Tracker, TrackerGlobals } from '@searchspring/snap-tracker';
 import { Logger } from '@searchspring/snap-logger';
 import { cookies } from '@searchspring/snap-toolbox';
 
-import type {
-	SearchControllerConfig,
-	AutocompleteControllerConfig,
-	FinderControllerConfig,
-	RecommendationControllerConfig,
-} from '@searchspring/snap-controller';
+import type { SearchControllerConfig, AutocompleteControllerConfig } from '@searchspring/snap-controller';
 
-import { Snap, SnapConfig, BRANCH_COOKIE, DEV_COOKIE } from './Snap';
+import { Snap, SnapConfig, DEV_COOKIE } from './Snap';
 import type { AutocompleteStore } from '@searchspring/snap-store-mobx';
 import { ClientGlobals } from '@searchspring/snap-client';
 
@@ -51,7 +46,7 @@ describe('Snap Preact', () => {
 	it('throws if configuration is not provided', () => {
 		expect(() => {
 			// @ts-ignore - testing bad instantiation
-			const snap = new Snap();
+			new Snap();
 		}).toThrow();
 	});
 
@@ -62,7 +57,7 @@ describe('Snap Preact', () => {
 
 		expect(() => {
 			// @ts-ignore - testing bad instantiation
-			const snap = new Snap(config);
+			new Snap(config);
 		}).toThrow();
 	});
 
@@ -72,7 +67,7 @@ describe('Snap Preact', () => {
 
 		const logger = new Logger({ prefix: 'Snap Preact ' });
 		const spy = jest.spyOn(console, 'error');
-		const snap = new Snap(baseConfig, { logger });
+		new Snap(baseConfig, { logger });
 		expect(spy).toHaveBeenCalledWith('Snap failed to find global context');
 
 		spy.mockClear();
@@ -180,7 +175,7 @@ describe('Snap Preact', () => {
 
 		const tracker = new Tracker(contextConfig.client!.globals as TrackerGlobals);
 		const spy = jest.spyOn(tracker.track.shopper, 'login');
-		const snap = new Snap(contextConfig, { tracker });
+		new Snap(contextConfig, { tracker });
 		expect(spy).toHaveBeenCalledWith({ id: contextConfig.context.shopper.id });
 
 		spy.mockClear();
@@ -200,7 +195,7 @@ describe('Snap Preact', () => {
 
 		const tracker = new Tracker(contextConfig.client!.globals as TrackerGlobals);
 		const spy = jest.spyOn(tracker.cookies.cart, 'set');
-		const snap = new Snap(contextConfig, { tracker });
+		new Snap(contextConfig, { tracker });
 		expect(spy).toHaveBeenCalledWith(['sku1', 'sku2', 'sku3']);
 
 		spy.mockClear();
@@ -229,13 +224,13 @@ describe('Snap Preact', () => {
 		window.addEventListener = jest.fn((event, callback) => {
 			events[event] = callback;
 		});
-		window.removeEventListener = jest.fn((event, callback) => {
+		window.removeEventListener = jest.fn((event) => {
 			delete events[event];
 		});
 
 		const tracker = new Tracker(generateBaseConfig().client!.globals as TrackerGlobals);
 		const spy = jest.spyOn(tracker.track, 'error');
-		const snap = new Snap(generateBaseConfig(), { tracker });
+		new Snap(generateBaseConfig(), { tracker });
 
 		const error = new ErrorEvent('error', {
 			error: new Error('test error'),
@@ -740,7 +735,7 @@ describe('Snap Preact', () => {
 			};
 			const client = new MockClient(acConfig.client!.globals as ClientGlobals);
 			const snap = new Snap(acConfig, { client });
-			const ac = await snap.getController('ac');
+			await snap.getController('ac');
 			await wait();
 			expect(onTarget).toHaveBeenCalledTimes(1);
 		});
@@ -1029,7 +1024,7 @@ describe('Snap Preact', () => {
 
 			const client = new MockClient(finderConfig.client!.globals as ClientGlobals);
 			const snap = new Snap(finderConfig, { client });
-			const finder = await snap.getController('finder');
+			await snap.getController('finder');
 			await wait();
 			expect(onTarget).toHaveBeenCalledTimes(1);
 		});
@@ -1199,7 +1194,7 @@ describe('Snap Preact', () => {
 			};
 			const client = new MockClient(recommendationConfig.client!.globals as ClientGlobals);
 			const snap = new Snap(recommendationConfig, { client });
-			const recommendation = await snap.getController('trendingRecs');
+			await snap.getController('trendingRecs');
 			await wait();
 			expect(onTarget).toHaveBeenCalledTimes(1);
 		});
@@ -1275,7 +1270,7 @@ describe('Snap Preact', () => {
 			const snap = new Snap(baseConfig);
 
 			await expect(async () => {
-				const [searchOne, searchTwo] = await snap.getControllers('searchOne', 'searchTwo');
+				await snap.getControllers('searchOne', 'searchTwo');
 			}).rejects.toBe(`getController could not find controller with id: searchOne`);
 		});
 
@@ -1296,7 +1291,7 @@ describe('Snap Preact', () => {
 			const snap = new Snap(searchConfig);
 
 			await expect(async () => {
-				const [searchOne, searchTwo] = await snap.getControllers('searchOne', 'searchTwo');
+				await snap.getControllers('searchOne', 'searchTwo');
 			}).rejects.toBe(`getController could not find controller with id: searchTwo`);
 		});
 

--- a/packages/snap-preact/src/Snap.tsx
+++ b/packages/snap-preact/src/Snap.tsx
@@ -1,6 +1,7 @@
+/** @jsx h */
+import { h, render } from 'preact';
 import deepmerge from 'deepmerge';
 import { isPlainObject } from 'is-plain-object';
-import { h, render } from 'preact';
 import { configure as configureMobx } from 'mobx';
 
 import { Client } from '@searchspring/snap-client';
@@ -13,10 +14,7 @@ import type { ClientConfig, ClientGlobals } from '@searchspring/snap-client';
 import type {
 	Controllers,
 	AbstractController,
-	SearchController,
 	AutocompleteController,
-	FinderController,
-	RecommendationController,
 	SearchControllerConfig,
 	AutocompleteControllerConfig,
 	FinderControllerConfig,

--- a/packages/snap-preact/src/configureSnapFeatures.ts
+++ b/packages/snap-preact/src/configureSnapFeatures.ts
@@ -30,7 +30,7 @@ function configureIntegratedSpellCorrection(config: SnapConfig) {
 		Object.keys(config?.controllers || {}).forEach((type) => {
 			switch (type) {
 				case 'autocomplete': {
-					config.controllers![type]!.forEach((controller, index) => {
+					config.controllers![type]!.forEach((controller) => {
 						if (typeof controller.config?.settings?.integratedSpellCorrection == 'undefined') {
 							// enable integratedSpellCorrection controller setting
 							controller.config.settings = deepmerge({ integratedSpellCorrection: true }, controller.config.settings || {});

--- a/packages/snap-preact/src/create/createAutocompleteController.test.ts
+++ b/packages/snap-preact/src/create/createAutocompleteController.test.ts
@@ -46,7 +46,7 @@ describe('createAutocompleteController', () => {
 	it('throws when incomplete configuration is used', () => {
 		expect(() => {
 			// @ts-ignore - testing invalid config passed
-			const controller = createAutocompleteController({});
+			createAutocompleteController({});
 		}).toThrow();
 
 		expect(() => {
@@ -57,7 +57,7 @@ describe('createAutocompleteController', () => {
 			};
 
 			// @ts-ignore - testing invalid config passed
-			const controller = createAutocompleteController(bareConfig);
+			createAutocompleteController(bareConfig);
 		}).toThrow();
 
 		expect(() => {
@@ -70,7 +70,7 @@ describe('createAutocompleteController', () => {
 			};
 
 			// @ts-ignore - testing invalid config passed
-			const controller = createAutocompleteController(bareConfig);
+			createAutocompleteController(bareConfig);
 		}).toThrow();
 	});
 

--- a/packages/snap-preact/src/create/createFinderController.test.ts
+++ b/packages/snap-preact/src/create/createFinderController.test.ts
@@ -60,7 +60,7 @@ describe('createFinderController', () => {
 	it('throws when incomplete configuration is used', () => {
 		expect(() => {
 			// @ts-ignore - testing invalid config passed
-			const controller = createFinderController({});
+			createFinderController({});
 		}).toThrow();
 
 		expect(() => {
@@ -71,7 +71,7 @@ describe('createFinderController', () => {
 			};
 
 			// @ts-ignore - testing invalid config passed
-			const controller = createFinderController(bareConfig);
+			createFinderController(bareConfig);
 		}).toThrow();
 
 		expect(() => {
@@ -84,7 +84,7 @@ describe('createFinderController', () => {
 			};
 
 			// @ts-ignore - testing invalid config passed
-			const controller = createFinderController(bareConfig);
+			createFinderController(bareConfig);
 		}).toThrow();
 	});
 

--- a/packages/snap-preact/src/create/createRecommendationController.test.ts
+++ b/packages/snap-preact/src/create/createRecommendationController.test.ts
@@ -46,7 +46,7 @@ describe('createRecommendationController', () => {
 	it('throws when incomplete configuration is used', () => {
 		expect(() => {
 			// @ts-ignore - testing invalid config passed
-			const controller = createRecommendationController({});
+			createRecommendationController({});
 		}).toThrow();
 
 		expect(() => {
@@ -57,7 +57,7 @@ describe('createRecommendationController', () => {
 			};
 
 			// @ts-ignore - testing invalid config passed
-			const controller = createRecommendationController(bareConfig);
+			createRecommendationController(bareConfig);
 		}).toThrow();
 
 		expect(() => {
@@ -70,7 +70,7 @@ describe('createRecommendationController', () => {
 			};
 
 			// @ts-ignore - testing invalid config passed
-			const controller = createRecommendationController(bareConfig);
+			createRecommendationController(bareConfig);
 		}).toThrow();
 	});
 

--- a/packages/snap-preact/src/create/createSearchController.test.ts
+++ b/packages/snap-preact/src/create/createSearchController.test.ts
@@ -45,7 +45,7 @@ describe('createSearchController', () => {
 	it('throws when incomplete configuration is used', () => {
 		expect(() => {
 			// @ts-ignore - testing invalid config passed
-			const controller = createSearchController({});
+			createSearchController({});
 		}).toThrow();
 
 		expect(() => {
@@ -56,7 +56,7 @@ describe('createSearchController', () => {
 			};
 
 			// @ts-ignore - testing invalid config passed
-			const controller = createSearchController(bareConfig);
+			createSearchController(bareConfig);
 		}).toThrow();
 
 		expect(() => {
@@ -69,7 +69,7 @@ describe('createSearchController', () => {
 			};
 
 			// @ts-ignore - testing invalid config passed
-			const controller = createSearchController(bareConfig);
+			createSearchController(bareConfig);
 		}).toThrow();
 	});
 

--- a/packages/snap-preact/src/integration.test.tsx
+++ b/packages/snap-preact/src/integration.test.tsx
@@ -2,11 +2,10 @@ import { h } from 'preact';
 
 import '@testing-library/jest-dom/extend-expect';
 import { cleanup, waitFor } from '@testing-library/preact';
-import userEvent from '@testing-library/user-event';
 
 import { cookies } from '@searchspring/snap-toolbox';
 
-import { Snap, SnapConfig, BRANCH_COOKIE, DEV_COOKIE } from './Snap';
+import { Snap, SnapConfig, DEV_COOKIE } from './Snap';
 
 const baseConfig: SnapConfig = {
 	client: {
@@ -168,7 +167,7 @@ describe('Snap Preact Integration', () => {
 	it(`takes the ss_attribution param from the URL and sets the sessionStorage`, async () => {
 		// set up
 		const key = 'ssAttribution';
-		let mockStorage: {
+		const mockStorage: {
 			[key: string]: string;
 		} = {};
 		global.Storage.prototype.setItem = jest.fn((key, value) => {
@@ -182,7 +181,7 @@ describe('Snap Preact Integration', () => {
 		window.location = {
 			href: 'https://www.merch.com',
 		};
-		let snap = new Snap(baseConfig);
+		new Snap(baseConfig);
 		expect(mockStorage[key]).toBeUndefined();
 
 		// should add attribution to storage from url
@@ -190,7 +189,7 @@ describe('Snap Preact Integration', () => {
 		window.location = {
 			href: 'https://www.merch.com?ss_attribution=email:emailTag',
 		};
-		snap = new Snap(baseConfig);
+		new Snap(baseConfig);
 		expect(mockStorage[key]).toBe('email:emailTag');
 
 		// remove attribution query param, but ensure that sessionStorage value still set
@@ -198,7 +197,7 @@ describe('Snap Preact Integration', () => {
 		window.location = {
 			href: 'https://www.merch.com',
 		};
-		snap = new Snap(baseConfig);
+		new Snap(baseConfig);
 		expect(mockStorage[key]).toBe('email:emailTag');
 
 		// change attribution to email:differentEmailTag
@@ -206,7 +205,7 @@ describe('Snap Preact Integration', () => {
 		window.location = {
 			href: 'https://www.merch.com?ss_attribution=email:differentEmailTag',
 		};
-		snap = new Snap(baseConfig);
+		new Snap(baseConfig);
 		expect(mockStorage[key]).toBe('email:differentEmailTag');
 
 		// clean up
@@ -227,7 +226,7 @@ describe('Snap Preact Integration', () => {
 		};
 
 		expect(() => {
-			const snap = new Snap(baseConfig);
+			new Snap(baseConfig);
 		}).toThrow();
 
 		// wait for rendering of BranchOverride component

--- a/packages/snap-preact/src/types.ts
+++ b/packages/snap-preact/src/types.ts
@@ -1,6 +1,5 @@
 import type { Client, ClientConfig, ClientGlobals } from '@searchspring/snap-client';
 import type {
-	AbstractController,
 	ControllerConfig,
 	SearchControllerConfig,
 	AutocompleteControllerConfig,

--- a/packages/snap-store-mobx/src/Abstract/AbstractStore.ts
+++ b/packages/snap-store-mobx/src/Abstract/AbstractStore.ts
@@ -1,4 +1,4 @@
-import { makeObservable, observable, toJS, configure } from 'mobx';
+import { makeObservable, observable, toJS } from 'mobx';
 import type { StoreConfigs, ErrorType } from '../types';
 export abstract class AbstractStore {
 	public custom = {};

--- a/packages/snap-store-mobx/src/Autocomplete/AutocompleteStore.test.ts
+++ b/packages/snap-store-mobx/src/Autocomplete/AutocompleteStore.test.ts
@@ -138,7 +138,7 @@ describe('Autocomplete Store', () => {
 	});
 
 	it('reset functions actually reset data', () => {
-		let mockStorage: {
+		const mockStorage: {
 			[key: string]: string;
 		} = {};
 

--- a/packages/snap-store-mobx/src/Autocomplete/AutocompleteStore.ts
+++ b/packages/snap-store-mobx/src/Autocomplete/AutocompleteStore.ts
@@ -10,7 +10,7 @@ import {
 	SearchSortingStore,
 	SearchHistoryStore,
 } from '../Search/Stores';
-import { StorageStore, StorageType } from '../Storage/StorageStore';
+import { StorageStore } from '../Storage/StorageStore';
 import {
 	AutocompleteStateStore,
 	AutocompleteTermStore,

--- a/packages/snap-store-mobx/src/Autocomplete/Stores/AutocompleteHistoryStore.ts
+++ b/packages/snap-store-mobx/src/Autocomplete/Stores/AutocompleteHistoryStore.ts
@@ -1,6 +1,3 @@
-import { observable, makeObservable } from 'mobx';
-
-import type { TrendingResponseModel } from '@searchspring/snap-client';
 import type { StoreServices } from '../../types';
 import type { AutocompleteStateStore } from './AutocompleteStateStore';
 import { Term } from './AutocompleteTermStore';

--- a/packages/snap-store-mobx/src/Autocomplete/Stores/AutocompleteTrendingStore.ts
+++ b/packages/snap-store-mobx/src/Autocomplete/Stores/AutocompleteTrendingStore.ts
@@ -1,5 +1,3 @@
-import { observable, makeObservable } from 'mobx';
-
 import type { TrendingResponseModel } from '@searchspring/snap-client';
 import type { StoreServices } from '../../types';
 import type { AutocompleteStateStore } from './AutocompleteStateStore';

--- a/packages/snap-store-mobx/src/Finder/FinderStore.test.ts
+++ b/packages/snap-store-mobx/src/Finder/FinderStore.test.ts
@@ -57,7 +57,7 @@ describe('Finder Store', () => {
 	it('throws if invalid services object', () => {
 		expect(() => {
 			// @ts-ignore
-			const finderStore = new FinderStore(config, {});
+			new FinderStore(config, {});
 		}).toThrow();
 	});
 
@@ -259,7 +259,7 @@ describe('Finder Store', () => {
 			});
 
 			it('it will NOT reset persisted selections if something in the config plugins has changed', () => {
-				const testPlugin = (controller: any, ...additionalParams: any[]) => {};
+				const testPlugin = () => {};
 
 				config = {
 					...config,
@@ -300,7 +300,7 @@ describe('Finder Store', () => {
 				config = {
 					...config,
 					middleware: {
-						onInit: (controller: any) => {},
+						onInit: () => {},
 					},
 					persist: {
 						enabled: true,
@@ -321,7 +321,7 @@ describe('Finder Store', () => {
 				config = {
 					...config,
 					middleware: {
-						afterSearch: (controller: any) => {},
+						afterSearch: () => {},
 					},
 					persist: {
 						enabled: true,

--- a/packages/snap-store-mobx/src/Search/Stores/SearchFacetStore.test.ts
+++ b/packages/snap-store-mobx/src/Search/Stores/SearchFacetStore.test.ts
@@ -12,16 +12,8 @@ import type {
 	MetaResponseModel,
 	MetaResponseModelFacet,
 	MetaResponseModelFacetDefaults,
-	MetaResponseModelFacetGrid,
-	MetaResponseModelFacetHierarchy,
-	MetaResponseModelFacetList,
-	MetaResponseModelFacetPalette,
 	MetaResponseModelFacetSlider,
-	SearchRequestModelFilterRangeAllOfValue,
-	SearchResponseModelFilterRange,
-	SearchResponseModelFacetRangeBucketsAllOfValues,
 	SearchResponseModelFacetRangeBuckets,
-	SearchResponseModelFacetValueAllOfValues,
 } from '@searchspring/snapi-types';
 
 const services = {
@@ -228,9 +220,6 @@ describe('Facet Store', () => {
 
 		expect(facet.overflow.limited).toBe(false);
 
-		// new store to ensure storage does not bleed
-
-		const newStorageStore = new StorageStore();
 		facets = new SearchFacetStore(
 			searchConfig,
 			services,

--- a/packages/snap-store-mobx/src/Search/Stores/SearchFacetStore.ts
+++ b/packages/snap-store-mobx/src/Search/Stores/SearchFacetStore.ts
@@ -333,7 +333,7 @@ export class FacetValue {
 	public count!: number;
 	public filtered!: boolean;
 	public value!: string;
-	public custom!: {};
+	public custom!: object;
 	public url: UrlManager;
 	public preview?: () => void;
 
@@ -389,7 +389,7 @@ export class FacetRangeValue {
 	public filtered!: boolean;
 	public low!: number;
 	public high!: number;
-	public custom!: {};
+	public custom!: object;
 	public url: UrlManager;
 
 	constructor(services: StoreServices, facet: ValueFacet, value: SearchResponseModelFacetValueAllOfValues) {

--- a/packages/snap-store-mobx/src/Search/Stores/SearchFilterStore.test.ts
+++ b/packages/snap-store-mobx/src/Search/Stores/SearchFilterStore.test.ts
@@ -79,7 +79,7 @@ describe('Filter Store', () => {
 		const filters = new SearchFilterStore(services, filtersInput, searchData.meta);
 
 		// check filter values
-		filters.forEach((filter, index) => {
+		filters.forEach((filter) => {
 			expect(filter.url.constructor.name).toStrictEqual(services.urlManager.constructor.name);
 		});
 	});

--- a/packages/snap-store-mobx/src/Search/Stores/SearchHistoryStore.test.ts
+++ b/packages/snap-store-mobx/src/Search/Stores/SearchHistoryStore.test.ts
@@ -210,7 +210,7 @@ describe('History Store', () => {
 		historyData.map((term) => historyStore.save(term));
 
 		expect(historyStore.queries).toHaveLength(config.max);
-		let trimmedData = historyData.slice(historyData.length - config.max).reverse();
+		const trimmedData = historyData.slice(historyData.length - config.max).reverse();
 		historyStore.queries.map((term, idx) => {
 			expect(term.string).toBe(trimmedData[idx]);
 		});

--- a/packages/snap-store-mobx/src/Search/Stores/SearchMerchandisingStore.ts
+++ b/packages/snap-store-mobx/src/Search/Stores/SearchMerchandisingStore.ts
@@ -1,5 +1,3 @@
-import { observable, makeObservable } from 'mobx';
-
 import type { StoreServices } from '../../types';
 import type {
 	SearchResponseModelMerchandising,

--- a/packages/snap-store-mobx/src/Search/Stores/SearchPaginationStore.ts
+++ b/packages/snap-store-mobx/src/Search/Stores/SearchPaginationStore.ts
@@ -126,7 +126,7 @@ export class SearchPaginationStore {
 		}
 	}
 
-	public getPages(min: number = 5, max?: number): Page[] {
+	public getPages(min = 5, max?: number): Page[] {
 		if (!Number.isInteger(min)) {
 			return [];
 		}

--- a/packages/snap-store-mobx/src/Storage/StorageStore.ts
+++ b/packages/snap-store-mobx/src/Storage/StorageStore.ts
@@ -7,7 +7,7 @@ const utils = {
 export class StorageStore {
 	private type: StorageType | null = null;
 	private expiration = 31536000000; // one year (ms)
-	private sameSite: string = 'Lax';
+	private sameSite = 'Lax';
 	private key = 'ss-storage';
 	public state: Record<string, any> = {};
 

--- a/packages/snap-toolbox/src/DomTargeter/DomTargeter.test.ts
+++ b/packages/snap-toolbox/src/DomTargeter/DomTargeter.test.ts
@@ -267,7 +267,7 @@ describe('DomTargeter', () => {
 			autoRetarget: true,
 		};
 
-		new DomTargeter([selector], (target: Target, elem: Element) => {}, document);
+		new DomTargeter([selector], () => {}, document);
 
 		expect(document.querySelector('.classToLookFor')).toBe(null);
 
@@ -325,7 +325,7 @@ describe('DomTargeter', () => {
 			},
 		];
 
-		new DomTargeter(selectors, (target: Target, elem: Element) => {}, document);
+		new DomTargeter(selectors, () => {}, document);
 
 		expect(document.querySelector('.classToLookFor')).toBe(null);
 
@@ -373,7 +373,7 @@ describe('DomTargeter', () => {
 			clickRetarget: true,
 		};
 
-		new DomTargeter([selector], (target: Target, elem: Element) => {}, document);
+		new DomTargeter([selector], () => {}, document);
 
 		expect(document.querySelector('.classToLookFor')).toBe(null);
 
@@ -416,7 +416,7 @@ describe('DomTargeter', () => {
 			clickRetarget: '#content',
 		};
 
-		new DomTargeter([selector], (target: Target, elem: Element) => {}, document);
+		new DomTargeter([selector], () => {}, document);
 
 		expect(document.querySelector('.classToLookFor')).toBe(null);
 
@@ -446,7 +446,7 @@ describe('DomTargeter', () => {
 					selector: '#content',
 					inject: {
 						action: 'append',
-						element: (target, element) => {
+						element: () => {
 							const div = document.createElement('div');
 							div.id = 'newThing';
 							div.innerHTML = 'blah';
@@ -458,7 +458,7 @@ describe('DomTargeter', () => {
 					selector: '#content',
 					inject: {
 						action: 'append',
-						element: (target, element) => {
+						element: () => {
 							const div = document.createElement('div');
 							div.id = 'newThing2';
 							div.innerHTML = 'tada';
@@ -470,7 +470,7 @@ describe('DomTargeter', () => {
 					selector: '#content',
 					inject: {
 						action: 'prepend',
-						element: (target, element) => {
+						element: () => {
 							const div = document.createElement('div');
 							div.id = 'newThing0';
 							div.innerHTML = 'first';
@@ -479,7 +479,7 @@ describe('DomTargeter', () => {
 					},
 				},
 			],
-			(target: Target, elem: Element) => {},
+			() => {},
 			document
 		);
 
@@ -501,7 +501,7 @@ describe('DomTargeter', () => {
 					selector: '#content',
 					inject: {
 						action: 'append',
-						element: (target, element) => {
+						element: () => {
 							const div = document.createElement('div');
 							div.id = 'newThing';
 							div.innerHTML = 'blah';
@@ -510,7 +510,7 @@ describe('DomTargeter', () => {
 					},
 				},
 			],
-			(target: Target, elem: Element) => {},
+			() => {},
 			document
 		);
 
@@ -520,7 +520,7 @@ describe('DomTargeter', () => {
 					selector: '#content',
 					inject: {
 						action: 'append',
-						element: (target, element) => {
+						element: () => {
 							const div = document.createElement('div');
 							div.id = 'newThing2';
 							div.innerHTML = 'tada';
@@ -529,7 +529,7 @@ describe('DomTargeter', () => {
 					},
 				},
 			],
-			(target: Target, elem: Element) => {},
+			() => {},
 			document
 		);
 
@@ -539,7 +539,7 @@ describe('DomTargeter', () => {
 					selector: '#content',
 					inject: {
 						action: 'prepend',
-						element: (target, element) => {
+						element: () => {
 							const div = document.createElement('div');
 							div.id = 'newThing0';
 							div.innerHTML = 'first';
@@ -548,7 +548,7 @@ describe('DomTargeter', () => {
 					},
 				},
 			],
-			(target: Target, elem: Element) => {},
+			() => {},
 			document
 		);
 
@@ -568,7 +568,7 @@ describe('DomTargeter', () => {
 					selector: '#content',
 					inject: {
 						action: 'before',
-						element: (target, element) => {
+						element: () => {
 							const div = document.createElement('div');
 							div.id = 'newThing';
 							div.innerHTML = 'blah';
@@ -577,7 +577,7 @@ describe('DomTargeter', () => {
 					},
 				},
 			],
-			(target: Target, elem: Element) => {},
+			() => {},
 			document
 		);
 
@@ -587,7 +587,7 @@ describe('DomTargeter', () => {
 					selector: '#content',
 					inject: {
 						action: 'after',
-						element: (target, element) => {
+						element: () => {
 							const div = document.createElement('div');
 							div.id = 'newThing2';
 							div.innerHTML = 'tada';
@@ -596,7 +596,7 @@ describe('DomTargeter', () => {
 					},
 				},
 			],
-			(target: Target, elem: Element) => {},
+			() => {},
 			document
 		);
 
@@ -614,7 +614,7 @@ describe('DomTargeter', () => {
 					selector: '#content',
 					inject: {
 						action: 'replace',
-						element: (target, element) => {
+						element: () => {
 							const div = document.createElement('div');
 							div.id = 'content';
 							div.innerHTML = 'blah';
@@ -623,7 +623,7 @@ describe('DomTargeter', () => {
 					},
 				},
 			],
-			(target: Target, elem: Element) => {},
+			() => {},
 			document
 		);
 
@@ -633,7 +633,7 @@ describe('DomTargeter', () => {
 					selector: '#content',
 					inject: {
 						action: 'after',
-						element: (target, element) => {
+						element: () => {
 							const div = document.createElement('div');
 							div.id = 'newThing';
 							div.innerHTML = 'tada';
@@ -642,7 +642,7 @@ describe('DomTargeter', () => {
 					},
 				},
 			],
-			(target: Target, elem: Element) => {},
+			() => {},
 			document
 		);
 
@@ -654,7 +654,7 @@ describe('DomTargeter', () => {
 					selector: '#content',
 					inject: {
 						action: 'replace',
-						element: (target, element) => {
+						element: () => {
 							const div = document.createElement('div');
 							div.id = 'lastThing';
 							div.innerHTML = 'tada';
@@ -663,7 +663,7 @@ describe('DomTargeter', () => {
 					},
 				},
 			],
-			(target: Target, elem: Element) => {},
+			() => {},
 			document
 		);
 

--- a/packages/snap-toolbox/src/getContext/getContext.ts
+++ b/packages/snap-toolbox/src/getContext/getContext.ts
@@ -33,7 +33,7 @@ export function getContext(evaluate: string[] = [], script?: HTMLScriptElement |
 		throw new Error('getContext: first parameter must be an array of strings');
 	}
 
-	let siteIdString = 'siteId';
+	const siteIdString = 'siteId';
 
 	const variables: ContextVariables = {};
 

--- a/packages/snap-tracker/src/Tracker.test.ts
+++ b/packages/snap-tracker/src/Tracker.test.ts
@@ -425,7 +425,7 @@ describe('Tracker', () => {
 			errortimestamp: 1,
 		};
 
-		const beaconEvent = await tracker.track.error(payload);
+		await tracker.track.error(payload);
 
 		await new Promise((r) => setTimeout(r, BATCH_TIMEOUT + 1)); // BATCH_TIMEOUT + 1
 
@@ -463,7 +463,7 @@ describe('Tracker', () => {
 			errortimestamp: 1,
 		};
 
-		const beaconEvent = await tracker.track.error(payload);
+		await tracker.track.error(payload);
 
 		await new Promise((r) => setTimeout(r, BATCH_TIMEOUT + 1)); // BATCH_TIMEOUT + 1
 

--- a/packages/snap-tracker/src/Tracker.ts
+++ b/packages/snap-tracker/src/Tracker.ts
@@ -150,7 +150,7 @@ export class Tracker {
 
 				while (Object.keys(attributes).length == 0 && elem !== null && levels <= MAX_PARENT_LEVELS) {
 					Object.values(elem.attributes).forEach((attr: Attr) => {
-						var attrName = attr.nodeName;
+						const attrName = attr.nodeName;
 
 						if (attributeList.indexOf(attrName) != -1) {
 							attributes[attrName] = elem && elem.getAttribute(attrName);
@@ -688,9 +688,9 @@ export class Tracker {
 			return;
 		}
 
-		let savedEvents = JSON.parse(this.localStorage.get(LOCALSTORAGE_BEACON_POOL_NAME) || '[]') as BeaconEvent[];
+		const savedEvents = JSON.parse(this.localStorage.get(LOCALSTORAGE_BEACON_POOL_NAME) || '[]') as BeaconEvent[];
 		if (eventsToSend) {
-			let eventsClone: BeaconEvent[] = [];
+			const eventsClone: BeaconEvent[] = [];
 			savedEvents.forEach((_event: BeaconEvent, idx: number) => {
 				// using Object.assign since we are not modifying nested properties
 				eventsClone.push(Object.assign({}, _event));
@@ -702,7 +702,7 @@ export class Tracker {
 
 			// de-dupe events
 			eventsToSend.forEach((event, idx) => {
-				let newEvent: BeaconEvent = Object.assign({}, event);
+				const newEvent: BeaconEvent = Object.assign({}, event);
 				delete newEvent.id;
 				delete newEvent.pid;
 				if (stringyEventsClone.indexOf(JSON.stringify(newEvent)) == -1) {

--- a/packages/snap-url-manager/src/Translators/Url/UrlTranslator.ts
+++ b/packages/snap-url-manager/src/Translators/Url/UrlTranslator.ts
@@ -1,6 +1,6 @@
 import deepmerge from 'deepmerge';
 
-import { UrlState, Translator, TranslatorConfig, UrlStateSort, RangeValueProperties, UrlStateFilterType, ParamLocationType } from '../../types';
+import { UrlState, Translator, TranslatorConfig, RangeValueProperties, UrlStateFilterType, ParamLocationType } from '../../types';
 
 type UrlParameter = {
 	key: Array<string>;


### PR DESCRIPTION
It was noticed that theming was not working for the `<Result/>` component from Autocomplete.

The `<Results/>` component was not properly merging the `displaySettings` props theme with the theme main props theme.

After looking into this though, I am a bit concerned about the way we are handling the `globalTheme` component props - seems that we would want to "deepmerge" these as well to achieve our future templating goals