### PR TITLE
Results Theme

### DIFF
--- a/packages/snap-preact-components/src/components/Organisms/Results/Results.tsx
+++ b/packages/snap-preact-components/src/components/Organisms/Results/Results.tsx
@@ -4,6 +4,7 @@ import { Fragment, h } from 'preact';
 import { observer } from 'mobx-react-lite';
 import { jsx, css } from '@emotion/react';
 import classnames from 'classnames';
+import deepmerge from 'deepmerge';
 
 import type { SearchController, AutocompleteController, RecommendationController } from '@searchspring/snap-controller';
 import type { SearchResultStore, Product, Banner } from '@searchspring/snap-store-mobx';
@@ -81,13 +82,14 @@ export const Results = observer((properties: ResultsProp): JSX.Element => {
 		...properties.theme?.components?.results,
 	};
 
-	const displaySettings = useDisplaySettings(props.breakpoints!);
-	if (displaySettings && Object.keys(displaySettings).length) {
-		props = {
-			...props,
-			...displaySettings,
-		};
-	}
+	const displaySettings = useDisplaySettings(props?.breakpoints || {});
+	const theme = deepmerge(props?.theme || {}, displaySettings?.theme || {});
+
+	props = {
+		...props,
+		...displaySettings,
+		theme,
+	};
 
 	const { disableStyles, className, layout, style, controller } = props;
 


### PR DESCRIPTION
It was noticed that theming was not working for the `<Result/>` component from Autocomplete.

The `<Results/>` component was not properly merging the `displaySettings` props theme with the theme main props theme.

After looking into this though, I am a bit concerned about the way we are handling the `globalTheme` component props - seems that we would want to "deepmerge" these as well to achieve our future templating goals.

Below is an example Autocomplete component using a theme that was previously not working as expected until this change:
```
import { h, Component } from 'preact';
import { observer } from 'mobx-react';

import { Autocomplete as LibraryAutocomplete } from '@searchspring/snap-preact-components';

type AutocompleteProps = {
	controller?: AutocompleteController;
};

@observer
export class Autocomplete extends Component<AutocompleteProps> {
	render() {
		const controller = this.props.controller;

		const theme = {
			components: {
				result: {
					hidePricing: true,
					detailSlot: <span>stock details</span>,
				},
			},
		};

		const breakpoints = {
			0: {
				columns: 1,
				rows: 1,
				hideHistory: true,
				hideTrending: true,
				theme: {
					components: {
						result: {
							detailSlot: <span>bp 0</span>,
						},
					},
				}
			},
			320: {
				columns: 2,
				rows: 1,
				vertical: true,
				hideHistory: true,
				hideTrending: true,
				theme: {
					components: {
						result: {
							detailSlot: <span>bp 320</span>,
						},
					},
				}
			},
			768: {
				columns: 3,
				rows: 1,
				layout: 'list',
				theme: {
					components: {
						result: {
							detailSlot: <span>bp 768</span>,
						},
					},
				}
			},
			1200: {
				width: 'auto',
				columns: 2,
				rows: 2,
				theme: {
					components: {
						result: {
							hidePricing: false,
							detailSlot: <span>bp 1200</span>,
						},
					},
				}
			},
		};

		return <LibraryAutocomplete controller={controller} input={controller.config.selector} breakpoints={breakpoints} theme={theme} />;
	}
}

```