### PR TITLE
Un-observe `pageSizeOptions`

### DIFF
--- a/packages/snap-preact-demo/src/index.ts
+++ b/packages/snap-preact-demo/src/index.ts
@@ -70,6 +70,26 @@ let config: SnapConfig = {
 						restorePosition: {
 							enabled: true,
 						},
+						pagination: {
+							pageSizeOptions: [
+								{
+									value: 12,
+									label: 'Show 12',
+								},
+								{
+									value: 24,
+									label: 'Show 24',
+								},
+								{
+									value: 48,
+									label: 'Show 48',
+								},
+								{
+									value: 72,
+									label: 'Show 72',
+								},
+							],
+						},
 					},
 				},
 				targeters: [

--- a/packages/snap-store-mobx/src/Search/Stores/SearchPaginationStore.ts
+++ b/packages/snap-store-mobx/src/Search/Stores/SearchPaginationStore.ts
@@ -60,7 +60,6 @@ export class SearchPaginationStore {
 		);
 
 		makeObservable(this, {
-			pageSizeOptions: observable,
 			page: observable,
 			pageSize: observable,
 			totalResults: observable,


### PR DESCRIPTION
This caused issues with sites that are replacing the value of `store.pagination.pageSizeOptions` - this change allows us to move forward with our enhancements to the pageSizeOptions.