### PR TITLE
sort search transform refactor

### DIFF
--- a/packages/snap-client/src/Client/transforms/searchRequest.test.ts
+++ b/packages/snap-client/src/Client/transforms/searchRequest.test.ts
@@ -57,12 +57,16 @@ describe('search request sort transform', () => {
 		expect(params).toEqual({});
 	});
 
-	it('throws if params invalid', () => {
-		expect(() => transformSearchRequest.sorts({ sorts: [{ field: 'a_field' }] })).toThrow();
-		expect(() => transformSearchRequest.sorts({ sorts: [{ direction: 'desc' as any }] })).toThrow();
-
+	it('returns empty object if params are invalid', () => {
+		//missing field or direction
+		const params1 = transformSearchRequest.sorts({ sorts: [{ field: 'a_field' }] });
+		const params2 = transformSearchRequest.sorts({ sorts: [{ direction: 'desc' as any }] });
 		// incorrect direction
-		expect(() => transformSearchRequest.sorts({ sorts: [{ field: 'a_field', direction: 'descending' as any }] })).toThrow();
+		const params3 = transformSearchRequest.sorts({ sorts: [{ field: 'a_field', direction: 'descending' as any }] });
+
+		expect(params1).toEqual({});
+		expect(params2).toEqual({});
+		expect(params3).toEqual({});
 	});
 });
 

--- a/packages/snap-client/src/Client/transforms/searchRequest.ts
+++ b/packages/snap-client/src/Client/transforms/searchRequest.ts
@@ -29,12 +29,10 @@ transformSearchRequest.sorts = (request: SearchRequestModel = {}) => {
 		}
 
 		if (!sort.field || !sort.direction) {
-			console.warn('valid sort requires field and direction');
 			return {};
 		}
 
 		if (sort.direction != 'asc' && sort.direction != 'desc') {
-			console.warn(`invalid sort direction used: ${sort.direction} - valid sort directions are: asc, desc`);
 			return {};
 		}
 

--- a/packages/snap-client/src/Client/transforms/searchRequest.ts
+++ b/packages/snap-client/src/Client/transforms/searchRequest.ts
@@ -24,16 +24,8 @@ export function transformSearchRequest(request: SearchRequestModel): any {
 
 transformSearchRequest.sorts = (request: SearchRequestModel = {}) => {
 	return (request.sorts || []).reduce((acc: Record<string, Array<SearchRequestModelSortsDirectionEnum>>, sort: SearchRequestModelSorts) => {
-		if (!sort.field && !sort.direction) {
+		if (!sort.field || !sort.direction || (sort.direction != 'asc' && sort.direction != 'desc')) {
 			return acc;
-		}
-
-		if (!sort.field || !sort.direction) {
-			return {};
-		}
-
-		if (sort.direction != 'asc' && sort.direction != 'desc') {
-			return {};
 		}
 
 		return {

--- a/packages/snap-client/src/Client/transforms/searchRequest.ts
+++ b/packages/snap-client/src/Client/transforms/searchRequest.ts
@@ -29,11 +29,13 @@ transformSearchRequest.sorts = (request: SearchRequestModel = {}) => {
 		}
 
 		if (!sort.field || !sort.direction) {
-			throw 'valid sort requires field and direction';
+			console.warn('valid sort requires field and direction');
+			return {};
 		}
 
 		if (sort.direction != 'asc' && sort.direction != 'desc') {
-			throw 'valid sort directions: asc, desc';
+			console.warn(`invalid sort direction used: ${sort.direction} - valid sort directions are: asc, desc`);
+			return {};
 		}
 
 		return {


### PR DESCRIPTION
…
dont throw when incorrect params are passed to sort transform. instead log a warning and fallback to default sort and continue.