### PR TITLE
Addressing `restorePosition` Issues

### DIFF
--- a/packages/snap-controller/src/Search/README.md
+++ b/packages/snap-controller/src/Search/README.md
@@ -115,7 +115,7 @@ const searchConfig = {
 For example, if `config.settings.infinite.backfill` contains a value of `5` and the user has paginated to page `4` and reloads the page, `4` pages of results will be shown. However, if the user has paginated to page `6` or above and reloads the page, only page `1` results will be shown. 
 
 ### Restore Position
-Any time you navigate back to a previous page, this setting will tell the controller to attempt to scroll to the previous position on the page. The restore position algorithm uses a selector that was stored when tracking the product that was clicked (`track.product.click()`) - this saves the product href, selector and domRect position details. This configuration can be disabled and left entirely up to the browser by setting `restorePosition.enabled` to `false` (the default setting).
+Any time you navigate back to a previous page, this setting will tell the controller to attempt to scroll to the previous position on the page. The restore position algorithm uses a selector that was stored when tracking the product that was clicked (`track.product.click()`) - this saves the product href, selector and domRect position details. For this to work properly, it is important that each product has a unique URL assigned to it in `mappings.core.url`. The functionality was made to work out of the box on many types of sites, but if it does not work, it can be disabled and left entirely up to the browser by setting `restorePosition.enabled` to `false` (the default setting unless using `config.settings.infinite`).
 
 When using infinite scroll, it is recommended to specify a value for `config.settings.infinite.backfill` to ensure that when returning to the product listing page, that the product is there to scroll to.
 

--- a/packages/snap-controller/src/Search/SearchController.ts
+++ b/packages/snap-controller/src/Search/SearchController.ts
@@ -136,9 +136,8 @@ export class SearchController extends AbstractController {
 			this.eventManager.on('restorePosition', async ({ controller, element }: RestorePositionObj, next: Next) => {
 				const scrollToPosition = () => {
 					return new Promise<void>(async (resolve) => {
-						let offset = element?.domRect?.top || 0;
 						const maxCheckTime = 500;
-						const checkTime = 25;
+						const checkTime = 50;
 						const maxScrolls = Math.ceil(maxCheckTime / checkTime);
 						const maxCheckCount = maxScrolls + 2;
 
@@ -147,10 +146,11 @@ export class SearchController extends AbstractController {
 						let scrolledElem: Element | undefined = undefined;
 
 						const checkAndScroll = () => {
+							let offset = element?.domRect?.top || 0;
 							let elem = document.querySelector(element?.selector!);
 
 							// for case where the element clicked on has no height
-							while (elem && !elem.clientHeight) {
+							while (elem && !elem.getBoundingClientRect().height) {
 								elem = elem.parentElement;
 								// original offset no longer applies since using different element
 								offset = 0;
@@ -165,9 +165,8 @@ export class SearchController extends AbstractController {
 								if (y > offset + 1 || y < offset - 1) {
 									window.scrollBy(0, y - offset);
 								} else {
-									scrolledElem = elem;
 									// don't need to scroll - it is right where we want it
-									return true;
+									scrolledElem = elem;
 								}
 							} else {
 								checkCount++;

--- a/packages/snap-controller/src/Search/SearchController.ts
+++ b/packages/snap-controller/src/Search/SearchController.ts
@@ -136,9 +136,9 @@ export class SearchController extends AbstractController {
 			this.eventManager.on('restorePosition', async ({ controller, element }: RestorePositionObj, next: Next) => {
 				const scrollToPosition = () => {
 					return new Promise<void>(async (resolve) => {
-						const offset = element?.domRect?.top || 0;
+						let offset = element?.domRect?.top || 0;
 						const maxCheckTime = 500;
-						const checkTime = 50;
+						const checkTime = 25;
 						const maxScrolls = Math.ceil(maxCheckTime / checkTime);
 						const maxCheckCount = maxScrolls + 2;
 
@@ -147,39 +147,43 @@ export class SearchController extends AbstractController {
 						let scrolledElem: Element | undefined = undefined;
 
 						const checkAndScroll = () => {
-							const elem = document.querySelector(element?.selector!);
-							if (elem) {
-								scrollBackCount++;
-							} else {
-								checkCount++;
+							let elem = document.querySelector(element?.selector!);
+
+							// for case where the element clicked on has no height
+							while (elem && !elem.clientHeight) {
+								elem = elem.parentElement;
+								// original offset no longer applies since using different element
+								offset = 0;
 							}
 
 							if (elem) {
 								const { y } = elem.getBoundingClientRect();
 
+								scrollBackCount++;
+
 								// if the offset is off, we need to scroll into position (can be caused by lazy loaded images)
 								if (y > offset + 1 || y < offset - 1) {
-									elem.scrollIntoView();
-									// after scrolling into view, use top value with offset (for when element at bottom)
-									const { top } = elem.getBoundingClientRect();
-									window.scrollBy(0, -(offset - top));
+									window.scrollBy(0, y - offset);
+								} else {
 									scrolledElem = elem;
-
+									// don't need to scroll - it is right where we want it
 									return true;
 								}
+							} else {
+								checkCount++;
 							}
 
-							return false;
+							return true;
 						};
 
-						while (checkAndScroll() || (scrollBackCount <= maxScrolls && checkCount <= maxCheckCount)) {
+						while (checkAndScroll() && scrollBackCount <= maxScrolls && checkCount <= maxCheckCount) {
 							await new Promise((resolve) => setTimeout(resolve, checkTime));
 						}
 
 						if (scrolledElem) {
 							controller.log.debug('restored position to: ', scrolledElem);
 						} else {
-							controller.log.debug('could not locate element with selector: ', element?.selector);
+							controller.log.debug('attempted to scroll back to element with selector: ', element?.selector);
 						}
 
 						resolve();


### PR DESCRIPTION
Some sites where the element clicked on had issues where we would never give up trying to scroll to the element - this was because the element had zero height. In those cases we not only never gave up, but we didn't know where to scroll to. To address this issue logic has been added that will check for element height on each execution of the `scrollToPosition` function; if a height is not found for the original element, we will fallback to using it's parent element until we find an element with a height.

Another issue solved by this PR is one involving slow scrollTo position animation. Sometimes the animation would take a very long time due to CSS styling on the element container. This has been bypassed by using `window.scrollBy` instead of `element.scrollIntoView`. In most cases, the change makes the repositioning instant instead of animated.

A final change to the logic revolves around when we give up scrolling to where we want to go. Previously the logging was a little flaky around this - now the logging will inform you when restoration has occurred vs. when we attempted (but gave up).