### PR TITLE
Removing Observer from `cloneWithProps`

### DIFF
--- a/packages/snap-preact-components/src/utilities/cloneWithProps.tsx
+++ b/packages/snap-preact-components/src/utilities/cloneWithProps.tsx
@@ -1,7 +1,7 @@
 import { h, cloneElement } from 'preact';
 import { observer } from 'mobx-react-lite';
 
-export const cloneWithProps = (input: any, props?: any): any => {
+export const cloneWithProps = (input: any, props?: any, observable?: boolean): any => {
 	if (!input) {
 		return;
 	} else if (typeof input == 'string' || typeof input == 'number' || typeof input == 'boolean') {
@@ -12,9 +12,13 @@ export const cloneWithProps = (input: any, props?: any): any => {
 		});
 	}
 
-	const ObservableClone = observer((properties) => {
-		return cloneElement(input, properties);
-	});
+	if (observable) {
+		const ObservableClone = observer((properties) => {
+			return cloneElement(input, properties);
+		});
 
-	return <ObservableClone {...props} />;
+		return <ObservableClone {...props} />;
+	}
+
+	return cloneElement(input, props);
 };

--- a/packages/snap-preact-components/src/utilities/cloneWithProps.tsx
+++ b/packages/snap-preact-components/src/utilities/cloneWithProps.tsx
@@ -1,7 +1,6 @@
 import { h, cloneElement } from 'preact';
-import { observer } from 'mobx-react-lite';
 
-export const cloneWithProps = (input: any, props?: any, observable?: boolean): any => {
+export const cloneWithProps = (input: any, props?: any): any => {
 	if (!input) {
 		return;
 	} else if (typeof input == 'string' || typeof input == 'number' || typeof input == 'boolean') {
@@ -10,14 +9,6 @@ export const cloneWithProps = (input: any, props?: any, observable?: boolean): a
 		return input.map((entry) => {
 			return cloneWithProps(entry, props);
 		});
-	}
-
-	if (observable) {
-		const ObservableClone = observer((properties) => {
-			return cloneElement(input, properties);
-		});
-
-		return <ObservableClone {...props} />;
 	}
 
 	return cloneElement(input, props);


### PR DESCRIPTION
The change made in v0.43.0 for this was breaking component functionality - any component that needs to be observer should be passed into slots as such.