### PR TITLE
Template `resultComponent` Usage

### DIFF
--- a/packages/snap-preact-components/src/components/Organisms/Results/Results.tsx
+++ b/packages/snap-preact-components/src/components/Organisms/Results/Results.tsx
@@ -11,7 +11,7 @@ import type { SearchResultStore, Product, Banner } from '@searchspring/snap-stor
 import { ContentType } from '@searchspring/snap-store-mobx';
 import { InlineBanner, InlineBannerProps } from '../../Atoms/Merchandising/InlineBanner';
 import { Result, ResultProps } from '../../Molecules/Result';
-import { ComponentProps, ResultsLayout, ResultsLayoutType, BreakpointsProps, StylingCSS } from '../../../types';
+import { ComponentProps, ResultsLayout, ResultsLayoutType, BreakpointsProps, StylingCSS, ResultComponent } from '../../../types';
 import { defined, mergeProps } from '../../../utilities';
 import { Theme, useTheme, CacheProvider } from '../../../providers';
 import { useDisplaySettings } from '../../../hooks/useDisplaySettings';
@@ -89,7 +89,7 @@ export const Results = observer((properties: ResultsProps): JSX.Element => {
 		theme,
 	};
 
-	const { disableStyles, className, layout, style, styleScript, resultLayout, controller } = props;
+	const { disableStyles, resultComponent, className, layout, style, styleScript, resultLayout, controller } = props;
 
 	const subProps: ResultsSubProps = {
 		result: {
@@ -143,8 +143,12 @@ export const Results = observer((properties: ResultsProps): JSX.Element => {
 							case ContentType.BANNER:
 								return <InlineBanner {...subProps.inlineBanner} key={result.id} banner={result as Banner} layout={props.layout} />;
 							default:
-								if (resultLayout && controller) {
-									return <ResultLayout controller={controller} result={result} layout={resultLayout} theme={theme} />;
+								// TODO: wrap with SearchResultTracker component (need to create)
+								if (resultComponent && controller) {
+									const ResultComponent = resultComponent;
+									return <ResultComponent controller={controller} result={result} />;
+								} else if (resultLayout && controller) {
+									return <ResultLayout controller={controller} result={result} layout={resultLayout} />;
 								} else {
 									return (
 										<Result
@@ -175,6 +179,7 @@ export interface ResultsProps extends ComponentProps {
 	breakpoints?: BreakpointsProps;
 	controller?: SearchController | AutocompleteController | RecommendationController;
 	resultLayout?: ResultLayoutTypes;
+	resultComponent?: ResultComponent;
 }
 
 interface ResultsSubProps {

--- a/packages/snap-preact-components/src/components/Templates/Autocomplete/Autocomplete.tsx
+++ b/packages/snap-preact-components/src/components/Templates/Autocomplete/Autocomplete.tsx
@@ -17,7 +17,7 @@ import { Facets, FacetsProps } from '../../Organisms/Facets';
 import { defined, cloneWithProps, mergeProps, combineMerge } from '../../../utilities';
 import { createHoverProps } from '../../../toolbox';
 import { Theme, useTheme, CacheProvider, ThemeProvider } from '../../../providers';
-import { ComponentProps, FacetDisplay, BreakpointsProps, StylingCSS } from '../../../types';
+import { ComponentProps, FacetDisplay, BreakpointsProps, StylingCSS, ResultComponent } from '../../../types';
 import { buildThemeBreakpointsObject, useDisplaySettings } from '../../../hooks/useDisplaySettings';
 import { ResultLayoutTypes } from '../../Layouts/ResultLayout';
 
@@ -319,6 +319,7 @@ export const Autocomplete = observer((properties: AutocompleteProps): JSX.Elemen
 		noResultsSlot,
 		linkSlot,
 		resultLayout,
+		resultComponent,
 		onTermClick,
 		disableStyles,
 		className,
@@ -352,6 +353,7 @@ export const Autocomplete = observer((properties: AutocompleteProps): JSX.Elemen
 			className: 'ss__autocomplete__results',
 			breakpoints: props.breakpoints,
 			resultLayout: resultLayout,
+			resultComponent: resultComponent,
 			// inherited props
 			...defined({
 				disableStyles,
@@ -706,6 +708,7 @@ export interface AutocompleteProps extends ComponentProps {
 	breakpoints?: BreakpointsProps;
 	width?: string;
 	resultLayout?: ResultLayoutTypes;
+	resultComponent?: ResultComponent;
 	onFacetOptionClick?: (e: React.MouseEvent<Element, MouseEvent>) => void;
 	onTermClick?: (e: React.MouseEvent<Element, MouseEvent>) => void;
 }

--- a/packages/snap-preact-components/src/components/Templates/Recommendation/Recommendation.tsx
+++ b/packages/snap-preact-components/src/components/Templates/Recommendation/Recommendation.tsx
@@ -13,7 +13,7 @@ import { Carousel, CarouselProps, defaultCarouselBreakpoints, defaultVerticalCar
 import { Result, ResultProps } from '../../Molecules/Result';
 import { combineMerge, defined, mergeProps } from '../../../utilities';
 import { Theme, useTheme, CacheProvider, ThemeProvider } from '../../../providers';
-import { ComponentProps, BreakpointsProps, StylingCSS } from '../../../types';
+import { ComponentProps, BreakpointsProps, StylingCSS, ResultComponent } from '../../../types';
 import { buildThemeBreakpointsObject, useDisplaySettings } from '../../../hooks/useDisplaySettings';
 import { RecommendationProfileTracker } from '../../Trackers/Recommendation/ProfileTracker';
 import { RecommendationResultTracker } from '../../Trackers/Recommendation/ResultTracker';
@@ -81,6 +81,7 @@ export const Recommendation = observer((properties: RecommendationProps): JSX.El
 		prevButton,
 		hideButtons,
 		resultLayout,
+		resultComponent,
 		disableStyles,
 		style,
 		className,
@@ -162,11 +163,16 @@ export const Recommendation = observer((properties: RecommendationProps): JSX.El
 								  ))
 								: resultsToRender.map((result) => (
 										<RecommendationResultTracker controller={controller} result={result}>
-											{resultLayout && controller ? (
-												<ResultLayout {...subProps.result} controller={controller} result={result} layout={resultLayout} />
-											) : (
-												<Result {...subProps.result} controller={controller} result={result} />
-											)}
+											{(() => {
+												if (resultComponent && controller) {
+													const ResultComponent = resultComponent;
+													return <ResultComponent controller={controller} result={result} />;
+												} else if (resultLayout && controller) {
+													return <ResultLayout controller={controller} result={result} layout={resultLayout} />;
+												} else {
+													return <Result key={result.id} {...subProps.result} controller={controller} result={result} />;
+												}
+											})()}
 										</RecommendationResultTracker>
 								  ))}
 						</Carousel>
@@ -192,6 +198,7 @@ export type RecommendationProps = {
 	children?: ComponentChildren;
 	vertical?: boolean;
 	resultLayout?: ResultLayoutTypes;
+	resultComponent?: ResultComponent;
 } & Omit<SwiperOptions, 'breakpoints'> &
 	ComponentProps;
 

--- a/packages/snap-preact-components/src/components/Templates/Search/Search.tsx
+++ b/packages/snap-preact-components/src/components/Templates/Search/Search.tsx
@@ -10,7 +10,7 @@ import type { SearchController } from '@searchspring/snap-controller';
 
 import { Results, ResultsProps } from '../../Organisms/Results';
 import { combineMerge, defined, mergeProps } from '../../../utilities';
-import { ComponentProps, StylingCSS } from '../../../types';
+import { ComponentProps, ResultComponent, StylingCSS } from '../../../types';
 import { Theme, useTheme, CacheProvider, ThemeProvider } from '../../../providers';
 import { Sidebar, SidebarProps } from '../../Organisms/Sidebar';
 import { Toolbar, ToolbarProps } from '../../Organisms/Toolbar';
@@ -79,6 +79,7 @@ export const Search = observer((properties: SearchProps): JSX.Element => {
 		styleScript,
 		hideSidebar,
 		resultLayout,
+		resultComponent,
 		hidetopToolBar,
 		hideBottomToolBar,
 		slideOutToggleWidth,
@@ -143,6 +144,7 @@ export const Search = observer((properties: SearchProps): JSX.Element => {
 		Results: {
 			// default props
 			resultLayout: resultLayout,
+			resultComponent: resultComponent,
 			// inherited props
 			...defined({
 				disableStyles,
@@ -217,6 +219,7 @@ export interface SearchProps extends ComponentProps {
 	controller: SearchController;
 	slideOutToggleWidth?: string;
 	resultLayout?: ResultLayoutTypes;
+	resultComponent?: ResultComponent;
 	hideSidebar?: boolean;
 	hidetopToolBar?: boolean;
 	hideBottomToolBar?: boolean;

--- a/packages/snap-preact-components/src/types.ts
+++ b/packages/snap-preact-components/src/types.ts
@@ -1,6 +1,7 @@
-import { SerializedStyles } from '@emotion/react';
-import { Theme } from './providers/theme';
+import type { SerializedStyles } from '@emotion/react';
+import type { Theme } from './providers/theme';
 import type { AbstractController } from '@searchspring/snap-controller';
+import type { Product } from '@searchspring/snap-store-mobx';
 
 export interface ComponentProps {
 	name?: string;
@@ -11,6 +12,12 @@ export interface ComponentProps {
 	theme?: Theme;
 	controller?: AbstractController;
 }
+
+export type ResultComponent = React.FunctionComponent<{
+	controller: AbstractController;
+	result: Product;
+	theme?: Theme;
+}>;
 
 export enum ResultsLayout {
 	GRID = 'grid',

--- a/packages/snap-preact-layout-demo/babel.config.js
+++ b/packages/snap-preact-layout-demo/babel.config.js
@@ -11,7 +11,25 @@ module.exports = (api) => {
 					corejs: '3.19',
 				},
 			],
+			['@babel/preset-react'],
 		],
-		plugins: [['@babel/plugin-transform-runtime'], ['@babel/plugin-transform-arrow-functions']],
+		plugins: [
+			['@babel/plugin-transform-runtime'],
+			[
+				'@babel/plugin-proposal-decorators',
+				{
+					legacy: true,
+				},
+			],
+			['@babel/plugin-proposal-class-properties'],
+			[
+				'@babel/plugin-transform-react-jsx',
+				{
+					pragma: 'h',
+					pragmaFrag: 'Fragment',
+				},
+			],
+			['@babel/plugin-transform-arrow-functions'],
+		],
 	};
 };

--- a/packages/snap-preact-layout-demo/src/components/Result.tsx
+++ b/packages/snap-preact-layout-demo/src/components/Result.tsx
@@ -1,0 +1,38 @@
+import { h, Fragment } from 'preact';
+import { Price, Image } from '@searchspring/snap-preact-components';
+
+export const Result: ResultComponent = (props) => {
+	const { result } = props;
+	const core = result.mappings.core;
+
+	return (
+		<article className="ss__result">
+			<div className="ss__result__image-wrapper">
+				<a href={core.url}>
+					<Image src={core.thumbnailImageUrl} alt={core.name} />
+				</a>
+			</div>
+			<div className="ss__result__details">
+				<div className="ss__result__details__title">
+					<a
+						href={core.url}
+						dangerouslySetInnerHTML={{
+							__html: core.name,
+						}}
+					/>
+				</div>
+
+				<div className="ss__result__details__pricing">
+					{core.price < core.msrp ? (
+						<Fragment>
+							<Price value={core.msrp} lineThrough={true} />
+							<Price value={core.price} />
+						</Fragment>
+					) : (
+						<Price value={core.price} />
+					)}
+				</div>
+			</div>
+		</article>
+	);
+};

--- a/packages/snap-preact-layout-demo/src/index.ts
+++ b/packages/snap-preact-layout-demo/src/index.ts
@@ -1,5 +1,6 @@
 import { SnapTemplate } from '@searchspring/snap-preact';
-import { resultLayout } from './resultLayout';
+// import { resultLayout } from './resultLayout';
+import { Result } from './components/Result';
 
 /*
 	brainstorming...
@@ -53,7 +54,8 @@ new SnapTemplate({
 			{
 				selector: '#searchspring-layout',
 				template: 'Search',
-				resultLayout: resultLayout,
+				// resultLayout: resultLayout,
+				resultComponent: Result,
 			},
 		],
 	},
@@ -65,7 +67,8 @@ new SnapTemplate({
 			{
 				component: 'Recs',
 				template: 'Recommendation',
-				resultLayout: resultLayout,
+				// resultLayout: resultLayout,
+				resultComponent: Result,
 			},
 		],
 	},
@@ -75,7 +78,8 @@ new SnapTemplate({
 			{
 				selector: 'input.searchspring-ac',
 				template: 'Autocomplete',
-				resultLayout: resultLayout,
+				// resultLayout: resultLayout,
+				resultComponent: Result,
 			},
 		],
 	},

--- a/packages/snap-preact-layout-demo/src/types.ts
+++ b/packages/snap-preact-layout-demo/src/types.ts
@@ -37,6 +37,10 @@ declare global {
 	type Next = EventManagerTypes.Next;
 	type Middleware<T> = EventManagerTypes.Middleware<T>;
 
+	// component types
+	type Theme = ComponentTypes.Theme;
+	type ResultComponent = ComponentTypes.ResultComponent;
+
 	// window globals
 	interface Window {
 		mergeSnapConfig?: any;

--- a/packages/snap-preact-layout-demo/tsconfig.json
+++ b/packages/snap-preact-layout-demo/tsconfig.json
@@ -5,7 +5,11 @@
 		"sourceMap": true,
 		"declaration": false,
 		"declarationMap": false,
-		"strict": true,
+		"jsx": "react-jsx",
+		"jsxImportSource": "preact",
+		"experimentalDecorators": true,
+		"useDefineForClassFields": true,
+		"strict": false,
 	},
 	"include": [
 		"src"

--- a/packages/snap-preact-layout-demo/webpack.common.js
+++ b/packages/snap-preact-layout-demo/webpack.common.js
@@ -24,14 +24,52 @@ module.exports = {
 	module: {
 		rules: [
 			{
-				test: /\.ts$/,
+				test: /\.tsx?$/,
 				use: 'ts-loader',
 				exclude: /node_modules/,
+			},
+			{
+				test: /\.(css|scss)$/,
+				exclude: /\.module\.(css|scss)$/,
+				use: [
+					{
+						loader: 'style-loader',
+						options: {
+							attributes: { class: styleClass },
+						},
+					},
+					'css-loader',
+					'sass-loader',
+				],
+			},
+			{
+				test: /\.module\.(css|scss)$/,
+				use: [
+					{
+						loader: 'style-loader',
+						options: {
+							attributes: { class: styleClass },
+						},
+					},
+					{
+						loader: 'css-loader',
+						options: {
+							modules: {
+								localIdentName: '[local]--[hash:base64:5]',
+							},
+						},
+					},
+					'sass-loader',
+				],
+			},
+			{
+				test: /\.(png|svg)$/,
+				use: ['file-loader'],
 			},
 		],
 	},
 	resolve: {
-		extensions: ['.ts', '.js'],
+		extensions: ['.js', '.jsx', '.ts', '.tsx'],
 		alias: {
 			react: 'preact/compat',
 			'react-dom/test-utils': 'preact/test-utils',

--- a/packages/snap-preact-layout-demo/webpack.dev.js
+++ b/packages/snap-preact-layout-demo/webpack.dev.js
@@ -13,7 +13,7 @@ const universal = merge(common, {
 	module: {
 		rules: [
 			{
-				test: /\.(js)$/,
+				test: /\.(js|jsx)$/,
 				include: [/node_modules\/@searchspring/, path.resolve(__dirname, 'src'), path.resolve(__dirname, '../')],
 				use: {
 					loader: 'babel-loader',
@@ -45,7 +45,7 @@ const modern = merge(common, {
 	module: {
 		rules: [
 			{
-				test: /\.(js)$/,
+				test: /\.(js|jsx)$/,
 				exclude: /node_modules/,
 				use: {
 					loader: 'babel-loader',

--- a/packages/snap-preact-layout-demo/webpack.modern.js
+++ b/packages/snap-preact-layout-demo/webpack.modern.js
@@ -16,7 +16,7 @@ module.exports = merge(common, {
 	module: {
 		rules: [
 			{
-				test: /\.(js)$/,
+				test: /\.(js|jsx)$/,
 				use: {
 					loader: 'babel-loader',
 					options: {
@@ -36,7 +36,7 @@ module.exports = merge(common, {
 	devServer: {
 		client: false,
 		server: 'https',
-		port: 2222,
+		port: 1111,
 		hot: false,
 		allowedHosts: 'all',
 		headers: {

--- a/packages/snap-preact-layout-demo/webpack.universal.js
+++ b/packages/snap-preact-layout-demo/webpack.universal.js
@@ -16,7 +16,7 @@ module.exports = merge(common, {
 	module: {
 		rules: [
 			{
-				test: /\.(js)$/,
+				test: /\.(js|jsx)$/,
 				include: [/node_modules\/@searchspring/, path.resolve(__dirname, 'src'), path.resolve(__dirname, '../')],
 				use: {
 					loader: 'babel-loader',

--- a/packages/snap-preact/src/Templates/SnapTemplate.tsx
+++ b/packages/snap-preact/src/Templates/SnapTemplate.tsx
@@ -8,7 +8,7 @@ import { componentMap } from './components';
 import type { SearchStoreConfigSettings, AutocompleteStoreConfigSettings } from '@searchspring/snap-store-mobx';
 import type { UrlTranslatorConfig } from '@searchspring/snap-url-manager';
 import type { RecommendationInstantiatorConfigSettings, RecommendationComponentObject } from '../Instantiators/RecommendationInstantiator';
-import type { ResultLayoutTypes } from '@searchspring/snap-preact-components';
+import type { ResultComponent, ResultLayoutTypes } from '@searchspring/snap-preact-components';
 import type { TemplateThemeConfig } from './themes';
 import type { SnapFeatures } from '../types';
 import type { SnapConfig, ExtendedTarget } from '../Snap';
@@ -19,6 +19,7 @@ type SearchTemplateConfig = {
 	theme?: TemplateThemeConfig;
 	template: 'Search';
 	resultLayout?: ResultLayoutTypes;
+	resultComponent?: ResultComponent;
 };
 
 type AutocompleteTemplateConfig = {
@@ -26,6 +27,7 @@ type AutocompleteTemplateConfig = {
 	theme?: TemplateThemeConfig;
 	template: 'Autocomplete';
 	resultLayout?: ResultLayoutTypes;
+	resultComponent?: ResultComponent;
 };
 
 type RecommendationTemplateConfig = {
@@ -33,6 +35,7 @@ type RecommendationTemplateConfig = {
 	theme?: TemplateThemeConfig;
 	template: 'Recommendation';
 	resultLayout?: ResultLayoutTypes;
+	resultComponent?: ResultComponent;
 };
 
 export type SnapTemplateConfig = {
@@ -108,7 +111,12 @@ export const createSearchTargeters = (templateConfig: SnapTemplateConfig): Exten
 		};
 
 		// if they are not undefined, add them
-		if (template.resultLayout) targeter.props = { resultLayout: template.resultLayout };
+		if (template.resultComponent) {
+			targeter.props = { resultComponent: template.resultComponent };
+		} else if (template.resultLayout) {
+			targeter.props = { resultLayout: template.resultLayout };
+		}
+
 		const variables = template.theme?.variables || templateConfig.config.theme.variables;
 		if (variables && targeter.theme) targeter.theme.variables = variables;
 		const overrides = template.theme?.overrides || templateConfig.config.theme.overrides;
@@ -132,7 +140,11 @@ export function createAutocompleteTargeters(templateConfig: SnapTemplateConfig):
 		};
 
 		// if they are not undefined, add them
-		if (template.resultLayout) targeter.props = { resultLayout: template.resultLayout };
+		if (template.resultComponent) {
+			targeter.props = { resultComponent: template.resultComponent };
+		} else if (template.resultLayout) {
+			targeter.props = { resultLayout: template.resultLayout };
+		}
 		const variables = template.theme?.variables || templateConfig.config.theme.variables;
 		if (variables && targeter.theme) targeter.theme.variables = variables;
 		const overrides = template.theme?.overrides || templateConfig.config.theme.overrides;
@@ -155,7 +167,11 @@ export function createRecommendationComponentMapping(templateConfig: SnapTemplat
 				};
 
 				// if they are not undefined, add them
-				if (template.resultLayout) mapping[template.component].props = { resultLayout: template.resultLayout };
+				if (template.resultComponent) {
+					mapping[template.component].props = { resultComponent: template.resultComponent };
+				} else if (template.resultLayout) {
+					mapping[template.component].props = { resultLayout: template.resultLayout };
+				}
 				const theme = mapping[template.component].theme;
 				const variables = template.theme?.variables || templateConfig.config.theme.variables;
 				if (variables && theme) theme.variables = variables;


### PR DESCRIPTION
* adding support of `resultComponent` usage in templates and other components
* leaving code for `resultLayout` props for now
* still need to add testing and documentation