### PR TITLE
Docs Quick Fixes

### DIFF
--- a/docs/documents.js
+++ b/docs/documents.js
@@ -492,6 +492,13 @@ var documents = [
 						searchable: true,
 					},
 					{
+						label: 'Until',
+						route: '/package-toolbox-until',
+						type: 'markdown',
+						url: './packages/snap-toolbox/src/until/README.md',
+						searchable: true,
+					},
+					{
 						label: 'Typedocs',
 						type: 'external',
 						url: 'https://searchspring.github.io/snap/packages/snap-toolbox/docs/',

--- a/packages/snap-controller/src/Autocomplete/README.md
+++ b/packages/snap-controller/src/Autocomplete/README.md
@@ -20,6 +20,7 @@ The `AutocompleteController` is used when making queries to the API `autocomplet
 | settings.history.limit | when set, historical (previously searched) queries will be fetched and made available in the history store | ➖ |   | 
 | settings.history.showResults | if history limit is set and there is no input, the first term results will be displayed | false |   | 
 | settings.redirects.merchandising | boolean to disable merchandising redirects when ac form is submitted | true |   | 
+| settings.redirects.singleResult | enable redirect to product detail page if search yields 1 result count | true |   |
 
 <br>
 


### PR DESCRIPTION
* adds `until` to navigation bar in docs
* adds setting for singleResult merchandising redirect in autocomplete controller
<img width="1840" alt="image" src="https://github.com/searchspring/snap/assets/5060400/56b237e1-96a2-40f6-bab6-c7cdd2fe5bcd">
