### PR TITLE
Release 0.50.0

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
 <body>
 	<div id="app"></div>
 
-	<script src="https://cdn.jsdelivr.net/npm/vue@next"></script>
+	<script src="https://cdn.jsdelivr.net/npm/vue@3.4.5"></script>
 	<script src="https://cdn.jsdelivr.net/npm/vue-router@4"></script>
 
 	<script>

--- a/packages/snap-controller/src/Search/README.md
+++ b/packages/snap-controller/src/Search/README.md
@@ -21,6 +21,7 @@ The `SearchController` is used when making queries to the API `search` endpoint.
 | settings.infinite | enable infinite scrolling by setting to empty object | ➖ |   |
 | settings.infinite.backfill | number of pages allowed for backfill | ➖ |   |
 | settings.restorePosition.enabled | boolean to enable/disable using `restorePosition` event middleware to restore the window scroll position when navigating back to previous page (when using infinite this is automatically set to true) | false |   |
+| settings.restorePosition.onPageShow | boolean to enable/disable having restorePosition occur on the 'pageshow' window event (requires `restorePosition.enable`) | false |   |
 <br>
 
 ```typescript

--- a/packages/snap-controller/src/Search/SearchController.ts
+++ b/packages/snap-controller/src/Search/SearchController.ts
@@ -134,6 +134,17 @@ export class SearchController extends AbstractController {
 		// restore position
 		if (this.config.settings?.restorePosition?.enabled) {
 			this.eventManager.on('restorePosition', async ({ controller, element }: RestorePositionObj, next: Next) => {
+				// attempt to grab the element from storage if it is not provided
+				if (!element?.selector) {
+					const lastRequest = this.storage.get('lastStringyParams');
+					if (lastRequest) {
+						const storableRequestParams = getStorableRequestParams(JSON.parse(lastRequest));
+						const stringyParams = JSON.stringify(storableRequestParams);
+						const scrollMap: { [key: string]: ElementPositionObj } = this.storage.get('scrollMap') || {};
+						element = scrollMap[stringyParams];
+					}
+				}
+
 				const scrollToPosition = () => {
 					return new Promise<void>(async (resolve) => {
 						const maxCheckTime = 500;
@@ -192,6 +203,13 @@ export class SearchController extends AbstractController {
 				if (element) await scrollToPosition();
 				await next();
 			});
+
+			// fire restorePosition event on 'pageshow' when setting is enabled
+			if (this.config.settings?.restorePosition?.onPageShow) {
+				window.addEventListener('pageshow', () => {
+					this.eventManager.fire('restorePosition', { controller: this, element: {} });
+				});
+			}
 		}
 
 		// attach config plugins and event middleware

--- a/packages/snap-preact-demo/src/index.ts
+++ b/packages/snap-preact-demo/src/index.ts
@@ -17,7 +17,7 @@ import './styles/custom.scss';
 let siteId = '8uyt2m';
 // grab siteId out of the URL
 const urlObj = url(window.location.href);
-const urlSiteIdParam = urlObj.params.query.siteId;
+const urlSiteIdParam = urlObj.params.query.siteId || urlObj.params.query.siteid;
 const storedSiteIdName = 'ss_siteId';
 
 if (urlSiteIdParam && urlSiteIdParam.match(/[a-zA-Z0-9]{6}/)) {

--- a/packages/snap-store-mobx/src/types.ts
+++ b/packages/snap-store-mobx/src/types.ts
@@ -24,6 +24,7 @@ export type SearchStoreConfig = StoreConfig & {
 		};
 		restorePosition?: {
 			enabled: boolean;
+			onPageShow?: boolean;
 		};
 		history?: {
 			url?: string;


### PR DESCRIPTION
Release needed to fix [docs](https://searchspring.github.io/snap) which are currently down due to reliance on external CDN resource.

Release also closes #950 which introduces the `restorePosition.onPageShow` setting.