### PR TITLE
AC Search Refactor

### DIFF
--- a/packages/snap-controller/src/Autocomplete/AutocompleteController.test.ts
+++ b/packages/snap-controller/src/Autocomplete/AutocompleteController.test.ts
@@ -925,7 +925,7 @@ describe('Autocomplete Controller', () => {
 
 		await waitFor(() => {
 			expect(storeResetfn).not.toHaveBeenCalled();
-			expect(urlManagerResetfn).toHaveBeenCalled();
+			expect(urlManagerResetfn).not.toHaveBeenCalled();
 			expect(setFocusedfn).toHaveBeenCalledTimes(1);
 		});
 

--- a/packages/snap-controller/src/Autocomplete/AutocompleteController.ts
+++ b/packages/snap-controller/src/Autocomplete/AutocompleteController.ts
@@ -375,27 +375,28 @@ export class AutocompleteController extends AbstractController {
 
 				const trendingResultsEnabled = this.store.trending?.length && this.config.settings?.trending?.showResults;
 				const historyResultsEnabled = this.store.history?.length && this.config.settings?.history?.showResults;
-				this.urlManager.reset().go();
 
-				if (!value) {
-					// there is no input value - reset state of store
-					this.store.reset();
+				this.handlers.input.timeoutDelay = setTimeout(() => {
+					if (!value) {
+						// there is no input value - reset state of store
+						this.store.reset();
 
-					// show results for trending or history (if configured) - trending has priority
-					if (trendingResultsEnabled) {
-						this.store.trending[0].preview();
-					} else if (historyResultsEnabled) {
-						this.store.history[0].preview();
-					}
-				} else {
-					// new query in the input - trigger a new search via UrlManager
-					this.handlers.input.timeoutDelay = setTimeout(() => {
+						// show results for trending or history (if configured) - trending has priority
+						if (trendingResultsEnabled) {
+							this.store.trending[0].preview();
+						} else if (historyResultsEnabled) {
+							this.store.history[0].preview();
+						} else {
+							// no input - need to reset URL
+							this.urlManager.reset().go();
+						}
+					} else {
+						// new query in the input - trigger a new search via UrlManager
 						this.store.state.locks.terms.unlock();
 						this.store.state.locks.facets.unlock();
-
 						this.urlManager.set({ query: this.store.state.input }).go();
-					}, INPUT_DELAY);
-				}
+					}
+				}, INPUT_DELAY);
 			},
 			timeoutDelay: undefined as undefined | ReturnType<typeof setTimeout>,
 		},


### PR DESCRIPTION
Duplicated searches were being made due to a line in the input handler. This refactor prevents these duplications by only resetting the UrlManager when there is no input value (instead of all the time). Additionally, the entire block that causes searches was put in the timeout block to prevent additional searches.