### PR TITLE
Release v0.53.4

### DIFF
--- a/packages/snap-preact-components/src/components/Molecules/Carousel/Carousel.tsx
+++ b/packages/snap-preact-components/src/components/Molecules/Carousel/Carousel.tsx
@@ -288,7 +288,7 @@ export const Carousel = observer((properties: CarouselProps): JSX.Element => {
 
 		//add usable class to last visible slide.
 		attachClasstoLastVisibleSlide();
-	}, []);
+	}, [properties]);
 
 	if (pagination) {
 		if (typeof pagination == 'object') {


### PR DESCRIPTION
bugfix for backwards compatible classnames on carousel re-renders