### PR TITLE
CLS Reduction

### DIFF
--- a/packages/snap-preact-demo/public/index.html
+++ b/packages/snap-preact-demo/public/index.html
@@ -137,15 +137,13 @@
 				</ul>
 			</div>
 			<div class="ss-lite-flex-nowrap ss-lite-main-layout">
-
-
 				<aside class="ss-lite-sidebar">
-					<div id="searchspring-sidebar">
+					<div id="searchspring-sidebar" style="min-height: 100vh">
 						<h2>Sidebar to be hidden!</h2>
 					</div>
 				</aside>
 				<section class="ss-lite-content">
-					<div id="searchspring-content">
+					<div id="searchspring-content" style="min-height: 100vh">
 						<h2>Content to be hidden!</h2>
 					</div>
 				</section>

--- a/packages/snap-preact-demo/public/website.css
+++ b/packages/snap-preact-demo/public/website.css
@@ -586,7 +586,6 @@ input[type='text'] {
 
 .ss-lite-main {
   flex: 1;
-  min-height: 500px;
   padding: 40px 0; }
 
 .ss-lite-breadcrumbs .ss-lite-list {
@@ -598,8 +597,6 @@ input[type='text'] {
     *display: inline;
     vertical-align: middle; }
 
-.ss-lite-main-layout {
-  min-height: 600px; }
   .ss-lite-main-layout .ss-lite-sidebar {
     -webkit-box-flex: 0;
     -webkit-flex: 0 1 auto;

--- a/packages/snap-preact-demo/src/index.ts
+++ b/packages/snap-preact-demo/src/index.ts
@@ -173,6 +173,7 @@ let config: SnapConfig = {
 					{
 						selector: '#searchspring-content',
 						hideTarget: true,
+						renderAfterSearch: true,
 						skeleton: () => ContentSkel,
 						component: async () => {
 							return (await import('./components/Content/Content')).Content;
@@ -181,6 +182,7 @@ let config: SnapConfig = {
 					{
 						selector: '#searchspring-sidebar',
 						hideTarget: true,
+						renderAfterSearch: true,
 						skeleton: () => SidebarSkel,
 						component: async () => {
 							return (await import('./components/Sidebar/Sidebar')).Sidebar;

--- a/packages/snap-preact-demo/tests/cypress/e2e/tracking/track.cy.js
+++ b/packages/snap-preact-demo/tests/cypress/e2e/tracking/track.cy.js
@@ -22,6 +22,8 @@ describe('Tracking', () => {
 		// wait for first login event
 		cy.wait(`@${BeaconType.LOGIN}`).then(() => {
 			// initial init will send a login event for the shopper due to integration script variables
+
+			cy.wait(100);
 			const shopperId = 'snaptest';
 			cy.get('#login').click();
 			cy.get('#login-modal').find('input').type(shopperId);
@@ -47,6 +49,7 @@ describe('Tracking', () => {
 			expect(store).to.haveOwnProperty('pagination');
 			expect(store.pagination.totalResults).to.be.greaterThan(0);
 
+			cy.wait(100);
 			cy.get(`.ss__result:first`).should('exist').trigger('click');
 
 			cy.wait(`@${BeaconType.CLICK}`).should((interception) => {
@@ -81,6 +84,7 @@ describe('Tracking', () => {
 	});
 
 	it('tracked product view', () => {
+		cy.wait(100);
 		cy.visit('https://localhost:2222/product.html');
 
 		cy.snapController().then(({ store }) => {
@@ -114,6 +118,7 @@ describe('Tracking', () => {
 	});
 
 	it('tracked cart view', () => {
+		cy.wait(100);
 		cy.visit('https://localhost:2222/cart.html');
 		cy.snapController().then(({ store }) => {
 			cy.wait(`@${BeaconType.CART}`).should((interception) => {
@@ -164,6 +169,7 @@ describe('Tracking', () => {
 	});
 
 	it('tracked order transaction', () => {
+		cy.wait(100);
 		cy.visit('https://localhost:2222/order.html');
 		cy.snapController().then(({ store }) => {
 			cy.wait(`@${BeaconType.ORDER}`).should((interception) => {
@@ -214,6 +220,7 @@ describe('Tracking', () => {
 	});
 
 	it('tracked all recommendation interaction events', () => {
+		cy.wait(100);
 		cy.visit('https://localhost:2222/product.html');
 
 		cy.snapController('recommend_similar_0').then(({ store }) => {
@@ -253,6 +260,7 @@ describe('Tracking', () => {
 				});
 			});
 
+			cy.wait(100);
 			// scroll down
 			cy.get('.ss__recommendation:first').scrollIntoView();
 
@@ -299,6 +307,7 @@ describe('Tracking', () => {
 					});
 				});
 
+			cy.wait(100);
 			// click next button and assert new profile product impressions
 			cy.get('.ss__recommendation:first .ss__carousel__next').should('exist').trigger('click');
 
@@ -335,6 +344,7 @@ describe('Tracking', () => {
 				});
 			});
 
+			cy.wait(100);
 			// click on result
 			cy.get('.ss__recommendation:first .ss__result')
 				.filter(':visible:first')

--- a/packages/snap-shared/src/MockClient/MockClient.ts
+++ b/packages/snap-shared/src/MockClient/MockClient.ts
@@ -10,21 +10,31 @@ import { MockData } from '../MockData/MockData';
 
 */
 
+export type MockConfig = {
+	delay?: number;
+};
+
 export class MockClient extends Client {
 	mockData: MockData;
+	mockConfig: MockConfig;
 
-	constructor(global: ClientGlobals, config: ClientConfig = {}) {
+	constructor(global: ClientGlobals, config: ClientConfig = {}, mockConfig: MockConfig = {}) {
 		super(global, config);
 
+		this.mockConfig = mockConfig;
 		this.mockData = new MockData({ siteId: global.siteId });
 	}
 
 	async meta() {
+		if (this.mockConfig.delay) await wait(this.mockConfig.delay);
+
 		return this.mockData.meta();
 	}
 
 	async search() {
 		const searchData = this.mockData.search();
+
+		if (this.mockConfig.delay) await wait(this.mockConfig.delay);
 
 		return Promise.all([this.meta() as MetaResponseModel, searchData as SearchResponseModel]);
 	}
@@ -32,20 +42,34 @@ export class MockClient extends Client {
 	async finder() {
 		const searchData = this.mockData.search();
 
+		if (this.mockConfig.delay) await wait(this.mockConfig.delay);
+
 		return Promise.all([this.meta() as MetaResponseModel, searchData as SearchResponseModel]);
 	}
 
 	async autocomplete() {
 		const autocompleteData = this.mockData.autocomplete();
 
+		if (this.mockConfig.delay) await wait(this.mockConfig.delay);
+
 		return Promise.all([this.meta() as MetaResponseModel, autocompleteData as AutocompleteResponseModel]);
 	}
 
 	async recommend() {
+		if (this.mockConfig.delay) await wait(this.mockConfig.delay);
+
 		return this.mockData.recommend();
 	}
 
 	async trending(): Promise<TrendingResponseModel> {
+		if (this.mockConfig.delay) await wait(this.mockConfig.delay);
+
 		return this.mockData.trending();
 	}
+}
+
+function wait(time = 0) {
+	return new Promise((resolve) => {
+		setTimeout(resolve, time);
+	});
 }

--- a/packages/snap-toolbox/src/DomTargeter/DomTargeter.test.ts
+++ b/packages/snap-toolbox/src/DomTargeter/DomTargeter.test.ts
@@ -241,6 +241,79 @@ describe('DomTargeter', () => {
 		expect(classNames).toEqual(['before-1', 'after-2', 'prepend-3', 'append-4', 'prepend-5', 'append-6', 'replaced']);
 	});
 
+	it('injects into elements and removes `min-height` by default', async () => {
+		const fn = jest.fn();
+		const dom = createDocument(`
+			<div id="content" style="min-height: 100vh"></div>
+		`);
+
+		const document = dom.window.document;
+
+		let contentElem = document.querySelector('#content');
+		expect(contentElem).not.toBeNull();
+
+		// initially element has a minHeight
+		expect((contentElem as HTMLElement).style.minHeight).toBe('100vh');
+
+		new DomTargeter(
+			[
+				{
+					selector: '#content',
+				},
+			],
+			(target: Target, elem: Element) => {
+				// on target function
+				fn();
+			},
+			document
+		);
+
+		// wait is needed due to promise usage (async)
+		await wait(200);
+
+		expect(fn).toHaveBeenCalledTimes(1);
+
+		// after onTarget resolves element minHeight is removed
+		expect((contentElem as HTMLElement).style.minHeight).toBe('');
+	});
+
+	it('injects into elements and does not remove `min-height` if configured not to', async () => {
+		const fn = jest.fn();
+		const dom = createDocument(`
+			<div id="content" style="min-height: 100vh"></div>
+		`);
+
+		const document = dom.window.document;
+
+		let contentElem = document.querySelector('#content');
+		expect(contentElem).not.toBeNull();
+
+		// initially element has a minHeight
+		expect((contentElem as HTMLElement).style.minHeight).toBe('100vh');
+
+		new DomTargeter(
+			[
+				{
+					unsetTargetMinHeight: false,
+					selector: '#content',
+				},
+			],
+			(target: Target, elem: Element) => {
+				// on target function
+				fn();
+			},
+			document
+		);
+
+		// wait is needed due to promise usage (async)
+		await wait(200);
+
+		expect(fn).toHaveBeenCalledTimes(1);
+
+		// after onTarget resolves element minHeight is removed
+		expect((contentElem as HTMLElement).style.minHeight).toBe('100vh');
+	});
+
 	it('injects into dynamically added elements with autoRetarget', async () => {
 		const dom = createDocument(`
 			<div id="content"></div>

--- a/packages/snap-toolbox/src/DomTargeter/DomTargeter.ts
+++ b/packages/snap-toolbox/src/DomTargeter/DomTargeter.ts
@@ -7,6 +7,7 @@ export type Target = {
 	emptyTarget?: boolean;
 	hideTarget?: boolean;
 	autoRetarget?: boolean;
+	unsetTargetMinHeight?: boolean;
 	clickRetarget?: boolean | string;
 	[any: string]: unknown;
 };
@@ -106,13 +107,13 @@ export class DomTargeter {
 
 		const errors: string[] = [];
 
-		targetElemPairs.forEach(({ target, elem }) => {
+		targetElemPairs.forEach(async ({ target, elem }) => {
 			if (target.inject) {
 				try {
 					const injectedElem = this.inject(elem, target);
 					this.targetedElems = this.targetedElems.concat(elem);
 
-					this.onTarget(target, injectedElem, elem);
+					await this.onTarget(target, injectedElem, elem);
 				} catch (e) {
 					errors.push(String(e));
 				}
@@ -121,11 +122,17 @@ export class DomTargeter {
 				target.emptyTarget = target.emptyTarget ?? true;
 				if (target.emptyTarget) while (elem.firstChild && elem.removeChild(elem.firstChild));
 
-				this.onTarget(target, elem);
+				await this.onTarget(target, elem);
 			}
 
 			// unhide target
 			target.hideTarget && this.unhideTarget(target.selector);
+
+			// remove styles by default
+			target.unsetTargetMinHeight = target.unsetTargetMinHeight ?? true;
+			if (target.unsetTargetMinHeight && (elem as HTMLElement).style.minHeight) {
+				(elem as HTMLElement).style.minHeight = '';
+			}
 		});
 
 		if (errors.length) {


### PR DESCRIPTION
* adding `unsetTargetMinHeight` setting in DomTargeter to remove `min-height` inline styles on targets (on by default)
* adding `renderAfterSearch` setting in extended DomTargeter (Snap config targeter) that prevents rendering until the search has completed (for SearchControllers)
* adding ability to specify a delay in the MockClient (needed to test `renderAfterSearch` change
* changes to make tracking E2E test in Demo store more reliable