### PR TITLE
Release 0.59.0

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -8,7 +8,7 @@ module.exports = {
 		'plugin:@typescript-eslint/recommended', // uses the recommended rules from the @typescript-eslint/eslint-plugin
 		'prettier', // disable ESLint rules from @typescript-eslint/eslint-plugin that would conflict with prettier
 	],
-	ignorePatterns: ["**/docs", "**/dist", "*.test.ts", "*.test.tsx"],
+	ignorePatterns: ["**/docs", "**/dist", "*.test.ts", "*.test.tsx", "./packages/snapps"],
 	rules: {
 		// add rules... or dont...
 		'no-debugger': 'error',

--- a/packages/snap-preact-components/src/components/Organisms/Recommendation/Recommendation.stories.tsx
+++ b/packages/snap-preact-components/src/components/Organisms/Recommendation/Recommendation.stories.tsx
@@ -138,6 +138,20 @@ export default {
 			},
 			control: { type: 'text' },
 		},
+		lazyRender: {
+			description: 'Lazy render settings object',
+			defaultValue: {
+				enabled: true,
+				offset: '10%',
+			},
+			table: {
+				type: {
+					summary: 'object',
+				},
+				defaultValue: { summary: 'Lazy render settings object' },
+			},
+			control: { type: 'object' },
+		},
 		breakpoints: {
 			defaultValue: undefined,
 			description: 'Recommendation title',

--- a/packages/snap-preact-components/src/components/Organisms/Recommendation/readme.md
+++ b/packages/snap-preact-components/src/components/Organisms/Recommendation/readme.md
@@ -88,6 +88,18 @@ import { Scrollbar } from 'swiper';
 <Recommendation controller={controller} modules={[Scrollbar]} scrollbar={{ draggable: true }} />
 ```
 
+### lazyRender 
+The `lazyRender` prop specifies an object of lazy rendering settings. The settings include an `enable` toggle (defaults to `true`) as well as an `offset` (default `"10%"`) to specify at what distance the component should start rendering relative to the bottom of the viewport.
+
+```jsx
+const customLazyRenderProps = {
+	enabled: true,
+	offset: "20px" // any css margin values accepted - px, %, etc...
+}
+
+<Recommendation controller={controller} lazyRender={ customLazyRenderProps } />
+```
+
 ### breakpoints
 An object that modifies the responsive behavior of the carousel at various viewports. 
 

--- a/packages/snap-preact-components/src/components/Organisms/RecommendationBundle/RecommendationBundle.stories.tsx
+++ b/packages/snap-preact-components/src/components/Organisms/RecommendationBundle/RecommendationBundle.stories.tsx
@@ -247,6 +247,20 @@ export default {
 				},
 			},
 		},
+		lazyRender: {
+			description: 'Lazy render settings object',
+			defaultValue: {
+				enabled: true,
+				offset: '10%',
+			},
+			table: {
+				type: {
+					summary: 'object',
+				},
+				defaultValue: { summary: 'Lazy render settings object' },
+			},
+			control: { type: 'object' },
+		},
 		breakpoints: {
 			defaultValue: undefined,
 			description: 'Recommendation title',

--- a/packages/snap-preact-components/src/components/Organisms/RecommendationBundle/readme.md
+++ b/packages/snap-preact-components/src/components/Organisms/RecommendationBundle/readme.md
@@ -222,6 +222,18 @@ import { Scrollbar } from 'swiper';
 <RecommendationBundle controller={controller} onAddToCart={(e, items)=>{console.log(items)}} modules={[Scrollbar]} scrollbar={{ draggable: true }} />
 ```
 
+### lazyRender 
+The `lazyRender` prop specifies an object of lazy rendering settings. The settings include an `enable` toggle (defaults to `true`) as well as an `offset` (default `"10%"`) to specify at what distance the component should start rendering relative to the bottom of the viewport.
+
+```jsx
+const customLazyRenderProps = {
+	enabled: true,
+	offset: "20px" // any css margin values accepted - px, %, etc...
+}
+
+<RecommendationBundle controller={controller} lazyRender={ customLazyRenderProps } onAddToCart={(e, items)=>{console.log(items)}} />
+```
+
 ### breakpoints
 An object that modifies the responsive behavior of the carousel at various viewports. 
 

--- a/packages/snap-preact-demo/public/index.html
+++ b/packages/snap-preact-demo/public/index.html
@@ -137,15 +137,13 @@
 				</ul>
 			</div>
 			<div class="ss-lite-flex-nowrap ss-lite-main-layout">
-
-
 				<aside class="ss-lite-sidebar">
-					<div id="searchspring-sidebar">
+					<div id="searchspring-sidebar" style="min-height: 100vh">
 						<h2>Sidebar to be hidden!</h2>
 					</div>
 				</aside>
 				<section class="ss-lite-content">
-					<div id="searchspring-content">
+					<div id="searchspring-content" style="min-height: 100vh">
 						<h2>Content to be hidden!</h2>
 					</div>
 				</section>

--- a/packages/snap-preact-demo/public/website.css
+++ b/packages/snap-preact-demo/public/website.css
@@ -586,7 +586,6 @@ input[type='text'] {
 
 .ss-lite-main {
   flex: 1;
-  min-height: 500px;
   padding: 40px 0; }
 
 .ss-lite-breadcrumbs .ss-lite-list {
@@ -598,8 +597,6 @@ input[type='text'] {
     *display: inline;
     vertical-align: middle; }
 
-.ss-lite-main-layout {
-  min-height: 600px; }
   .ss-lite-main-layout .ss-lite-sidebar {
     -webkit-box-flex: 0;
     -webkit-flex: 0 1 auto;

--- a/packages/snap-preact-demo/src/components/Recommendations/Bundles/Bundles.tsx
+++ b/packages/snap-preact-demo/src/components/Recommendations/Bundles/Bundles.tsx
@@ -19,6 +19,9 @@ export const Bundles = observer((props) => {
 	const bundleRecsProps = {
 		controller: controller,
 		onAddToCart: (data) => controller.log.debug('ADDING TO CART', data),
+		lazyRender: {
+			enabled: false,
+		},
 	};
 
 	return (

--- a/packages/snap-preact-demo/src/components/Recommendations/Recs/Recs.tsx
+++ b/packages/snap-preact-demo/src/components/Recommendations/Recs/Recs.tsx
@@ -33,7 +33,7 @@ export class Recs extends Component<RecsProps> {
 				</Carousel>
 
 				<hr style={{ margin: '20px 0' }} />
-				<Recommendation controller={controller} title={'Recommended For You'} speed={0}>
+				<Recommendation controller={controller} title={'Recommended For You'} speed={0} lazyRender={{ enabled: false }}>
 					{store.results.map((result) => (
 						<Result controller={controller} result={result}></Result>
 					))}

--- a/packages/snap-preact-demo/src/index.ts
+++ b/packages/snap-preact-demo/src/index.ts
@@ -173,6 +173,7 @@ let config: SnapConfig = {
 					{
 						selector: '#searchspring-content',
 						hideTarget: true,
+						renderAfterSearch: true,
 						skeleton: () => ContentSkel,
 						component: async () => {
 							return (await import('./components/Content/Content')).Content;
@@ -181,6 +182,7 @@ let config: SnapConfig = {
 					{
 						selector: '#searchspring-sidebar',
 						hideTarget: true,
+						renderAfterSearch: true,
 						skeleton: () => SidebarSkel,
 						component: async () => {
 							return (await import('./components/Sidebar/Sidebar')).Sidebar;

--- a/packages/snap-preact-demo/tests/cypress/e2e/recommendation/recommendationBundle.cy.js
+++ b/packages/snap-preact-demo/tests/cypress/e2e/recommendation/recommendationBundle.cy.js
@@ -78,19 +78,15 @@ describe('BundledRecommendations', () => {
 					.should('exist')
 					.should('have.text', 'Subtotal for 4 items');
 				//price
-				cy.get(`${config?.selectors?.recommendation.cta} .ss__price--strike`).should('exist').should('have.text', '$175.00');
+				cy.get(`${config?.selectors?.recommendation.cta} .ss__price--strike`).should('exist').contains(`$${store.cart.msrp}`);
 				//strike
 				cy.get(`${config?.selectors?.recommendation.cta} .ss__recommendation-bundle__wrapper__cta__subtotal__price .ss__price`)
 					.should('exist')
-					.should('have.text', '$157.00');
+					.contains(`$${store.cart.price}`);
 				//button
 				cy.get(`${config?.selectors?.recommendation.cta} .ss__recommendation-bundle__wrapper__cta__button`)
 					.should('exist')
 					.should('have.text', 'Add All To Cart');
-
-				expect(store.cart.count).to.equal(4);
-				expect(store.cart.price).to.equal(157);
-				expect(store.cart.msrp).to.equal(175);
 			});
 
 			//check it is responsive to cartstore changes.
@@ -98,25 +94,21 @@ describe('BundledRecommendations', () => {
 				.should('exist')
 				.click()
 				.then(() => {
-					//title
-					cy.get(`${config?.selectors?.recommendation.cta} .ss__recommendation-bundle__wrapper__cta__subtotal__title`)
-						.should('exist')
-						.should('have.text', 'Subtotal for 3 items');
-					//price
-					cy.get(`${config?.selectors?.recommendation.cta} .ss__price--strike`).should('exist').should('have.text', '$125.00');
-					//strike
-					cy.get(`${config?.selectors?.recommendation.cta} .ss__recommendation-bundle__wrapper__cta__subtotal__price .ss__price`)
-						.should('exist')
-						.should('have.text', '$109.00');
-					//button
-					cy.get(`${config?.selectors?.recommendation.cta} .ss__recommendation-bundle__wrapper__cta__button`)
-						.should('exist')
-						.should('have.text', 'Add All To Cart');
-
 					cy.snapController(config?.selectors?.recommendation.controller).then(({ store }) => {
-						expect(store.cart.count).to.equal(3);
-						expect(store.cart.price).to.equal(109);
-						expect(store.cart.msrp).to.equal(125);
+						//title
+						cy.get(`${config?.selectors?.recommendation.cta} .ss__recommendation-bundle__wrapper__cta__subtotal__title`)
+							.should('exist')
+							.should('have.text', 'Subtotal for 3 items');
+						//price
+						cy.get(`${config?.selectors?.recommendation.cta} .ss__price--strike`).should('exist').contains(`$${store.cart.msrp}`);
+						//strike
+						cy.get(`${config?.selectors?.recommendation.cta} .ss__recommendation-bundle__wrapper__cta__subtotal__price .ss__price`)
+							.should('exist')
+							.contains(`$${store.cart.price}`);
+						//button
+						cy.get(`${config?.selectors?.recommendation.cta} .ss__recommendation-bundle__wrapper__cta__button`)
+							.should('exist')
+							.should('have.text', 'Add All To Cart');
 					});
 				});
 		});

--- a/packages/snap-preact-demo/tests/cypress/e2e/recommendation/recommendationBundle.cy.js
+++ b/packages/snap-preact-demo/tests/cypress/e2e/recommendation/recommendationBundle.cy.js
@@ -78,19 +78,19 @@ describe('BundledRecommendations', () => {
 					.should('exist')
 					.should('have.text', 'Subtotal for 4 items');
 				//price
-				cy.get(`${config?.selectors?.recommendation.cta} .ss__price--strike`).should('exist').should('have.text', '$150.00');
+				cy.get(`${config?.selectors?.recommendation.cta} .ss__price--strike`).should('exist').should('have.text', '$175.00');
 				//strike
 				cy.get(`${config?.selectors?.recommendation.cta} .ss__recommendation-bundle__wrapper__cta__subtotal__price .ss__price`)
 					.should('exist')
-					.should('have.text', '$123.00');
+					.should('have.text', '$157.00');
 				//button
 				cy.get(`${config?.selectors?.recommendation.cta} .ss__recommendation-bundle__wrapper__cta__button`)
 					.should('exist')
 					.should('have.text', 'Add All To Cart');
 
 				expect(store.cart.count).to.equal(4);
-				expect(store.cart.price).to.equal(123);
-				expect(store.cart.msrp).to.equal(150);
+				expect(store.cart.price).to.equal(157);
+				expect(store.cart.msrp).to.equal(175);
 			});
 
 			//check it is responsive to cartstore changes.
@@ -103,11 +103,11 @@ describe('BundledRecommendations', () => {
 						.should('exist')
 						.should('have.text', 'Subtotal for 3 items');
 					//price
-					cy.get(`${config?.selectors?.recommendation.cta} .ss__price--strike`).should('exist').should('have.text', '$100.00');
+					cy.get(`${config?.selectors?.recommendation.cta} .ss__price--strike`).should('exist').should('have.text', '$125.00');
 					//strike
 					cy.get(`${config?.selectors?.recommendation.cta} .ss__recommendation-bundle__wrapper__cta__subtotal__price .ss__price`)
 						.should('exist')
-						.should('have.text', '$75.00');
+						.should('have.text', '$109.00');
 					//button
 					cy.get(`${config?.selectors?.recommendation.cta} .ss__recommendation-bundle__wrapper__cta__button`)
 						.should('exist')
@@ -115,8 +115,8 @@ describe('BundledRecommendations', () => {
 
 					cy.snapController(config?.selectors?.recommendation.controller).then(({ store }) => {
 						expect(store.cart.count).to.equal(3);
-						expect(store.cart.price).to.equal(75);
-						expect(store.cart.msrp).to.equal(100);
+						expect(store.cart.price).to.equal(109);
+						expect(store.cart.msrp).to.equal(125);
 					});
 				});
 		});

--- a/packages/snap-preact-demo/tests/cypress/e2e/tracking/track.cy.js
+++ b/packages/snap-preact-demo/tests/cypress/e2e/tracking/track.cy.js
@@ -22,6 +22,8 @@ describe('Tracking', () => {
 		// wait for first login event
 		cy.wait(`@${BeaconType.LOGIN}`).then(() => {
 			// initial init will send a login event for the shopper due to integration script variables
+
+			cy.wait(100);
 			const shopperId = 'snaptest';
 			cy.get('#login').click();
 			cy.get('#login-modal').find('input').type(shopperId);
@@ -47,6 +49,7 @@ describe('Tracking', () => {
 			expect(store).to.haveOwnProperty('pagination');
 			expect(store.pagination.totalResults).to.be.greaterThan(0);
 
+			cy.wait(100);
 			cy.get(`.ss__result:first`).should('exist').trigger('click');
 
 			cy.wait(`@${BeaconType.CLICK}`).should((interception) => {
@@ -81,6 +84,7 @@ describe('Tracking', () => {
 	});
 
 	it('tracked product view', () => {
+		cy.wait(100);
 		cy.visit('https://localhost:2222/product.html');
 
 		cy.snapController().then(({ store }) => {
@@ -114,6 +118,7 @@ describe('Tracking', () => {
 	});
 
 	it('tracked cart view', () => {
+		cy.wait(100);
 		cy.visit('https://localhost:2222/cart.html');
 		cy.snapController().then(({ store }) => {
 			cy.wait(`@${BeaconType.CART}`).should((interception) => {
@@ -164,6 +169,7 @@ describe('Tracking', () => {
 	});
 
 	it('tracked order transaction', () => {
+		cy.wait(100);
 		cy.visit('https://localhost:2222/order.html');
 		cy.snapController().then(({ store }) => {
 			cy.wait(`@${BeaconType.ORDER}`).should((interception) => {
@@ -214,6 +220,7 @@ describe('Tracking', () => {
 	});
 
 	it('tracked all recommendation interaction events', () => {
+		cy.wait(100);
 		cy.visit('https://localhost:2222/product.html');
 
 		cy.snapController('recommend_similar_0').then(({ store }) => {
@@ -253,6 +260,7 @@ describe('Tracking', () => {
 				});
 			});
 
+			cy.wait(100);
 			// scroll down
 			cy.get('.ss__recommendation:first').scrollIntoView();
 
@@ -299,6 +307,7 @@ describe('Tracking', () => {
 					});
 				});
 
+			cy.wait(100);
 			// click next button and assert new profile product impressions
 			cy.get('.ss__recommendation:first .ss__carousel__next').should('exist').trigger('click');
 
@@ -335,6 +344,7 @@ describe('Tracking', () => {
 				});
 			});
 
+			cy.wait(100);
 			// click on result
 			cy.get('.ss__recommendation:first .ss__result')
 				.filter(':visible:first')

--- a/packages/snap-shared/src/MockClient/MockClient.ts
+++ b/packages/snap-shared/src/MockClient/MockClient.ts
@@ -10,21 +10,31 @@ import { MockData } from '../MockData/MockData';
 
 */
 
+export type MockConfig = {
+	delay?: number;
+};
+
 export class MockClient extends Client {
 	mockData: MockData;
+	mockConfig: MockConfig;
 
-	constructor(global: ClientGlobals, config: ClientConfig = {}) {
+	constructor(global: ClientGlobals, config: ClientConfig = {}, mockConfig: MockConfig = {}) {
 		super(global, config);
 
+		this.mockConfig = mockConfig;
 		this.mockData = new MockData({ siteId: global.siteId });
 	}
 
 	async meta() {
+		if (this.mockConfig.delay) await wait(this.mockConfig.delay);
+
 		return this.mockData.meta();
 	}
 
 	async search() {
 		const searchData = this.mockData.search();
+
+		if (this.mockConfig.delay) await wait(this.mockConfig.delay);
 
 		return Promise.all([this.meta() as MetaResponseModel, searchData as SearchResponseModel]);
 	}
@@ -32,20 +42,34 @@ export class MockClient extends Client {
 	async finder() {
 		const searchData = this.mockData.search();
 
+		if (this.mockConfig.delay) await wait(this.mockConfig.delay);
+
 		return Promise.all([this.meta() as MetaResponseModel, searchData as SearchResponseModel]);
 	}
 
 	async autocomplete() {
 		const autocompleteData = this.mockData.autocomplete();
 
+		if (this.mockConfig.delay) await wait(this.mockConfig.delay);
+
 		return Promise.all([this.meta() as MetaResponseModel, autocompleteData as AutocompleteResponseModel]);
 	}
 
 	async recommend() {
+		if (this.mockConfig.delay) await wait(this.mockConfig.delay);
+
 		return this.mockData.recommend();
 	}
 
 	async trending(): Promise<TrendingResponseModel> {
+		if (this.mockConfig.delay) await wait(this.mockConfig.delay);
+
 		return this.mockData.trending();
 	}
+}
+
+function wait(time = 0) {
+	return new Promise((resolve) => {
+		setTimeout(resolve, time);
+	});
 }

--- a/packages/snap-toolbox/src/DomTargeter/DomTargeter.test.ts
+++ b/packages/snap-toolbox/src/DomTargeter/DomTargeter.test.ts
@@ -241,6 +241,79 @@ describe('DomTargeter', () => {
 		expect(classNames).toEqual(['before-1', 'after-2', 'prepend-3', 'append-4', 'prepend-5', 'append-6', 'replaced']);
 	});
 
+	it('injects into elements and removes `min-height` by default', async () => {
+		const fn = jest.fn();
+		const dom = createDocument(`
+			<div id="content" style="min-height: 100vh"></div>
+		`);
+
+		const document = dom.window.document;
+
+		let contentElem = document.querySelector('#content');
+		expect(contentElem).not.toBeNull();
+
+		// initially element has a minHeight
+		expect((contentElem as HTMLElement).style.minHeight).toBe('100vh');
+
+		new DomTargeter(
+			[
+				{
+					selector: '#content',
+				},
+			],
+			(target: Target, elem: Element) => {
+				// on target function
+				fn();
+			},
+			document
+		);
+
+		// wait is needed due to promise usage (async)
+		await wait(200);
+
+		expect(fn).toHaveBeenCalledTimes(1);
+
+		// after onTarget resolves element minHeight is removed
+		expect((contentElem as HTMLElement).style.minHeight).toBe('');
+	});
+
+	it('injects into elements and does not remove `min-height` if configured not to', async () => {
+		const fn = jest.fn();
+		const dom = createDocument(`
+			<div id="content" style="min-height: 100vh"></div>
+		`);
+
+		const document = dom.window.document;
+
+		let contentElem = document.querySelector('#content');
+		expect(contentElem).not.toBeNull();
+
+		// initially element has a minHeight
+		expect((contentElem as HTMLElement).style.minHeight).toBe('100vh');
+
+		new DomTargeter(
+			[
+				{
+					unsetTargetMinHeight: false,
+					selector: '#content',
+				},
+			],
+			(target: Target, elem: Element) => {
+				// on target function
+				fn();
+			},
+			document
+		);
+
+		// wait is needed due to promise usage (async)
+		await wait(200);
+
+		expect(fn).toHaveBeenCalledTimes(1);
+
+		// after onTarget resolves element minHeight is removed
+		expect((contentElem as HTMLElement).style.minHeight).toBe('100vh');
+	});
+
 	it('injects into dynamically added elements with autoRetarget', async () => {
 		const dom = createDocument(`
 			<div id="content"></div>

--- a/packages/snap-toolbox/src/DomTargeter/DomTargeter.ts
+++ b/packages/snap-toolbox/src/DomTargeter/DomTargeter.ts
@@ -7,6 +7,7 @@ export type Target = {
 	emptyTarget?: boolean;
 	hideTarget?: boolean;
 	autoRetarget?: boolean;
+	unsetTargetMinHeight?: boolean;
 	clickRetarget?: boolean | string;
 	[any: string]: unknown;
 };
@@ -106,13 +107,13 @@ export class DomTargeter {
 
 		const errors: string[] = [];
 
-		targetElemPairs.forEach(({ target, elem }) => {
+		targetElemPairs.forEach(async ({ target, elem }) => {
 			if (target.inject) {
 				try {
 					const injectedElem = this.inject(elem, target);
 					this.targetedElems = this.targetedElems.concat(elem);
 
-					this.onTarget(target, injectedElem, elem);
+					await this.onTarget(target, injectedElem, elem);
 				} catch (e) {
 					errors.push(String(e));
 				}
@@ -121,11 +122,17 @@ export class DomTargeter {
 				target.emptyTarget = target.emptyTarget ?? true;
 				if (target.emptyTarget) while (elem.firstChild && elem.removeChild(elem.firstChild));
 
-				this.onTarget(target, elem);
+				await this.onTarget(target, elem);
 			}
 
 			// unhide target
 			target.hideTarget && this.unhideTarget(target.selector);
+
+			// remove styles by default
+			target.unsetTargetMinHeight = target.unsetTargetMinHeight ?? true;
+			if (target.unsetTargetMinHeight && (elem as HTMLElement).style.minHeight) {
+				(elem as HTMLElement).style.minHeight = '';
+			}
 		});
 
 		if (errors.length) {


### PR DESCRIPTION
* adding `lazyRender` to recommendation components
* option to `renderAfterSearch` in Snap targeters
* DomTargeter feature to remove 'min-height' from inline style by default
```
<div id="searchspring-sidebar" style="min-height: 100vh">
```