### PR TITLE
AutocompleteController Bind settings

### DIFF
--- a/packages/snap-controller/src/Autocomplete/AutocompleteController.test.ts
+++ b/packages/snap-controller/src/Autocomplete/AutocompleteController.test.ts
@@ -11,6 +11,7 @@ import { AutocompleteController, INPUT_DELAY as _INPUT_DELAY } from './Autocompl
 import { waitFor } from '@testing-library/preact';
 
 import { MockClient } from '@searchspring/snap-shared';
+import deepmerge from 'deepmerge';
 
 const KEY_ENTER = 13;
 const KEY_ESCAPE = 27;
@@ -211,6 +212,35 @@ describe('Autocomplete Controller', () => {
 		await controller.bind();
 
 		controller.unbind();
+
+		let inputEl: HTMLInputElement | null;
+
+		await waitFor(() => {
+			inputEl = document.querySelector(controller.config.selector);
+			expect(inputEl).toBeDefined();
+		});
+
+		const query = 'bumpers';
+		inputEl!.value = query;
+		inputEl!.focus();
+		inputEl!.dispatchEvent(new Event('input'));
+		expect(controller.urlManager.state.query).toBe(undefined);
+	});
+
+	it('can opt out of binding input event', async () => {
+		const bindingConfig = deepmerge(acConfig, { settings: { bind: { input: false } } });
+
+		const controller = new AutocompleteController(bindingConfig, {
+			client: new MockClient(globals, {}),
+			store: new AutocompleteStore(bindingConfig, services),
+			urlManager,
+			eventManager: new EventManager(),
+			profiler: new Profiler(),
+			logger: new Logger(),
+			tracker: new Tracker(globals),
+		});
+
+		await controller.bind();
 
 		let inputEl: HTMLInputElement | null;
 
@@ -665,6 +695,79 @@ describe('Autocomplete Controller', () => {
 		await new Promise((resolve) => setTimeout(resolve, INPUT_DELAY));
 
 		expect(beforeSubmitfn).toHaveBeenCalledWith('beforeSubmit', {
+			controller,
+			input: inputEl!,
+		});
+
+		beforeSubmitfn.mockClear();
+	});
+
+	it('can opt out of submit event', async () => {
+		document.body.innerHTML = '<div><form action="/search.html"><input type="text" id="search_query"></form></div>';
+
+		const bindingConfig = deepmerge(acConfig, { settings: { bind: { submit: false } } });
+
+		const controller = new AutocompleteController(bindingConfig, {
+			client: new MockClient(globals, {}),
+			store: new AutocompleteStore(bindingConfig, services),
+			urlManager,
+			eventManager: new EventManager(),
+			profiler: new Profiler(),
+			logger: new Logger(),
+			tracker: new Tracker(globals),
+		});
+
+		await controller.bind();
+		(controller.client as MockClient).mockData.updateConfig({ autocomplete: 'autocomplete.query.bumpers' });
+
+		const inputEl: HTMLInputElement | null = document.querySelector(controller.config.selector);
+
+		const query = 'bumpers';
+		inputEl!.value = query;
+
+		const form = inputEl!.form;
+		const beforeSubmitfn = jest.spyOn(controller.eventManager, 'fire');
+
+		form?.dispatchEvent(new Event('submit', { bubbles: true }));
+		//this timeout seems to be needed. Cant replace with waitFor
+		await new Promise((resolve) => setTimeout(resolve, INPUT_DELAY));
+
+		expect(beforeSubmitfn).not.toHaveBeenCalledWith('beforeSubmit', {
+			controller,
+			input: inputEl!,
+		});
+
+		beforeSubmitfn.mockClear();
+	});
+
+	it('can opt out of submit event (with no form)', async () => {
+		const bindingConfig = deepmerge(acConfig, { action: '/search', settings: { bind: { submit: false } } });
+
+		const controller = new AutocompleteController(bindingConfig, {
+			client: new MockClient(globals, {}),
+			store: new AutocompleteStore(bindingConfig, services),
+			urlManager,
+			eventManager: new EventManager(),
+			profiler: new Profiler(),
+			logger: new Logger(),
+			tracker: new Tracker(globals),
+		});
+
+		await controller.bind();
+		(controller.client as MockClient).mockData.updateConfig({ autocomplete: 'autocomplete.query.bumpers' });
+
+		const beforeSubmitfn = jest.spyOn(controller.eventManager, 'fire');
+		const inputEl: HTMLInputElement | null = document.querySelector(controller.config.selector);
+
+		const query = 'bumpers';
+		inputEl!.value = query;
+
+		inputEl!.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, keyCode: KEY_ENTER }));
+
+		// this timeout seems to be needed. Cant replace with waitFor
+		await new Promise((resolve) => setTimeout(resolve, INPUT_DELAY));
+
+		expect(beforeSubmitfn).not.toHaveBeenCalledWith('beforeSubmit', {
 			controller,
 			input: inputEl!,
 		});

--- a/packages/snap-controller/src/Autocomplete/AutocompleteController.test.ts
+++ b/packages/snap-controller/src/Autocomplete/AutocompleteController.test.ts
@@ -727,6 +727,7 @@ describe('Autocomplete Controller', () => {
 
 		const form = inputEl!.form;
 		const beforeSubmitfn = jest.spyOn(controller.eventManager, 'fire');
+		const handlerSubmitfn = jest.spyOn(controller.handlers.input, 'formSubmit');
 
 		form?.dispatchEvent(new Event('submit', { bubbles: true }));
 		//this timeout seems to be needed. Cant replace with waitFor
@@ -736,6 +737,8 @@ describe('Autocomplete Controller', () => {
 			controller,
 			input: inputEl!,
 		});
+
+		expect(handlerSubmitfn).not.toHaveBeenCalled();
 
 		beforeSubmitfn.mockClear();
 	});
@@ -757,6 +760,7 @@ describe('Autocomplete Controller', () => {
 		(controller.client as MockClient).mockData.updateConfig({ autocomplete: 'autocomplete.query.bumpers' });
 
 		const beforeSubmitfn = jest.spyOn(controller.eventManager, 'fire');
+		const enterKeyfn = jest.spyOn(controller.handlers.input, 'enterKey');
 		const inputEl: HTMLInputElement | null = document.querySelector(controller.config.selector);
 
 		const query = 'bumpers';
@@ -771,6 +775,8 @@ describe('Autocomplete Controller', () => {
 			controller,
 			input: inputEl!,
 		});
+
+		expect(enterKeyfn).not.toHaveBeenCalled();
 
 		beforeSubmitfn.mockClear();
 	});

--- a/packages/snap-controller/src/Autocomplete/AutocompleteController.ts
+++ b/packages/snap-controller/src/Autocomplete/AutocompleteController.ts
@@ -220,7 +220,6 @@ export class AutocompleteController extends AbstractController {
 	handlers = {
 		input: {
 			enterKey: async (e: KeyboardEvent): Promise<boolean | undefined> => {
-				console.log('enter key handler...');
 				if (e.keyCode == KEY_ENTER) {
 					const input = e.target as HTMLInputElement;
 					let actionUrl = this.store.services.urlManager;
@@ -435,7 +434,6 @@ export class AutocompleteController extends AbstractController {
 	}
 
 	async bind(): Promise<void> {
-		console.log('binding???');
 		if (!this.initialized) {
 			await this.init();
 		}
@@ -444,7 +442,6 @@ export class AutocompleteController extends AbstractController {
 
 		const inputs: NodeListOf<HTMLInputElement> = document.querySelectorAll(this.config.selector);
 		inputs.forEach((input) => {
-			console.log('binding input???', input);
 			input.setAttribute('spellcheck', 'false');
 			input.setAttribute('autocomplete', 'off');
 			input.setAttribute('autocorrect', 'off');
@@ -464,9 +461,7 @@ export class AutocompleteController extends AbstractController {
 			const form = input.form;
 			let formActionUrl: string | undefined;
 
-			console.log('binding action???', this.config.action);
 			if (this.config.action) {
-				console.log('binding action???');
 				this.config.settings?.bind?.submit && input.addEventListener('keydown', this.handlers.input.enterKey);
 				formActionUrl = this.config.action;
 			} else if (form) {

--- a/packages/snap-controller/src/Autocomplete/AutocompleteController.ts
+++ b/packages/snap-controller/src/Autocomplete/AutocompleteController.ts
@@ -35,6 +35,10 @@ const defaultConfig: AutocompleteControllerConfig = {
 			merchandising: true,
 			singleResult: false,
 		},
+		bind: {
+			input: true,
+			submit: true,
+		},
 	},
 };
 
@@ -216,6 +220,7 @@ export class AutocompleteController extends AbstractController {
 	handlers = {
 		input: {
 			enterKey: async (e: KeyboardEvent): Promise<boolean | undefined> => {
+				console.log('enter key handler...');
 				if (e.keyCode == KEY_ENTER) {
 					const input = e.target as HTMLInputElement;
 					let actionUrl = this.store.services.urlManager;
@@ -430,6 +435,7 @@ export class AutocompleteController extends AbstractController {
 	}
 
 	async bind(): Promise<void> {
+		console.log('binding???');
 		if (!this.initialized) {
 			await this.init();
 		}
@@ -438,6 +444,7 @@ export class AutocompleteController extends AbstractController {
 
 		const inputs: NodeListOf<HTMLInputElement> = document.querySelectorAll(this.config.selector);
 		inputs.forEach((input) => {
+			console.log('binding input???', input);
 			input.setAttribute('spellcheck', 'false');
 			input.setAttribute('autocomplete', 'off');
 			input.setAttribute('autocorrect', 'off');
@@ -445,7 +452,7 @@ export class AutocompleteController extends AbstractController {
 
 			input.setAttribute(INPUT_ATTRIBUTE, '');
 
-			input.addEventListener('input', this.handlers.input.input);
+			this.config.settings?.bind?.input && input.addEventListener('input', this.handlers.input.input);
 
 			if (this.config?.settings?.initializeFromUrl && !input.value && this.store.state.input) {
 				input.value = this.store.state.input;
@@ -457,11 +464,13 @@ export class AutocompleteController extends AbstractController {
 			const form = input.form;
 			let formActionUrl: string | undefined;
 
+			console.log('binding action???', this.config.action);
 			if (this.config.action) {
-				input.addEventListener('keydown', this.handlers.input.enterKey);
+				console.log('binding action???');
+				this.config.settings?.bind?.submit && input.addEventListener('keydown', this.handlers.input.enterKey);
 				formActionUrl = this.config.action;
 			} else if (form) {
-				form.addEventListener('submit', this.handlers.input.formSubmit as unknown as EventListener);
+				this.config.settings?.bind?.submit && form.addEventListener('submit', this.handlers.input.formSubmit as unknown as EventListener);
 				formActionUrl = form.action || '';
 
 				// serializeForm will include additional form element in our urlManager as globals

--- a/packages/snap-controller/src/Autocomplete/README.md
+++ b/packages/snap-controller/src/Autocomplete/README.md
@@ -22,6 +22,8 @@ The `AutocompleteController` is used when making queries to the API `autocomplet
 | settings.history.showResults | if history limit is set and there is no input, the first term results will be displayed | false |   | 
 | settings.redirects.merchandising | boolean to disable merchandising redirects when ac form is submitted | true |   | 
 | settings.redirects.singleResult | enable redirect to product detail page if search yields 1 result count | false |   |
+| settings.bind.input | boolean to disable binding of the input element (selector) | true |   | 
+| settings.bind.submit | boolean to disable binding of the submit event (form submission of enter key press) | true |   |
 | settings.variants.field | used to set the field in which to grab the variant data from | ➖ |   | 
 | settings.variants.realtime.enabled | enable real time variant updates | ➖ |   | 
 | settings.variants.realtime.filters | specify which filters to use to determine which results are updated | ➖ |   | 

--- a/packages/snap-store-mobx/src/types.ts
+++ b/packages/snap-store-mobx/src/types.ts
@@ -124,6 +124,10 @@ export type AutocompleteStoreConfigSettings = {
 		merchandising?: boolean;
 		singleResult?: boolean;
 	};
+	bind?: {
+		input?: boolean;
+		submit?: boolean;
+	};
 };
 
 // Autocomplete config


### PR DESCRIPTION
Adding ability to opt out of either `input` or `submit` bindings in AutocompleteController via controller settings.

Example:
```
autocomplete: [
	{
		config: {
			id: 'autocomplete',
			selector: 'input.searchspring-ac',
			settings: {
				bind: {
					input: false
					submit: false
				}
			},
		},
	},
],
```

I've combined the input enter key press and form submit events into one "submit" so simplify configuration. Additionally, there are other bindings that occur for things like document click, input focus and input escape key press that I don't think are necessary to provide settings for, but could be added if we needed to.