### PR TITLE
A11y Statement Image Fix

### DIFF
--- a/docs/ACCESSIBILITY_STATEMENT.md
+++ b/docs/ACCESSIBILITY_STATEMENT.md
@@ -1,4 +1,4 @@
-![Logo of Searchspring, a division of Athos Commerce](../images/division-of-athos.png)
+![Logo of Searchspring, a division of Athos Commerce](./images/division-of-athos.png)
 
 # Accessibility Statement
 

--- a/docs/ACCESSIBILITY_STATEMENT.md
+++ b/docs/ACCESSIBILITY_STATEMENT.md
@@ -1,4 +1,4 @@
-![Logo of Searchspring, a division of Athos Commerce](https://github.com/searchspring/snap/blob/main/images/division-of-athos.png?raw=true)
+![Logo of Searchspring, a division of Athos Commerce](https://raw.githubusercontent.com/searchspring/snap/main/images/division-of-athos.png)
 
 # Accessibility Statement
 

--- a/docs/ACCESSIBILITY_STATEMENT.md
+++ b/docs/ACCESSIBILITY_STATEMENT.md
@@ -1,4 +1,4 @@
-![Logo of Searchspring, a division of Athos Commerce](./images/division-of-athos.png)
+![Logo of Searchspring, a division of Athos Commerce](https://github.com/searchspring/snap/blob/main/images/division-of-athos.png?raw=true)
 
 # Accessibility Statement
 

--- a/index.html
+++ b/index.html
@@ -42,14 +42,6 @@
 				{ a: "(https://github.com/searchspring/snap/blob/main/docs/INTEGRATION_RECOMMENDATIONS.md)", b: "(#/integration-recommendations)"},
 				{ a: "(https://github.com/searchspring/snap/blob/main/docs/INTEGRATION_LEGACY_RECOMMENDATIONS.md)", b: "(#/integration-legacy-recommendations)"},
 
-				{ a: "https://github.com/searchspring/snap/blob/main/images/snap-dependencies.jpg?raw=true", b: "./images/snap-dependencies.jpg"},
-				{ a: "https://github.com/searchspring/snap/blob/main/images/snap-dependencies.png?raw=true", b: "./images/snap-dependencies.png"},
-				{ a: "https://github.com/searchspring/snap/blob/main/images/logger-example.png?raw=true", b: "./images/logger-example.png"},
-				{ a: "https://github.com/searchspring/snap/blob/main/images/emojis.png?raw=true", b: "./images/emojis.png"},
-				{ a: "https://github.com/searchspring/snap/blob/main/images/colors.png?raw=true", b: "./images/colors.png"},
-				{ a: "https://github.com/searchspring/snap/blob/main/images/colors.png?raw=true", b: "./images/colors.png"},
-				{ a: "https://github.com/searchspring/snap/blob/main/images/nebo404.svg?raw=true", b: "./images/nebo404.svg"},
-				{ a: "https://github.com/searchspring/snap/blob/main/images/division-of-athos.png?raw=true", b: "./images/division-of-athos.png"},
 
 				{ a: "(https://github.com/searchspring/snap/tree/main/packages/snap-client)", b: "(#/package-client)"},
 				{ a: "(https://github.com/searchspring/snap/tree/main/packages/snap-store-mobx)", b: "(#/package-storeMobx)"},


### PR DESCRIPTION
* moving to absolute URL for image (like all the rest of the images in the docs)
* removing link replacement for image URLs that are not used (these images are all absolute - likely because it never worked)