### PR TITLE
Prevent Incorrect Autocomplete Redirects

### DIFF
--- a/packages/snap-controller/src/Autocomplete/AutocompleteController.test.ts
+++ b/packages/snap-controller/src/Autocomplete/AutocompleteController.test.ts
@@ -995,58 +995,6 @@ describe('Autocomplete Controller', () => {
 		});
 	});
 
-	it('will redirect when the input does not match the search (spell correction)', async () => {
-		document.body.innerHTML = '<div><input type="text" id="search_query"></div>';
-		acConfig = {
-			...acConfig,
-			selector: '#search_query',
-			action: '/search',
-			settings: {
-				redirects: {
-					merchandising: true,
-				},
-			},
-		};
-
-		const controller = new AutocompleteController(acConfig, {
-			client: new MockClient(globals, {}),
-			store: new AutocompleteStore(acConfig, services),
-			urlManager,
-			eventManager: new EventManager(),
-			profiler: new Profiler(),
-			logger: new Logger(),
-			tracker: new Tracker(globals),
-		});
-		(controller.client as MockClient).mockData.updateConfig({ autocomplete: 'correctedRedirect', siteId: '8uyt2m' });
-
-		const query = 'rumper';
-		controller.urlManager = controller.urlManager.set('query', query);
-
-		await controller.bind();
-		const inputEl: HTMLInputElement = document.querySelector(controller.config.selector)!;
-		expect(inputEl).toBeDefined();
-
-		inputEl.value = query;
-		inputEl.dispatchEvent(new Event('input', { bubbles: true }));
-
-		await controller.search();
-		expect(controller.store.terms.length).toBeGreaterThan(0);
-
-		// @ts-ignore
-		delete window.location;
-		window.location = {
-			...window.location,
-			href: '', // jest does not support window location changes
-		};
-
-		inputEl.focus();
-		inputEl.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, keyCode: KEY_ENTER }));
-
-		await waitFor(() => {
-			expect(window.location.href).toContain('https://searchspring.com/?redirect');
-		});
-	});
-
 	it('will not redirect when the previous search included a redirect in merchandising response', async () => {
 		document.body.innerHTML = '<div><input type="text" id="search_query"></div>';
 		acConfig = {

--- a/packages/snap-controller/src/Autocomplete/AutocompleteController.test.ts
+++ b/packages/snap-controller/src/Autocomplete/AutocompleteController.test.ts
@@ -967,6 +967,58 @@ describe('Autocomplete Controller', () => {
 		});
 		(controller.client as MockClient).mockData.updateConfig({ autocomplete: 'redirect', siteId: '8uyt2m' });
 
+		const query = 'romper';
+		controller.urlManager = controller.urlManager.set('query', query);
+
+		await controller.bind();
+		const inputEl: HTMLInputElement = document.querySelector(controller.config.selector)!;
+		expect(inputEl).toBeDefined();
+
+		inputEl.value = query;
+		inputEl.dispatchEvent(new Event('input', { bubbles: true }));
+
+		await controller.search();
+		expect(controller.store.terms.length).toBeGreaterThan(0);
+
+		// @ts-ignore
+		delete window.location;
+		window.location = {
+			...window.location,
+			href: '', // jest does not support window location changes
+		};
+
+		inputEl.focus();
+		inputEl.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, keyCode: KEY_ENTER }));
+
+		await waitFor(() => {
+			expect(window.location.href).toContain('https://searchspring.com/?redirect');
+		});
+	});
+
+	it('will redirect when the input does not match the search (spell correction)', async () => {
+		document.body.innerHTML = '<div><input type="text" id="search_query"></div>';
+		acConfig = {
+			...acConfig,
+			selector: '#search_query',
+			action: '/search',
+			settings: {
+				redirects: {
+					merchandising: true,
+				},
+			},
+		};
+
+		const controller = new AutocompleteController(acConfig, {
+			client: new MockClient(globals, {}),
+			store: new AutocompleteStore(acConfig, services),
+			urlManager,
+			eventManager: new EventManager(),
+			profiler: new Profiler(),
+			logger: new Logger(),
+			tracker: new Tracker(globals),
+		});
+		(controller.client as MockClient).mockData.updateConfig({ autocomplete: 'correctedRedirect', siteId: '8uyt2m' });
+
 		const query = 'rumper';
 		controller.urlManager = controller.urlManager.set('query', query);
 
@@ -1019,7 +1071,7 @@ describe('Autocomplete Controller', () => {
 		});
 		(controller.client as MockClient).mockData.updateConfig({ autocomplete: 'redirect', siteId: '8uyt2m' });
 
-		const query = 'rumper';
+		const query = 'romper';
 		controller.urlManager = controller.urlManager.set('query', query);
 
 		await controller.bind();
@@ -1049,7 +1101,7 @@ describe('Autocomplete Controller', () => {
 		inputEl.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, keyCode: KEY_ENTER }));
 
 		await waitFor(() => {
-			expect(window.location.href).toContain('/search?oq=rumper&search_query=romper');
+			expect(window.location.href).toContain('/search?search_query=dress');
 		});
 	});
 

--- a/packages/snap-controller/src/Autocomplete/AutocompleteController.ts
+++ b/packages/snap-controller/src/Autocomplete/AutocompleteController.ts
@@ -376,15 +376,46 @@ export class AutocompleteController extends AbstractController {
 
 				e.preventDefault();
 
+				// wait until loading and input delay is complete before submission
+
+				if (this.store.waiting) {
+					const waitForReady = async () => {
+						return new Promise<void>((resolve) => {
+							const checkWaiting = () => {
+								if (!this.store.waiting) {
+									resolve();
+								} else {
+									setTimeout(checkWaiting, 50);
+								}
+							};
+							checkWaiting();
+						});
+					};
+
+					// wait until the store is no longer in waiting state
+					await waitForReady();
+				}
+
+				// wait until the store is no longer in loading state
+				if (this.store.loading) {
+					const waitForLoading = async () => {
+						return new Promise<void>((resolve) => {
+							const checkLoading = () => {
+								if (!this.store.loading) {
+									resolve();
+								} else {
+									setTimeout(checkLoading, 50);
+								}
+							};
+							checkLoading();
+						});
+					};
+
+					await waitForLoading();
+				}
+
 				// when spellCorrection is enabled
 				if (this.config.globals?.search?.query?.spellCorrection) {
-					// wait until loading is complete before submission
-					// TODO make this better
-					await timeout(INPUT_DELAY + 1);
-					while (this.store.loading) {
-						await timeout(INPUT_DELAY);
-					}
-
 					if (this.config.settings!.integratedSpellCorrection) {
 						//set fallbackQuery to the correctedQuery
 						if (this.store.search.correctedQuery) {
@@ -471,6 +502,7 @@ export class AutocompleteController extends AbstractController {
 				const trendingResultsEnabled = this.store.trending?.length && this.config.settings?.trending?.showResults;
 				const historyResultsEnabled = this.store.history?.length && this.config.settings?.history?.showResults;
 
+				this.store.waiting = true;
 				this.handlers.input.timeoutDelay = setTimeout(() => {
 					if (!value) {
 						// there is no input value - reset state of store
@@ -491,6 +523,8 @@ export class AutocompleteController extends AbstractController {
 						this.store.state.locks.facets.unlock();
 						this.urlManager.set({ query: this.store.state.input }).go();
 					}
+
+					this.store.waiting = false;
 				}, INPUT_DELAY);
 			},
 			timeoutDelay: undefined as undefined | ReturnType<typeof setTimeout>,

--- a/packages/snap-controller/src/Autocomplete/AutocompleteController.ts
+++ b/packages/snap-controller/src/Autocomplete/AutocompleteController.ts
@@ -144,8 +144,6 @@ export class AutocompleteController extends AbstractController {
 		this.eventManager.on('beforeSubmit', async (ac: AfterStoreObj, next: Next): Promise<void | boolean> => {
 			await next();
 
-			// wait for input delay, if loading is in progress, do not redirect
-			await timeout(INPUT_DELAY + 1);
 			const loading = (ac.controller as AutocompleteController).store.loading;
 			if (loading) return;
 
@@ -319,9 +317,6 @@ export class AutocompleteController extends AbstractController {
 
 					e.preventDefault();
 
-					// wait for input delay
-					await timeout(INPUT_DELAY + 1);
-
 					// when spellCorrection is enabled
 					if (this.config.globals?.search?.query?.spellCorrection) {
 						// wait until loading is complete before submission
@@ -342,6 +337,9 @@ export class AutocompleteController extends AbstractController {
 					}
 
 					actionUrl = actionUrl?.set('query', input.value);
+
+					// wait for input delay
+					await timeout(INPUT_DELAY + 1);
 
 					try {
 						await this.eventManager.fire('beforeSubmit', {
@@ -381,9 +379,6 @@ export class AutocompleteController extends AbstractController {
 
 				e.preventDefault();
 
-				// wait for input delay
-				await timeout(INPUT_DELAY + 1);
-
 				// when spellCorrection is enabled
 				if (this.config.globals?.search?.query?.spellCorrection) {
 					// wait until loading is complete before submission
@@ -404,6 +399,9 @@ export class AutocompleteController extends AbstractController {
 						addHiddenFormInput(form, PARAM_ORIGINAL_QUERY, this.store.search.originalQuery.string);
 					}
 				}
+
+				// wait for input delay
+				await timeout(INPUT_DELAY + 1);
 
 				try {
 					await this.eventManager.fire('beforeSubmit', {
@@ -652,6 +650,8 @@ export class AutocompleteController extends AbstractController {
 			}
 
 			this.store.loading = true;
+			// clear the redirect URL until proper abort functionality is implemented
+			this.store.merchandising.redirect = '';
 
 			try {
 				await this.eventManager.fire('beforeSearch', {

--- a/packages/snap-preact/src/Instantiators/RecommendationInstantiator.test.tsx
+++ b/packages/snap-preact/src/Instantiators/RecommendationInstantiator.test.tsx
@@ -153,29 +153,6 @@ describe('RecommendationInstantiator', () => {
 		expect(clientSpy).toHaveBeenCalledTimes(0);
 	});
 
-	it('logs an error when the recommend response does not comeback', async () => {
-		document.body.innerHTML = `<script type="searchspring/recommend" profile="${DEFAULT_PROFILE}"></script>`;
-
-		const logger = new Logger({ prefix: 'RecommendationInstantiator ' });
-		const client = new MockClient(baseConfig.client!.globals, {});
-		client.mockData.updateConfig({ recommend: { results: 'broken' } });
-		const clientSpy = jest.spyOn(client, 'recommend');
-		const logSpy = jest.spyOn(console, 'log');
-		const recommendationInstantiator = new RecommendationInstantiator(baseConfig, { logger, client });
-		await wait();
-
-		expect(Object.keys(recommendationInstantiator.controller).length).toBe(1);
-		expect(clientSpy).toHaveBeenCalledTimes(1);
-		expect(logSpy).not.toHaveBeenCalledWith(
-			`profile '${DEFAULT_PROFILE}' found on the following element is missing a component!\n<script type=\"searchspring/recommend\" profile=\"trending\"></script>`
-		);
-		expect(logSpy).toHaveBeenCalledWith(
-			'%c ‼ %c [recommend_trending_0] :: Search JSON not found.',
-			'color: #cc1212; font-weight: bold; font-size: 14px; line-height: 12px;',
-			'color: #cc1212; font-weight: bold;'
-		);
-	});
-
 	it('logs an error when the profile response does not contain templateParameters', async () => {
 		document.body.innerHTML = `<script type="searchspring/recommend" profile="${DEFAULT_PROFILE}"></script>`;
 

--- a/packages/snap-shared/src/MockData/MockData.ts
+++ b/packages/snap-shared/src/MockData/MockData.ts
@@ -57,38 +57,38 @@ export class MockData {
 	}
 
 	meta(file?: string): MetaResponseModel {
+		const metaFile = `${__dirname}/meta/${this.config.siteId}/${file || this.config.meta}.json`;
 		try {
-			const metaFile = `${__dirname}/meta/${this.config.siteId}/${file || this.config.meta}.json`;
 			return getJSON(metaFile);
 		} catch (err) {
-			throw 'Meta JSON not found.';
+			throw `Meta JSON '${metaFile}' not found.`;
 		}
 	}
 
 	search(file?: string): SearchResponseModel {
+		const searchFile = `${__dirname}/search/${this.config.siteId}/${file || this.config.search}.json`;
 		try {
-			const searchFile = `${__dirname}/search/${this.config.siteId}/${file || this.config.search}.json`;
 			return getJSON(searchFile);
 		} catch (err) {
-			throw 'Search JSON not found.';
+			throw `Search JSON '${searchFile}' not found.`;
 		}
 	}
 
 	autocomplete(file?: string): AutocompleteResponseModel {
+		const autocompleteFile = `${__dirname}/autocomplete/${this.config.siteId}/${file || this.config.autocomplete}.json`;
 		try {
-			const autocompleteFile = `${__dirname}/autocomplete/${this.config.siteId}/${file || this.config.autocomplete}.json`;
 			return getJSON(autocompleteFile);
 		} catch (err) {
-			throw 'AC JSON not found.';
+			throw `AC JSON '${autocompleteFile}' not found.`;
 		}
 	}
 
 	trending(file?: string) {
+		const trendingFile = `${__dirname}/trending/${this.config.siteId}/${file || this.config.trending}.json`;
 		try {
-			const trendingFile = `${__dirname}/trending/${this.config.siteId}/${file || this.config.trending}.json`;
 			return getJSON(trendingFile);
 		} catch (err) {
-			throw 'Trending JSON not found.';
+			throw `Trending JSON '${trendingFile}' not found.`;
 		}
 	}
 
@@ -96,7 +96,7 @@ export class MockData {
 		try {
 			return { meta: this.meta(), ...this.search(file) };
 		} catch (err) {
-			throw 'Search JSON not found.';
+			throw `SearchMeta JSON not found: ${err}`;
 		}
 	}
 
@@ -104,30 +104,30 @@ export class MockData {
 		try {
 			return { meta: this.meta(), ...this.autocomplete(file) };
 		} catch (err) {
-			throw 'Search JSON not found.';
+			throw `AutocompleteMeta JSON not found: ${err}`;
 		}
 	}
 
 	file(path?: string) {
+		const dataFile = `${__dirname}/${path}`;
 		try {
-			const dataFile = `${__dirname}/${path}`;
 			return getJSON(dataFile);
 		} catch (err) {
-			throw 'Data file not found!';
+			throw `Data file '${dataFile}' not found!`;
 		}
 	}
 
 	recommend(files?: { profileFile?: string; resultsFile?: string }) {
+		const profileFile = `${__dirname}/recommend/profile/${this.config.siteId}/${files?.profileFile || this.config.recommend?.profile}.json`;
+		const resultsFile = `${__dirname}/recommend/results/${this.config.siteId}/${files?.resultsFile || this.config.recommend?.results}.json`;
 		try {
-			const profileFile = `${__dirname}/recommend/profile/${this.config.siteId}/${files?.profileFile || this.config.recommend?.profile}.json`;
-			const resultsFile = `${__dirname}/recommend/results/${this.config.siteId}/${files?.resultsFile || this.config.recommend?.results}.json`;
 			return {
 				meta: this.meta(),
 				profile: getJSON(profileFile).profile,
 				results: getJSON(resultsFile)[0].results,
 			};
 		} catch (err) {
-			throw 'Search JSON not found.';
+			throw `Recommend JSON not found. Profile: '${profileFile}', Results: '${resultsFile}'`;
 		}
 	}
 }

--- a/packages/snap-shared/src/MockData/autocomplete/8uyt2m/correctedRedirect.json
+++ b/packages/snap-shared/src/MockData/autocomplete/8uyt2m/correctedRedirect.json
@@ -30,9 +30,6 @@
         }
       },
       "attributes": {
-        "badges": [
-          "[object Object]"
-        ],
         "id": "d8a991f80f953fb73c1409e8605a2183",
         "intellisuggestData": "eJyyKK0sMcplYCjKzy1ILWJw1nUNcdZ1N9f1CDKyNGIwZDBkMGAwMjBiSC_KTAEEAAD__w36CvY",
         "intellisuggestSignature": "6c8af67aaf98d31ccd2a73b979b0fd4e908fe5cc6550fd64481f3f85ef9e14d7",
@@ -101,9 +98,6 @@
         }
       },
       "attributes": {
-        "badges": [
-          "[object Object]"
-        ],
         "id": "abc7918c3761069e9b165c20c5a19d69",
         "intellisuggestData": "eJyyKK0sMcplYCjKzy1ILWJw1vVxDNF1N9S1sDCy9GUwZDBmMGAwMjBiSC_KTAEEAAD__wyICug",
         "intellisuggestSignature": "5bff9cc6a14a926dfed2a255191e910f1978edc068100bfae8a7082270e8eb45",
@@ -138,9 +132,6 @@
         }
       },
       "attributes": {
-        "badges": [
-          "[object Object]"
-        ],
         "id": "46e301da0f045dc882185afa9b26b6e3",
         "intellisuggestData": "eJyyKK0sMcplYCjKzy1ILWJw1g3y0w030g2wMDExZDBkMGEwYDAyMGJIL8pMAQQAAP__AeoKsg",
         "intellisuggestSignature": "08ab8b343dbe380adf06d3aa2aa8d0728cbdea2684b38078507f0a033141146d",
@@ -176,8 +167,6 @@
       },
       "attributes": {
         "badges": [
-          "[object Object]",
-          "[object Object]"
         ],
         "id": "b7143b0f8ac3979b07e22209e10a1421",
         "intellisuggestData": "eJyyKK0sMcplYCjKzy1ILWJw1g3wcdYNN9Q1MLQ0MGIwZDBlMGAwMjBiSC_KTAEEAAD__wsBCsw",
@@ -214,7 +203,6 @@
       },
       "attributes": {
         "badges": [
-          "[object Object]"
         ],
         "id": "c2a33d3e15f0b2e76a188e73e79ced3f",
         "intellisuggestData": "eJyyKK0sMcplYCjKzy1ILWJw1vVxDNH1NNc1MDCy9GAwZDBjMGAwMjBiSC_KTAEEAAD__wvWCt4",
@@ -250,9 +238,6 @@
         }
       },
       "attributes": {
-        "badges": [
-          "[object Object]"
-        ],
         "id": "35d3de37841721d42e40cf8d5787ede9",
         "intellisuggestData": "eJyyKK0sMcplYCjKzy1ILWJw1g3wcdYNMtI1MDA28GMwZDBnMGAwMjBiSC_KTAEEAAD__wv9Ct8",
         "intellisuggestSignature": "cafcfc8b3c62f90cedb8c10959830ec31c4aada04bf02991484189d9724a9ca8",
@@ -355,9 +340,6 @@
         }
       },
       "attributes": {
-        "badges": [
-          "[object Object]"
-        ],
         "id": "3bd7afca11518cc90919eb35abe8bbb6",
         "intellisuggestData": "eJyyKK0sMcplYCjKzy1ILWJw1nV11vU01zU1Mwn3YTBkMDRgMGAwMjBiSC_KTAEEAAD__wrTCt8",
         "intellisuggestSignature": "6f87a6e6c94585cf228af914569d1fea98a782cb85293af1bca9e3ff9dc1129e",
@@ -392,9 +374,6 @@
         }
       },
       "attributes": {
-        "badges": [
-          "[object Object]"
-        ],
         "id": "91bf1cc65600ec9cda37fb8079b5e945",
         "intellisuggestData": "eJyyKK0sMcplYCjKzy1ILWJw1g3wcdYNN9I1NLIwMGQwZDA0ZDBgMDIwYkgvykwBBAAA__8Vlwr6",
         "intellisuggestSignature": "48c0f73be2d758ddd4540ba052ac426f092fd208ff2ec7c7c3bb6b390a08a9f3",
@@ -430,8 +409,6 @@
       },
       "attributes": {
         "badges": [
-          "[object Object]",
-          "[object Object]"
         ],
         "id": "e7444a00e72ceb80ded94201478f7daf",
         "intellisuggestData": "eJyyKK0sMcplYCjKzy1ILWJw1g3wcdYNMNE1MDQ3MGQwZDA0YjBgMDIwYkgvykwBBAAA__8U7Qrz",
@@ -501,9 +478,6 @@
         }
       },
       "attributes": {
-        "badges": [
-          "[object Object]"
-        ],
         "id": "1d00807d61b5311953fa71a8d68c7499",
         "intellisuggestData": "eJyyKK0sMcplYCjKzy1ILWJw1vVxDNENMNS1sDQz9mAwZDA0YTBgMDIwYkgvykwBBAAA__8X0wsd",
         "intellisuggestSignature": "e058ddf0c3696714dd85e24b1d6953e33803d2acc0f68e8f8e02eb59c4a33589",
@@ -538,9 +512,6 @@
         }
       },
       "attributes": {
-        "badges": [
-          "[object Object]"
-        ],
         "id": "f9d3df1a404260a58614b34092b7f4b1",
         "intellisuggestData": "eJyyKK0sMcplYCjKzy1ILWJw1vUJ0vU017UwMDEwZDBkMDRlMGAwMjBiSC_KTAEEAAD__wiQCrU",
         "intellisuggestSignature": "9831620ac88acb539ec99da4fff6466f962cf2f9a37736c892870b31ed8e9f86",
@@ -575,9 +546,6 @@
         }
       },
       "attributes": {
-        "badges": [
-          "[object Object]"
-        ],
         "id": "79ff9298382e518058997edcf017ca53",
         "intellisuggestData": "eJyyKK0sMcplYCjKzy1ILWJw1vUJ0g030rUwMDEwZDBkMDRjMGAwMjBiSC_KTAEEAAD__wl5Cr8",
         "intellisuggestSignature": "c80035012f296ceec11eb8385418f78a9e750fa71d2190e8f75d01950e284ed5",
@@ -612,9 +580,6 @@
         }
       },
       "attributes": {
-        "badges": [
-          "[object Object]"
-        ],
         "id": "5ad6b3b2d52f914748bea2c7eb77e81c",
         "intellisuggestData": "eJyyKK0sMcplYCjKzy1ILWJw1g111w0y0Q0yNzc1YDBkMDRnMGAwMjBiSC_KTAEEAAD__wxACuM",
         "intellisuggestSignature": "151123d279a7fc22ed64bfb54e65a289ffbdb55fb822f75097910d2065d73481",
@@ -683,10 +648,6 @@
         }
       },
       "attributes": {
-        "badges": [
-          "[object Object]",
-          "[object Object]"
-        ],
         "id": "d3134b75ff40b8ea5025827af7597d8e",
         "intellisuggestData": "eJyyKK0sMcplYCjKzy1ILWJw1nUN0_U00Q0ws7SwZDBkMLRkMGAwMjBiSC_KTAEEAAD__wwNCuY",
         "intellisuggestSignature": "bb654aa60d3d2ba4eddd3e5b0f3601f36a944b10cd0f629df0b23fedbd08be64",
@@ -755,9 +716,6 @@
         }
       },
       "attributes": {
-        "badges": [
-          "[object Object]"
-        ],
         "id": "8de38d3e062fea4a6cc8f9fbb2b53dcc",
         "intellisuggestData": "eJyyKK0sMcplYCjKzy1ILWJw1vWL0vU01zWwNDI0ZzBkMDJkMGAwMjBiSC_KTAEEAAD__wnRCsI",
         "intellisuggestSignature": "c57328a2ec1aa55d6c34a17eb8f2fef22761399fc8971a7d287a3b80d95181b1",
@@ -792,9 +750,6 @@
         }
       },
       "attributes": {
-        "badges": [
-          "[object Object]"
-        ],
         "id": "7d890eedfd0849a83b34a07bbed5f0f5",
         "intellisuggestData": "eJyyKK0sMcplYCjKzy1ILWJw1vWL0nU11jWwNDI0ZzBkMDJiMGAwMjBiSC_KTAEEAAD__wkhCrs",
         "intellisuggestSignature": "15267dd0082ed6f950a0db6e13d1001587d45dde1b160ff0a3baddeec0dc6971",
@@ -829,9 +784,6 @@
         }
       },
       "attributes": {
-        "badges": [
-          "[object Object]"
-        ],
         "id": "5d1b372f6a57b75d27644bde4453fc79",
         "intellisuggestData": "eJyyKK0sMcplYCjKzy1ILWJw1vWL0vU31TWwsDQyYTBkMDJmMGAwMjBiSC_KTAEEAAD__wqbCsw",
         "intellisuggestSignature": "0a2f4d9faadfef46f9a5a345ada9eeb74f9749697c06865200f4eea15cbff765",
@@ -866,10 +818,6 @@
         }
       },
       "attributes": {
-        "badges": [
-          "[object Object]",
-          "[object Object]"
-        ],
         "id": "08c8b7c48e3a88c43789b4658a9cd994",
         "intellisuggestData": "eJyyKK0sMcplYCjKzy1ILWJw1vWL0g031DWwsDQyYTBkMDJhMGAwMjBiSC_KTAEEAAD__wsLCtE",
         "intellisuggestSignature": "f3031c89ab4f24bc30ed8e8790a4d19bd49ccd0f21659d6d35178786054db72f",
@@ -904,9 +852,6 @@
         }
       },
       "attributes": {
-        "badges": [
-          "[object Object]"
-        ],
         "id": "be849f3017694eef3a8e45990c9bb860",
         "intellisuggestData": "eJyyKK0sMcplYCjKzy1ILWJw1vX3CdN1N9M1MPQJ8mAwZDAyZTBgMDIwYkgvykwBBAAA__8bwAtQ",
         "intellisuggestSignature": "e5b5474c1cdcd7dff9e0c203d325af68fc4728c2a2532a35029fb06cda7ef258",
@@ -941,9 +886,6 @@
         }
       },
       "attributes": {
-        "badges": [
-          "[object Object]"
-        ],
         "id": "e9203ecf7d1b001094abb680a11bf250",
         "intellisuggestData": "eJyyKK0sMcplYCjKzy1ILWJw1nUK0A031HU0Mzc1YDBkMDJjMGAwMjBiSC_KTAEEAAD__wnkCsk",
         "intellisuggestSignature": "5c6f82dfebf9a8983284e230961782ea1cd3a9aa774b02dc6c208a454cc8d32c",
@@ -978,9 +920,6 @@
         }
       },
       "attributes": {
-        "badges": [
-          "[object Object]"
-        ],
         "id": "bf53337c6c59749a99b919e2dcdaf232",
         "intellisuggestData": "eJyyKK0sMcplYCjKzy1ILWJw1nUL0Y000Q0wNTM1YDBkMDJnMGAwMjBiSC_KTAEEAAD__wxNCuQ",
         "intellisuggestSignature": "5d8ae03643cc13d3d3b294f754644e52b6b7d3488ebc2f112f60d55a08efbf99",
@@ -1015,10 +954,6 @@
         }
       },
       "attributes": {
-        "badges": [
-          "[object Object]",
-          "[object Object]"
-        ],
         "id": "5885a7e30551f6f556054699fa0f1884",
         "intellisuggestData": "eJyyKK0sMcplYCjKzy1ILWJw1nUL0Q0w0jUzsjRxZDBkMLJgMGAwMjBiSC_KTAEEAAD__wo9CtA",
         "intellisuggestSignature": "f4210a36053bcfcc796dffdfa0a5e4e731cafa33e6d6d2bb02fdb532aa457d19",
@@ -1053,9 +988,6 @@
         }
       },
       "attributes": {
-        "badges": [
-          "[object Object]"
-        ],
         "id": "915a166bec0d56d14096aaeb3387ba0b",
         "intellisuggestData": "eJyyKK0sMcplYCjKzy1ILWJw1nUL0Q0y0Q0wM7I0YTBkMLJkMGAwMjBiSC_KTAEEAAD__wwRCuQ",
         "intellisuggestSignature": "784d773683104c813bd6d17a7b963d7c8c4d79d640114ca0fdcf9e513f9b8511",

--- a/packages/snap-shared/src/MockData/autocomplete/8uyt2m/correctedRedirect.json
+++ b/packages/snap-shared/src/MockData/autocomplete/8uyt2m/correctedRedirect.json
@@ -1877,7 +1877,8 @@
     "query": "romper"
   },
   "autocomplete": {
-    "query": "romper",
+    "query": "rumper",
+    "correctedQuery": "romper",
     "suggested": {
       "text": "romper",
       "type": "exact",

--- a/packages/snap-shared/src/MockData/autocomplete/8uyt2m/redirect.json
+++ b/packages/snap-shared/src/MockData/autocomplete/8uyt2m/redirect.json
@@ -30,9 +30,6 @@
         }
       },
       "attributes": {
-        "badges": [
-          "[object Object]"
-        ],
         "id": "d8a991f80f953fb73c1409e8605a2183",
         "intellisuggestData": "eJyyKK0sMcplYCjKzy1ILWJw1nUNcdZ1N9f1CDKyNGIwZDBkMGAwMjBiSC_KTAEEAAD__w36CvY",
         "intellisuggestSignature": "6c8af67aaf98d31ccd2a73b979b0fd4e908fe5cc6550fd64481f3f85ef9e14d7",
@@ -101,9 +98,6 @@
         }
       },
       "attributes": {
-        "badges": [
-          "[object Object]"
-        ],
         "id": "abc7918c3761069e9b165c20c5a19d69",
         "intellisuggestData": "eJyyKK0sMcplYCjKzy1ILWJw1vVxDNF1N9S1sDCy9GUwZDBmMGAwMjBiSC_KTAEEAAD__wyICug",
         "intellisuggestSignature": "5bff9cc6a14a926dfed2a255191e910f1978edc068100bfae8a7082270e8eb45",
@@ -138,9 +132,6 @@
         }
       },
       "attributes": {
-        "badges": [
-          "[object Object]"
-        ],
         "id": "46e301da0f045dc882185afa9b26b6e3",
         "intellisuggestData": "eJyyKK0sMcplYCjKzy1ILWJw1g3y0w030g2wMDExZDBkMGEwYDAyMGJIL8pMAQQAAP__AeoKsg",
         "intellisuggestSignature": "08ab8b343dbe380adf06d3aa2aa8d0728cbdea2684b38078507f0a033141146d",
@@ -175,10 +166,6 @@
         }
       },
       "attributes": {
-        "badges": [
-          "[object Object]",
-          "[object Object]"
-        ],
         "id": "b7143b0f8ac3979b07e22209e10a1421",
         "intellisuggestData": "eJyyKK0sMcplYCjKzy1ILWJw1g3wcdYNN9Q1MLQ0MGIwZDBlMGAwMjBiSC_KTAEEAAD__wsBCsw",
         "intellisuggestSignature": "a6af9b23292dedee55bbf0e07e898f83cf2ffbae30b8f931ce49feede0d826c0",
@@ -213,9 +200,6 @@
         }
       },
       "attributes": {
-        "badges": [
-          "[object Object]"
-        ],
         "id": "c2a33d3e15f0b2e76a188e73e79ced3f",
         "intellisuggestData": "eJyyKK0sMcplYCjKzy1ILWJw1vVxDNH1NNc1MDCy9GAwZDBjMGAwMjBiSC_KTAEEAAD__wvWCt4",
         "intellisuggestSignature": "45597fa7f8ed0df873cf84a6c8f8ba5d84ce3691c7704de7eaf6279193f98fcd",
@@ -250,9 +234,6 @@
         }
       },
       "attributes": {
-        "badges": [
-          "[object Object]"
-        ],
         "id": "35d3de37841721d42e40cf8d5787ede9",
         "intellisuggestData": "eJyyKK0sMcplYCjKzy1ILWJw1g3wcdYNMtI1MDA28GMwZDBnMGAwMjBiSC_KTAEEAAD__wv9Ct8",
         "intellisuggestSignature": "cafcfc8b3c62f90cedb8c10959830ec31c4aada04bf02991484189d9724a9ca8",
@@ -355,9 +336,6 @@
         }
       },
       "attributes": {
-        "badges": [
-          "[object Object]"
-        ],
         "id": "3bd7afca11518cc90919eb35abe8bbb6",
         "intellisuggestData": "eJyyKK0sMcplYCjKzy1ILWJw1nV11vU01zU1Mwn3YTBkMDRgMGAwMjBiSC_KTAEEAAD__wrTCt8",
         "intellisuggestSignature": "6f87a6e6c94585cf228af914569d1fea98a782cb85293af1bca9e3ff9dc1129e",
@@ -392,9 +370,6 @@
         }
       },
       "attributes": {
-        "badges": [
-          "[object Object]"
-        ],
         "id": "91bf1cc65600ec9cda37fb8079b5e945",
         "intellisuggestData": "eJyyKK0sMcplYCjKzy1ILWJw1g3wcdYNN9I1NLIwMGQwZDA0ZDBgMDIwYkgvykwBBAAA__8Vlwr6",
         "intellisuggestSignature": "48c0f73be2d758ddd4540ba052ac426f092fd208ff2ec7c7c3bb6b390a08a9f3",
@@ -429,10 +404,6 @@
         }
       },
       "attributes": {
-        "badges": [
-          "[object Object]",
-          "[object Object]"
-        ],
         "id": "e7444a00e72ceb80ded94201478f7daf",
         "intellisuggestData": "eJyyKK0sMcplYCjKzy1ILWJw1g3wcdYNMNE1MDQ3MGQwZDA0YjBgMDIwYkgvykwBBAAA__8U7Qrz",
         "intellisuggestSignature": "759c093f2554e3dae479125ed3ef7c998af0dffc0d39e93cd5ec41710363643b",
@@ -501,9 +472,6 @@
         }
       },
       "attributes": {
-        "badges": [
-          "[object Object]"
-        ],
         "id": "1d00807d61b5311953fa71a8d68c7499",
         "intellisuggestData": "eJyyKK0sMcplYCjKzy1ILWJw1vVxDNENMNS1sDQz9mAwZDA0YTBgMDIwYkgvykwBBAAA__8X0wsd",
         "intellisuggestSignature": "e058ddf0c3696714dd85e24b1d6953e33803d2acc0f68e8f8e02eb59c4a33589",
@@ -538,9 +506,6 @@
         }
       },
       "attributes": {
-        "badges": [
-          "[object Object]"
-        ],
         "id": "f9d3df1a404260a58614b34092b7f4b1",
         "intellisuggestData": "eJyyKK0sMcplYCjKzy1ILWJw1vUJ0vU017UwMDEwZDBkMDRlMGAwMjBiSC_KTAEEAAD__wiQCrU",
         "intellisuggestSignature": "9831620ac88acb539ec99da4fff6466f962cf2f9a37736c892870b31ed8e9f86",
@@ -575,9 +540,6 @@
         }
       },
       "attributes": {
-        "badges": [
-          "[object Object]"
-        ],
         "id": "79ff9298382e518058997edcf017ca53",
         "intellisuggestData": "eJyyKK0sMcplYCjKzy1ILWJw1vUJ0g030rUwMDEwZDBkMDRjMGAwMjBiSC_KTAEEAAD__wl5Cr8",
         "intellisuggestSignature": "c80035012f296ceec11eb8385418f78a9e750fa71d2190e8f75d01950e284ed5",
@@ -612,9 +574,6 @@
         }
       },
       "attributes": {
-        "badges": [
-          "[object Object]"
-        ],
         "id": "5ad6b3b2d52f914748bea2c7eb77e81c",
         "intellisuggestData": "eJyyKK0sMcplYCjKzy1ILWJw1g111w0y0Q0yNzc1YDBkMDRnMGAwMjBiSC_KTAEEAAD__wxACuM",
         "intellisuggestSignature": "151123d279a7fc22ed64bfb54e65a289ffbdb55fb822f75097910d2065d73481",
@@ -683,10 +642,6 @@
         }
       },
       "attributes": {
-        "badges": [
-          "[object Object]",
-          "[object Object]"
-        ],
         "id": "d3134b75ff40b8ea5025827af7597d8e",
         "intellisuggestData": "eJyyKK0sMcplYCjKzy1ILWJw1nUN0_U00Q0ws7SwZDBkMLRkMGAwMjBiSC_KTAEEAAD__wwNCuY",
         "intellisuggestSignature": "bb654aa60d3d2ba4eddd3e5b0f3601f36a944b10cd0f629df0b23fedbd08be64",
@@ -755,9 +710,6 @@
         }
       },
       "attributes": {
-        "badges": [
-          "[object Object]"
-        ],
         "id": "8de38d3e062fea4a6cc8f9fbb2b53dcc",
         "intellisuggestData": "eJyyKK0sMcplYCjKzy1ILWJw1vWL0vU01zWwNDI0ZzBkMDJkMGAwMjBiSC_KTAEEAAD__wnRCsI",
         "intellisuggestSignature": "c57328a2ec1aa55d6c34a17eb8f2fef22761399fc8971a7d287a3b80d95181b1",
@@ -792,9 +744,6 @@
         }
       },
       "attributes": {
-        "badges": [
-          "[object Object]"
-        ],
         "id": "7d890eedfd0849a83b34a07bbed5f0f5",
         "intellisuggestData": "eJyyKK0sMcplYCjKzy1ILWJw1vWL0nU11jWwNDI0ZzBkMDJiMGAwMjBiSC_KTAEEAAD__wkhCrs",
         "intellisuggestSignature": "15267dd0082ed6f950a0db6e13d1001587d45dde1b160ff0a3baddeec0dc6971",
@@ -829,9 +778,6 @@
         }
       },
       "attributes": {
-        "badges": [
-          "[object Object]"
-        ],
         "id": "5d1b372f6a57b75d27644bde4453fc79",
         "intellisuggestData": "eJyyKK0sMcplYCjKzy1ILWJw1vWL0vU31TWwsDQyYTBkMDJmMGAwMjBiSC_KTAEEAAD__wqbCsw",
         "intellisuggestSignature": "0a2f4d9faadfef46f9a5a345ada9eeb74f9749697c06865200f4eea15cbff765",
@@ -866,10 +812,6 @@
         }
       },
       "attributes": {
-        "badges": [
-          "[object Object]",
-          "[object Object]"
-        ],
         "id": "08c8b7c48e3a88c43789b4658a9cd994",
         "intellisuggestData": "eJyyKK0sMcplYCjKzy1ILWJw1vWL0g031DWwsDQyYTBkMDJhMGAwMjBiSC_KTAEEAAD__wsLCtE",
         "intellisuggestSignature": "f3031c89ab4f24bc30ed8e8790a4d19bd49ccd0f21659d6d35178786054db72f",
@@ -904,9 +846,6 @@
         }
       },
       "attributes": {
-        "badges": [
-          "[object Object]"
-        ],
         "id": "be849f3017694eef3a8e45990c9bb860",
         "intellisuggestData": "eJyyKK0sMcplYCjKzy1ILWJw1vX3CdN1N9M1MPQJ8mAwZDAyZTBgMDIwYkgvykwBBAAA__8bwAtQ",
         "intellisuggestSignature": "e5b5474c1cdcd7dff9e0c203d325af68fc4728c2a2532a35029fb06cda7ef258",
@@ -941,9 +880,6 @@
         }
       },
       "attributes": {
-        "badges": [
-          "[object Object]"
-        ],
         "id": "e9203ecf7d1b001094abb680a11bf250",
         "intellisuggestData": "eJyyKK0sMcplYCjKzy1ILWJw1nUK0A031HU0Mzc1YDBkMDJjMGAwMjBiSC_KTAEEAAD__wnkCsk",
         "intellisuggestSignature": "5c6f82dfebf9a8983284e230961782ea1cd3a9aa774b02dc6c208a454cc8d32c",
@@ -978,9 +914,6 @@
         }
       },
       "attributes": {
-        "badges": [
-          "[object Object]"
-        ],
         "id": "bf53337c6c59749a99b919e2dcdaf232",
         "intellisuggestData": "eJyyKK0sMcplYCjKzy1ILWJw1nUL0Y000Q0wNTM1YDBkMDJnMGAwMjBiSC_KTAEEAAD__wxNCuQ",
         "intellisuggestSignature": "5d8ae03643cc13d3d3b294f754644e52b6b7d3488ebc2f112f60d55a08efbf99",
@@ -1015,10 +948,6 @@
         }
       },
       "attributes": {
-        "badges": [
-          "[object Object]",
-          "[object Object]"
-        ],
         "id": "5885a7e30551f6f556054699fa0f1884",
         "intellisuggestData": "eJyyKK0sMcplYCjKzy1ILWJw1nUL0Q0w0jUzsjRxZDBkMLJgMGAwMjBiSC_KTAEEAAD__wo9CtA",
         "intellisuggestSignature": "f4210a36053bcfcc796dffdfa0a5e4e731cafa33e6d6d2bb02fdb532aa457d19",
@@ -1053,9 +982,6 @@
         }
       },
       "attributes": {
-        "badges": [
-          "[object Object]"
-        ],
         "id": "915a166bec0d56d14096aaeb3387ba0b",
         "intellisuggestData": "eJyyKK0sMcplYCjKzy1ILWJw1nUL0Q0y0Q0wM7I0YTBkMLJkMGAwMjBiSC_KTAEEAAD__wwRCuQ",
         "intellisuggestSignature": "784d773683104c813bd6d17a7b963d7c8c4d79d640114ca0fdcf9e513f9b8511",

--- a/packages/snap-store-mobx/src/Autocomplete/AutocompleteStore.ts
+++ b/packages/snap-store-mobx/src/Autocomplete/AutocompleteStore.ts
@@ -26,6 +26,7 @@ import type { AutocompleteStoreConfig, StoreServices } from '../types';
 import { MetaStore } from '../Meta/MetaStore';
 
 export class AutocompleteStore extends AbstractStore {
+	public waiting = false;
 	public services: StoreServices;
 	public meta!: MetaStore;
 	public merchandising!: SearchMerchandisingStore;

--- a/packages/snap-store-mobx/src/Autocomplete/AutocompleteStore.ts
+++ b/packages/snap-store-mobx/src/Autocomplete/AutocompleteStore.ts
@@ -26,7 +26,6 @@ import type { AutocompleteStoreConfig, StoreServices } from '../types';
 import { MetaStore } from '../Meta/MetaStore';
 
 export class AutocompleteStore extends AbstractStore {
-	public waiting = false;
 	public services: StoreServices;
 	public meta!: MetaStore;
 	public merchandising!: SearchMerchandisingStore;


### PR DESCRIPTION
This pull request is addresses ab issue where a redirect was happening when it should not. The issue ended up being timing related to when the API responses came back and were loaded into the store. Due to the way we are using "showResults" for the trending terms, if a query was made and returned prior to when the "showResults" query completed the redirect URL would STILL show up in the store causing the redirect to occur when it shouldn't. Redirect now also requires input to occur, where previously just pressing enter in their search bar (blank query) would still redirect if the selected term had a redirect. Adding some waiting around the INPUT_DELAY and redirection (ensuring not loading) ensures that we do not redirect when a new query is in progress.